### PR TITLE
Updating the package versions for several TerraFX.Interop libraries

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,9 +27,9 @@
     <PackageReference Update="System.Composition" Version="1.3.0-rc1.19456.4" />
     <PackageReference Update="System.IO.Pipelines" Version="4.6.0-rc1.19456.4" />
     <PackageReference Update="TerraFX.Interop.Libc" Version="1.2017.0-alpha-20190917.1" />
-    <PackageReference Update="TerraFX.Interop.PulseAudio" Version="0.1.0-alpha-20190917.1" />
-    <PackageReference Update="TerraFX.Interop.Vulkan" Version="0.1.0-alpha-20190917.1" />
-    <PackageReference Update="TerraFX.Interop.Windows" Version="0.1.0-alpha-20190917.1" />
+    <PackageReference Update="TerraFX.Interop.PulseAudio" Version="12.2.0-alpha-20190917.2" />
+    <PackageReference Update="TerraFX.Interop.Vulkan" Version="1.0.51-alpha-20190917.2" />
+    <PackageReference Update="TerraFX.Interop.Windows" Version="10.0.15063-alpha-20190917.2" />
     <PackageReference Update="TerraFX.Interop.Xlib" Version="6.3.0-alpha-20190917.1" />
     <PackageReference Update="TerraFX.Utilities" Version="0.1.0-alpha-20190917.1" />
   </ItemGroup>


### PR DESCRIPTION
This updates the package version for the PulseAudio, Vulkan, and Windows interop libraries to match their updated versions. This allows better tracking of what native library a given interop dependency represents.