### PR TITLE
Clean up the UI providers to ensure a clean shutdown.

### DIFF
--- a/sources/ApplicationModel/Application.cs
+++ b/sources/ApplicationModel/Application.cs
@@ -77,7 +77,9 @@ namespace TerraFX.ApplicationModel
 
             _state.Transition(from: Stopped, to: Running);
             {
-                var dispatchProvider = _compositionHost.Value.GetExport<IDispatchProvider>();
+                var windowProvider = _compositionHost.Value.GetExport<IWindowProvider>();
+
+                var dispatchProvider = windowProvider.DispatchProvider;
                 var dispatcher = dispatchProvider.DispatcherForCurrentThread;
                 var previousTimestamp = dispatchProvider.CurrentTimestamp;
 
@@ -108,7 +110,7 @@ namespace TerraFX.ApplicationModel
         {
             var priorState = _state.BeginDispose();
 
-            if (priorState < Disposing) // (previousState != Disposing) && (previousState != Disposed)
+            if (priorState < Disposing)
             {
                 _compositionHost?.Dispose();
             }

--- a/sources/Graphics/IGraphicsProvider.cs
+++ b/sources/Graphics/IGraphicsProvider.cs
@@ -1,6 +1,5 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace TerraFX.Graphics

--- a/sources/Graphics/IGraphicsSurface.cs
+++ b/sources/Graphics/IGraphicsSurface.cs
@@ -11,6 +11,9 @@ namespace TerraFX.Graphics
         /// <summary>Gets the number of buffers for the instance.</summary>
         int BufferCount { get; }
 
+        /// <summary>Gets the display handle for the instance.</summary>
+        IntPtr DisplayHandle { get; }
+
         /// <summary>Gets the height of the instance.</summary>
         float Height => Size.Y;
 
@@ -22,9 +25,6 @@ namespace TerraFX.Graphics
 
         /// <summary>Gets the width of the instance.</summary>
         float Width => Size.X;
-
-        /// <summary>Gets the window provider handle for the instance.</summary>
-        IntPtr WindowProviderHandle { get; }
 
         /// <summary>Gets the window handle for the instance.</summary>
         IntPtr WindowHandle { get; }

--- a/sources/Provider/Vulkan/Graphics/GraphicsContext.cs
+++ b/sources/Provider/Vulkan/Graphics/GraphicsContext.cs
@@ -1,7 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using TerraFX.Graphics;
 using TerraFX.Interop;
@@ -765,7 +764,7 @@ namespace TerraFX.Provider.Vulkan.Graphics
                         sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
                         pNext = null,
                         flags = 0,
-                        hinstance = _graphicsSurface.WindowProviderHandle,
+                        hinstance = _graphicsSurface.DisplayHandle,
                         hwnd = _graphicsSurface.WindowHandle,
                     };
 
@@ -784,7 +783,7 @@ namespace TerraFX.Provider.Vulkan.Graphics
                         sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,
                         pNext = null,
                         flags = 0,
-                        dpy = _graphicsSurface.WindowProviderHandle,
+                        dpy = _graphicsSurface.DisplayHandle,
                         window = (UIntPtr)_graphicsSurface.WindowHandle.ToPointer(),
                     };
 

--- a/sources/Provider/Win32/UI/GraphicsSurface.cs
+++ b/sources/Provider/Win32/UI/GraphicsSurface.cs
@@ -3,7 +3,8 @@
 using System;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
-using static TerraFX.Utilities.ExceptionUtilities;
+using TerraFX.Utilities;
+using static TerraFX.Utilities.AssertionUtilities;
 
 namespace TerraFX.Provider.Win32.UI
 {
@@ -15,10 +16,8 @@ namespace TerraFX.Provider.Win32.UI
 
         internal GraphicsSurface(Window window, int bufferCount)
         {
-            if (bufferCount <= 0)
-            {
-                ThrowArgumentOutOfRangeException(nameof(bufferCount), bufferCount);
-            }
+            Assert(window != null, Resources.ArgumentNullExceptionMessage, nameof(bufferCount));
+            Assert(bufferCount <= 0, Resources.ArgumentOutOfRangeExceptionMessage, nameof(bufferCount), bufferCount);
 
             _window = window;
             _bufferCount = bufferCount;
@@ -27,14 +26,14 @@ namespace TerraFX.Provider.Win32.UI
         /// <summary>Gets the number of buffers for the instance.</summary>
         public int BufferCount => _bufferCount;
 
+        /// <summary>Gets the display handle for the instance.</summary>
+        public IntPtr DisplayHandle => WindowProvider.EntryPointModule;
+
         /// <summary>Gets the kind of surface represented by the instance.</summary>
         public GraphicsSurfaceKind Kind => GraphicsSurfaceKind.Win32;
 
         /// <summary>Gets the size of the instance.</summary>
         public Vector2 Size => _window.Bounds.Size;
-
-        /// <summary>Gets the window provider handle for the instance.</summary>
-        public IntPtr WindowProviderHandle => WindowProvider.EntryPointModule;
 
         /// <summary>Gets the window handle for the instance.</summary>
         public IntPtr WindowHandle => _window.Handle;

--- a/sources/Provider/Xlib/UI/Dispatcher.cs
+++ b/sources/Provider/Xlib/UI/Dispatcher.cs
@@ -47,19 +47,16 @@ namespace TerraFX.Provider.Xlib.UI
             ThrowIfNotThread(_parentThread);
 
             var display = _dispatchProvider.Display;
-            var wmProtocolsAtom = _dispatchProvider.WmProtocolsAtom;
-            var dispatcherExitRequestedAtom = (IntPtr)(void*)_dispatchProvider.DispatcherExitRequestedAtom;
-
             while (XPending(display) != 0)
             {
                 XEvent xevent;
                 _ = XNextEvent(display, &xevent);
 
-                var isWmProtocolsEvent = (xevent.type == ClientMessage) && (xevent.xclient.format == 32) && (xevent.xclient.message_type == wmProtocolsAtom);
+                var isWmProtocolsEvent = (xevent.type == ClientMessage) && (xevent.xclient.format == 32) && (xevent.xclient.message_type == _dispatchProvider.WmProtocolsAtom);
 
-                if (!isWmProtocolsEvent || (xevent.xclient.data.l[0] != dispatcherExitRequestedAtom))
+                if (!isWmProtocolsEvent || (xevent.xclient.data.l[0] != (IntPtr)(void*)_dispatchProvider.DispatcherExitRequestedAtom))
                 {
-                    WindowProvider.ForwardWindowEvent(_dispatchProvider, &xevent, isWmProtocolsEvent);
+                    WindowProvider.ForwardWindowEvent(&xevent, isWmProtocolsEvent);
                 }
                 else
                 {

--- a/sources/Provider/Xlib/UI/GraphicsSurface.cs
+++ b/sources/Provider/Xlib/UI/GraphicsSurface.cs
@@ -3,7 +3,8 @@
 using System;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
-using static TerraFX.Utilities.ExceptionUtilities;
+using TerraFX.Utilities;
+using static TerraFX.Utilities.AssertionUtilities;
 
 namespace TerraFX.Provider.Xlib.UI
 {
@@ -15,10 +16,8 @@ namespace TerraFX.Provider.Xlib.UI
 
         internal GraphicsSurface(Window window, int bufferCount)
         {
-            if (bufferCount <= 0)
-            {
-                ThrowArgumentOutOfRangeException(nameof(bufferCount), bufferCount);
-            }
+            Assert(window != null, Resources.ArgumentNullExceptionMessage, nameof(bufferCount));
+            Assert(bufferCount <= 0, Resources.ArgumentOutOfRangeExceptionMessage, nameof(bufferCount), bufferCount);
 
             _window = window;
             _bufferCount = bufferCount;
@@ -27,14 +26,14 @@ namespace TerraFX.Provider.Xlib.UI
         /// <summary>Gets the number of buffers for the instance.</summary>
         public int BufferCount => _bufferCount;
 
+        /// <summary>Gets the display handle for the instance.</summary>
+        public IntPtr DisplayHandle => (IntPtr)(void*)DispatchProvider.Instance.Display;
+
         /// <summary>Gets the kind of surface represented by the instance.</summary>
         public GraphicsSurfaceKind Kind => GraphicsSurfaceKind.Xlib;
 
         /// <summary>Gets the size of the instance.</summary>
         public Vector2 Size => _window.Bounds.Size;
-
-        /// <summary>Gets the window provider handle for the instance.</summary>
-        public IntPtr WindowProviderHandle => (IntPtr)(void*)((WindowProvider)_window.WindowProvider).DispatchProvider.Display;
 
         /// <summary>Gets the window handle for the instance.</summary>
         public IntPtr WindowHandle => (IntPtr)(void*)_window.Handle;

--- a/sources/Provider/Xlib/UI/Window.cs
+++ b/sources/Provider/Xlib/UI/Window.cs
@@ -396,6 +396,14 @@ namespace TerraFX.Provider.Xlib.UI
                 (IntPtr)(VisibilityChangeMask | StructureNotifyMask)
             );
 
+            var wmDeleteWindowAtom = dispatchProvider.WmDeleteWindowAtom;
+            var status = XSetWMProtocols(display, window, &wmDeleteWindowAtom, count: 1);
+
+            if (status == 0)
+            {
+                ThrowExternalException(nameof(XSetWMProtocols), status);
+            }
+
             var clientEvent = new XClientMessageEvent {
                 type = ClientMessage,
                 serial = UIntPtr.Zero,
@@ -422,7 +430,7 @@ namespace TerraFX.Provider.Xlib.UI
                 clientEvent.data.l[1] = (IntPtr)bits;
             }
 
-            var status = XSendEvent(
+            status = XSendEvent(
                 clientEvent.display,
                 clientEvent.window,
                 propagate: False,

--- a/sources/Provider/Xlib/UI/Window.cs
+++ b/sources/Provider/Xlib/UI/Window.cs
@@ -37,6 +37,8 @@ namespace TerraFX.Provider.Xlib.UI
 
         internal Window(WindowProvider windowProvider)
         {
+            Assert(windowProvider != null, Resources.ArgumentNullExceptionMessage, nameof(windowProvider));
+
             _handle = new Lazy<UIntPtr>(CreateWindowHandle, isThreadSafe: true);
 
             _parentThread = Thread.CurrentThread;
@@ -109,8 +111,8 @@ namespace TerraFX.Provider.Xlib.UI
         }
 
         /// <summary>Activates the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
         /// <exception cref="ExternalException">The call to <see cref="XRaiseWindow(UIntPtr, UIntPtr)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsActive" /> was <c>false</c> but the instance has already been disposed.</exception>
         public void Activate()
         {
             var succeeded = TryActivate();
@@ -122,19 +124,17 @@ namespace TerraFX.Provider.Xlib.UI
         }
 
         /// <summary>Closes the instance.</summary>
-        /// <exception cref="ExternalException">The call to <see cref="XSendEvent(UIntPtr, UIntPtr, int, IntPtr, XEvent*)" /> failed.</exception>
         /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ExternalException">The call to <see cref="XSendEvent(UIntPtr, UIntPtr, int, IntPtr, XEvent*)" /> failed.</exception>
         /// <remarks>
         ///   <para>This method can be called from any thread.</para>
         ///   <para>This method does nothing if the underlying <c>HWND</c> has not been created.</para>
         /// </remarks>
         public void Close()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_handle.IsValueCreated)
             {
-                var dispatchProvider = _windowProvider.DispatchProvider;
+                var dispatchProvider = DispatchProvider.Instance;
 
                 var clientEvent = new XClientMessageEvent {
                     type = ClientMessage,
@@ -166,73 +166,71 @@ namespace TerraFX.Provider.Xlib.UI
         /// <param name="bufferCount">The number of buffers created for the instance.</param>
         /// <returns>A new <see cref="IGraphicsSurface" /> for the instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferCount" /> is less than or equal to zero.</exception>
-        public IGraphicsSurface CreateGraphicsSurface(int bufferCount) => new GraphicsSurface(this, bufferCount);
+        public IGraphicsSurface CreateGraphicsSurface(int bufferCount)
+        {
+            if (bufferCount <= 0)
+            {
+                ThrowArgumentOutOfRangeException(nameof(bufferCount), bufferCount);
+            }
+
+            return new GraphicsSurface(this, bufferCount);
+        }
 
         /// <summary>Disables the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsEnabled" /> was <c>true</c> but the instance has already been disposed.</exception>
         public void Disable()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_isEnabled)
             {
-                var display = _windowProvider.DispatchProvider.Display;
                 var wmHints = new XWMHints {
                     flags = (IntPtr)InputHint,
                     input = False
                 };
 
-                _ = XSetWMHints(display, _handle.Value, &wmHints);
+                _ = XSetWMHints(DispatchProvider.Instance.Display, Handle, &wmHints);
                 _isEnabled = false;
             }
         }
 
         /// <summary>Enables the instance.</summary>
         /// <exception cref="ExternalException">The call to <see cref="XGetWMHints(UIntPtr, UIntPtr)" /> failed.</exception>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsEnabled" /> was <c>false</c> but the instance has already been disposed.</exception>
         public void Enable()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_isEnabled == false)
             {
-                var display = _windowProvider.DispatchProvider.Display;
                 var wmHints = new XWMHints {
                     flags = (IntPtr)InputHint,
                     input = True
                 };
 
-                _ = XSetWMHints(display, _handle.Value, &wmHints);
+                _ = XSetWMHints(DispatchProvider.Instance.Display, Handle, &wmHints);
                 _isEnabled = true;
             }
         }
 
         /// <summary>Hides the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsVisible" /> was <c>true</c> but the instance has already been disposed.</exception>
         public void Hide()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_isVisible)
             {
-                var display = _windowProvider.DispatchProvider.Display;
-                _ = XUnmapWindow(display, _handle.Value);
+                _ = XUnmapWindow(DispatchProvider.Instance.Display, Handle);
             }
         }
 
         /// <summary>Maximizes the instance.</summary>
         /// <exception cref="ExternalException">The call to <see cref="XGetWindowAttributes(UIntPtr, UIntPtr, XWindowAttributes*)" /> failed.</exception>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="WindowState" /> was not <see cref="WindowState.Maximized" /> but the instance has already been disposed.</exception>
         public void Maximize()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_windowState != WindowState.Maximized)
             {
-                var display = _windowProvider.DispatchProvider.Display;
+                var display = DispatchProvider.Instance.Display;
+                var handle = Handle;
 
                 XWindowAttributes windowAttributes;
-                var status = XGetWindowAttributes(display, _handle.Value, &windowAttributes);
+                var status = XGetWindowAttributes(display, handle, &windowAttributes);
 
                 if (status != Success)
                 {
@@ -244,7 +242,7 @@ namespace TerraFX.Provider.Xlib.UI
                 var screenWidth = XWidthOfScreen(windowAttributes.screen);
                 var screenHeight = XHeightOfScreen(windowAttributes.screen);
 
-                _ = XMoveResizeWindow(display, _handle.Value, 0, 0, (uint)screenWidth, (uint)screenHeight);
+                _ = XMoveResizeWindow(display, handle, 0, 0, (uint)screenWidth, (uint)screenHeight);
                 _windowState = WindowState.Maximized;
             }
         }
@@ -252,17 +250,16 @@ namespace TerraFX.Provider.Xlib.UI
         /// <summary>Minimizes the instance.</summary>
         /// <exception cref="ExternalException">The call to <see cref="XGetWindowAttributes(UIntPtr, UIntPtr, XWindowAttributes*)" /> failed.</exception>
         /// <exception cref="ExternalException">The call to <see cref="XIconifyWindow(UIntPtr, UIntPtr, int)" /> failed.</exception>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="WindowState" /> was not <see cref="WindowState.Minimized" /> but the instance has already been disposed.</exception>
         public void Minimize()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_windowState != WindowState.Minimized)
             {
-                var display = _windowProvider.DispatchProvider.Display;
+                var display = DispatchProvider.Instance.Display;
+                var handle = Handle;
 
                 XWindowAttributes windowAttributes;
-                var status = XGetWindowAttributes(display, _handle.Value, &windowAttributes);
+                var status = XGetWindowAttributes(display, handle, &windowAttributes);
 
                 if (status != Success)
                 {
@@ -271,7 +268,7 @@ namespace TerraFX.Provider.Xlib.UI
 
                 var screenNumber = XScreenNumberOfScreen(windowAttributes.screen);
 
-                status = XIconifyWindow(display, _handle.Value, screenNumber);
+                status = XIconifyWindow(display, handle, screenNumber);
 
                 if (status == 0)
                 {
@@ -283,17 +280,14 @@ namespace TerraFX.Provider.Xlib.UI
         }
 
         /// <summary>Restores the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="WindowState" /> was not <see cref="WindowState.Restored" /> but the instance has already been disposed.</exception>
         public void Restore()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_windowState != WindowState.Restored)
             {
                 if (_windowState == WindowState.Maximized)
                 {
-                    var display = _windowProvider.DispatchProvider.Display;
-                    _ = XMoveResizeWindow(display, _handle.Value, (int)_restoredBounds.X, (int)_restoredBounds.Y, (uint)_restoredBounds.Width, (uint)_restoredBounds.Height);
+                    _ = XMoveResizeWindow(DispatchProvider.Instance.Display, Handle, (int)_restoredBounds.X, (int)_restoredBounds.Y, (uint)_restoredBounds.Width, (uint)_restoredBounds.Height);
                 }
 
                 Show();
@@ -302,31 +296,24 @@ namespace TerraFX.Provider.Xlib.UI
         }
 
         /// <summary>Shows the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsVisible" /> was <c>false</c> but the instance has already been disposed.</exception>
         public void Show()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_isVisible == false)
             {
-                var display = _windowProvider.DispatchProvider.Display;
-                _ = XMapWindow(display, _handle.Value);
-
+                _ = XMapWindow(DispatchProvider.Instance.Display, Handle);
                 _ = TryActivate();
             }
         }
 
         /// <summary>Tries to activate the instance.</summary>
         /// <returns><c>true</c> if the instance was succesfully activated; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <exception cref="ObjectDisposedException"><see cref="IsActive" /> was <c>false</c> but the instance has already been disposed.</exception>
         public bool TryActivate()
         {
-            _state.ThrowIfDisposedOrDisposing();
-
             if (_isActive == false)
             {
-                var display = _windowProvider.DispatchProvider.Display;
-                _ = XRaiseWindow(display, _handle.Value);
+                _ = XRaiseWindow(DispatchProvider.Instance.Display, Handle);
             }
 
             return true;
@@ -374,7 +361,7 @@ namespace TerraFX.Provider.Xlib.UI
         {
             _state.AssertNotDisposedOrDisposing();
 
-            var dispatchProvider = _windowProvider.DispatchProvider;
+            var dispatchProvider = DispatchProvider.Instance;
             var display = dispatchProvider.Display;
 
             var defaultScreen = XDefaultScreenOfDisplay(display);
@@ -390,12 +377,12 @@ namespace TerraFX.Provider.Xlib.UI
                 float.IsNaN(Bounds.Y) ? (int)(screenHeight * 0.125f) : (int)Bounds.Y,
                 float.IsNaN(Bounds.Width) ? (uint)(screenWidth * 0.75f) : (uint)Bounds.Width,
                 float.IsNaN(Bounds.Height) ? (uint)(screenHeight * 0.75f) : (uint)Bounds.Height,
-                0,
-                CopyFromParent,
-                InputOutput,
+                border_width: 0,
+                depth :CopyFromParent,
+                c_class: InputOutput,
                 (Visual*)CopyFromParent,
-                UIntPtr.Zero,
-                null
+                valuemask: UIntPtr.Zero,
+                attributes: null
             );
 
             if (window == (UIntPtr)None)
@@ -455,7 +442,7 @@ namespace TerraFX.Provider.Xlib.UI
         {
             var priorState = _state.BeginDispose();
 
-            if (priorState < Disposing) // (previousState != Disposing) && (previousState != Disposed)
+            if (priorState < Disposing)
             {
                 // We are only allowed to dispose of the window handle from the parent
                 // thread. So, if we are on the wrong thread, we will close the window
@@ -481,21 +468,15 @@ namespace TerraFX.Provider.Xlib.UI
 
             if (_handle.IsValueCreated)
             {
-                // TODO: This fails due to ObjectDisposedException if the application terminates
-                // due to the application disposing.
-                //
-                // var display = _windowProvider.DispatchProvider.Display;
-                // _ = XDestroyWindow(display, _handle.Value);
+                _ = XDestroyWindow(DispatchProvider.Instance.Display, _handle.Value);
             }
         }
 
         private void HandleXClientMessage(XClientMessageEvent* xclientMessage, bool isWmProtocolsEvent)
         {
-            var dispatchProvider = _windowProvider.DispatchProvider;
-
             if (isWmProtocolsEvent)
             {
-                if (xclientMessage->data.l[0] == (IntPtr)(void*)dispatchProvider.WmDeleteWindowAtom)
+                if (xclientMessage->data.l[0] == (IntPtr)(void*)DispatchProvider.Instance.WmDeleteWindowAtom)
                 {
                     // If we are already disposing, then Dispose is happening on some other thread
                     // and Close was called in order for us to continue disposal on the parent thread.

--- a/sources/UI/IWindowProvider.cs
+++ b/sources/UI/IWindowProvider.cs
@@ -1,6 +1,5 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace TerraFX.UI
@@ -8,6 +7,9 @@ namespace TerraFX.UI
     /// <summary>Provides access to a window subsystem.</summary>
     public interface IWindowProvider
     {
+        /// <summary>Gets the <see cref="IDispatchProvider" /> for the instance.</summary>
+        IDispatchProvider DispatchProvider { get; }
+
         /// <summary>Gets the <see cref="IWindow" /> objects created by the instance.</summary>
         IEnumerable<IWindow> Windows { get; }
 


### PR DESCRIPTION
This cleans up both UI providers to be more in-sync with each other and ensures that they can cleanly shut down.

The Xlib provider was additionally updated to properly report errors and to listen for the WM_DELETE_WINDOW event.