### PR TITLE
Adding the terrafx package feed from azure.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,6 +64,7 @@
     <RepositoryType>git</RepositoryType>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
+      https://blob.terrafx.dev/nuget/index.json;
     </RestoreSources>
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>


### PR DESCRIPTION
This adds the TerrFX package feed from Azure so nightlies can be tested.