### PR TITLE
Fix whitespace issues in audio primitives

### DIFF
--- a/sources/Audio/AudioDecoder.cs
+++ b/sources/Audio/AudioDecoder.cs
@@ -32,7 +32,6 @@ namespace TerraFX.Audio
         /// <summary>Writer for decoded output data.</summary>
         protected PipeWriter OutputWriter => _outputPipe.Writer;
 
-
         /// <summary>Reader for decoded output data.</summary>
         public PipeReader Reader => _outputPipe.Reader;
 

--- a/sources/Audio/AudioEncoder.cs
+++ b/sources/Audio/AudioEncoder.cs
@@ -16,7 +16,6 @@ namespace TerraFX.Audio
         /// <summary>The output pipe for encoded data.</summary>
         private readonly Pipe _outputPipe;
 
-
         /// <summary>Initializes a new instance of the <see cref="AudioEncoder"/> class.</summary>
         /// <param name="options">Audio encoder options.</param>
         /// <param name="pipeOptions">Options for input/output pipes. Defaults to <see cref="PipeOptions.Default" />.</param>

--- a/sources/Audio/IAudioPlaybackDevice.cs
+++ b/sources/Audio/IAudioPlaybackDevice.cs
@@ -13,7 +13,6 @@ namespace TerraFX.Audio
         /// <summary>The adapter used for this playback device.</summary>
         IAudioAdapter Adapter { get; }
 
-
         /// <summary>The input data to be given to the underlying device.</summary>
         PipeWriter Writer { get; }
 


### PR DESCRIPTION
This is the follow-up PR to #18 you requested - I fixed the whitespace issues.