### PR TITLE
Updating the build scripts so CI can successfully run.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,7 +70,7 @@
   <PropertyGroup>
     <MicrosoftNetCompilersPackageVersion>3.0.0-beta4-final</MicrosoftNetCompilersPackageVersion>
     <MicrosoftNetCoreCompilersPackageVersion>$(MicrosoftNetCompilersPackageVersion)</MicrosoftNetCoreCompilersPackageVersion>
-    <MicrosoftNetTestSdkPackageVersion>16.0.1</MicrosoftNetTestSdkPackageVersion>
+    <MicrosoftNetTestSdkPackageVersion>16.0.0</MicrosoftNetTestSdkPackageVersion>
     <NUnitPackageVersion>3.11.0</NUnitPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.13.0</NUnit3TestAdapterPackageVersion>
     <SystemCompositionPackageVersion>1.3.0-preview3.19128.7</SystemCompositionPackageVersion>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -103,6 +103,17 @@ try {
   $LogDir = Join-Path -Path $ArtifactsDir -ChildPath "log"
   Create-Directory -Path $LogDir
 
+  if ($ci) {
+    $DotNetInstallScript = Join-Path -Path $ArtifactsDir -ChildPath "dotnet-install.ps1"
+    Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile $DotNetInstallScript -UseBasicParsing
+
+    $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
+    Create-Directory -Path $DotNetInstallDirectory
+
+    & $DotNetInstallScript -Channel master -Version latest -InstallDir $DotNetInstallDirectory
+    $env:PATH="$DotNetInstallDirectory;$env:PATH"
+  }
+
   if ($restore) {
     Restore
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -183,6 +183,17 @@ CreateDirectory "$ArtifactsDir"
 LogDir="$ArtifactsDir/log"
 CreateDirectory "$LogDir"
 
+if $ci; then
+  DotNetInstallScript="$ArtifactsDir/dotnet-install.ps1"
+  wget -O "$DotNetInstallScript" "https://dot.net/v1/dotnet-install.sh"
+
+  DotNetInstallDirectory="$ArtifactsDir/dotnet"
+  CreateDirectory "$DotNetInstallDirectory"
+
+  . "$DotNetInstallScript" --channel master --version latest --install-dir "$DotNetInstallDirectory"
+  PATH="$DotNetInstallDirectory:$PATH:"
+fi
+
 if $restore; then
   Restore
 


### PR DESCRIPTION
This updates the build scripts to pull down the .NET SDK for CI and downgrades the MicrosoftNetTestSdkPackageVersion so that tests will successfully run.