### PR TITLE
Cleaning up the WindowProvider to properly post a quit message when all windows are destroyed

### DIFF
--- a/sources/ApplicationModel/Application.cs
+++ b/sources/ApplicationModel/Application.cs
@@ -93,6 +93,7 @@ namespace TerraFX.ApplicationModel
                 // we can end up with a NullReferenceException when we try to execute
                 // OnIdle.
 
+                dispatcher.ExitRequested += OnDispatcherExitRequested;
                 dispatcher.DispatchPending();
 
                 while (_state == Running)
@@ -120,6 +121,8 @@ namespace TerraFX.ApplicationModel
 
                     dispatcher.DispatchPending();
                 }
+
+                dispatcher.ExitRequested -= OnDispatcherExitRequested;
             }
             _ = _state.TryTransition(from: Exiting, to: Stopped);
         }
@@ -166,6 +169,8 @@ namespace TerraFX.ApplicationModel
                 _compositionHost.Value.Dispose();
             }
         }
+
+        private void OnDispatcherExitRequested(object? sender, EventArgs e) => RequestExit();
 
         private void OnIdle(TimeSpan delta, uint framesPerSecond)
         {

--- a/sources/Provider/Win32/HelperUtilities.cs
+++ b/sources/Provider/Win32/HelperUtilities.cs
@@ -1,0 +1,35 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
+
+using System;
+using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Provider.Win32
+{
+    internal static unsafe partial class HelperUtilities
+    {
+        public static void ThrowExternalExceptionIfFalse(string methodName, int value)
+        {
+            if (value == FALSE)
+            {
+                ThrowExternalExceptionForLastError(methodName);
+            }
+        }
+
+        public static void ThrowExternalExceptionIfZero(string methodName, int value)
+        {
+            if (value == 0)
+            {
+                ThrowExternalExceptionForLastError(methodName);
+            }
+        }
+
+        public static void ThrowExternalExceptionIfZero(string methodName, IntPtr value)
+        {
+            if (value == IntPtr.Zero)
+            {
+                ThrowExternalExceptionForLastError(methodName);
+            }
+        }
+    }
+}

--- a/sources/Provider/Win32/UI/DispatchProvider.cs
+++ b/sources/Provider/Win32/UI/DispatchProvider.cs
@@ -9,7 +9,7 @@ using TerraFX.Interop;
 using TerraFX.UI;
 using TerraFX.Utilities;
 using static TerraFX.Interop.Kernel32;
-using static TerraFX.Interop.Windows;
+using static TerraFX.Provider.Win32.HelperUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 
 namespace TerraFX.Provider.Win32.UI
@@ -38,12 +38,7 @@ namespace TerraFX.Provider.Win32.UI
             get
             {
                 LARGE_INTEGER performanceCount;
-                var succeeded = QueryPerformanceCounter(&performanceCount);
-
-                if (succeeded == FALSE)
-                {
-                    ThrowExternalExceptionForLastError(nameof(QueryPerformanceCounter));
-                }
+                ThrowExternalExceptionIfFalse(nameof(QueryPerformanceCounter), QueryPerformanceCounter(&performanceCount));
 
                 var ticks = (long)(performanceCount.QuadPart * _tickFrequency);
                 return new Timestamp(ticks);
@@ -82,12 +77,7 @@ namespace TerraFX.Provider.Win32.UI
         private static double GetTickFrequency()
         {
             LARGE_INTEGER frequency;
-            var succeeded = QueryPerformanceFrequency(&frequency);
-
-            if (succeeded == FALSE)
-            {
-                ThrowExternalExceptionForLastError(nameof(QueryPerformanceFrequency));
-            }
+            ThrowExternalExceptionIfFalse(nameof(QueryPerformanceFrequency), QueryPerformanceFrequency(&frequency));
 
             const double TicksPerSecond = Timestamp.TicksPerSecond;
             return TicksPerSecond / frequency.QuadPart;

--- a/sources/Provider/Win32/UI/Window.cs
+++ b/sources/Provider/Win32/UI/Window.cs
@@ -60,6 +60,9 @@ namespace TerraFX.Provider.Win32.UI
             Dispose(isDisposing: false);
         }
 
+        /// <summary>Occurs when the <see cref="IWindow.Location" /> property changes.</summary>
+        public event EventHandler<PropertyChangedEventArgs<Vector2>>? LocationChanged;
+
         /// <summary>Occurs when the <see cref="IWindow.Size" /> property changes.</summary>
         public event EventHandler<PropertyChangedEventArgs<Vector2>>? SizeChanged;
 
@@ -406,8 +409,12 @@ namespace TerraFX.Provider.Win32.UI
 
         private IntPtr HandleWmMove(IntPtr lParam)
         {
-            var location = new Vector2(x: LOWORD(lParam), y: HIWORD(lParam));
-            _bounds = _bounds.WithLocation(location);
+            var previousLocation = _bounds.Location;
+            var currentLocation = new Vector2(x: LOWORD(lParam), y: HIWORD(lParam));
+
+            _bounds = _bounds.WithLocation(currentLocation);
+            OnLocationChanged(previousLocation, currentLocation);
+
             return IntPtr.Zero;
         }
 
@@ -442,6 +449,15 @@ namespace TerraFX.Provider.Win32.UI
             OnSizeChanged(previousSize, currentSize);
 
             return IntPtr.Zero;
+        }
+
+        private void OnLocationChanged(Vector2 previousLocation, Vector2 currentLocation)
+        {
+            if (LocationChanged != null)
+            {
+                var eventArgs = new PropertyChangedEventArgs<Vector2>(previousLocation, currentLocation);
+                LocationChanged(this, eventArgs);
+            }
         }
 
         private void OnSizeChanged(Vector2 previousSize, Vector2 currentSize)

--- a/sources/Provider/Win32/UI/Window.cs
+++ b/sources/Provider/Win32/UI/Window.cs
@@ -11,6 +11,7 @@ using TerraFX.UI;
 using TerraFX.Utilities;
 using static TerraFX.Interop.User32;
 using static TerraFX.Interop.Windows;
+using static TerraFX.Provider.Win32.HelperUtilities;
 using static TerraFX.Provider.Win32.UI.WindowProvider;
 using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
@@ -314,11 +315,7 @@ namespace TerraFX.Provider.Win32.UI
                     lpParam: GCHandle.ToIntPtr(_windowProvider.NativeHandle).ToPointer()
                 );
             }
-
-            if (hWnd == IntPtr.Zero)
-            {
-                ThrowExternalExceptionForLastError(nameof(CreateWindowEx));
-            }
+            ThrowExternalExceptionIfZero(nameof(CreateWindowEx), hWnd);
 
             return hWnd;
         }
@@ -353,12 +350,7 @@ namespace TerraFX.Provider.Win32.UI
 
             if (_handle.IsCreated)
             {
-                var result = DestroyWindow(_handle.Value);
-
-                if (result == FALSE)
-                {
-                    ThrowExternalExceptionForLastError(nameof(DestroyWindow));
-                }
+                ThrowExternalExceptionIfFalse(nameof(DestroyWindow), DestroyWindow(_handle.Value));
             }
         }
 

--- a/sources/Provider/Xlib/HelperUtilities.cs
+++ b/sources/Provider/Xlib/HelperUtilities.cs
@@ -1,0 +1,92 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Interop.Xlib;
+using static TerraFX.Utilities.AssertionUtilities;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Provider.Xlib
+{
+    internal static unsafe partial class HelperUtilities
+    {
+        public static UIntPtr CreateAtom(UIntPtr display, ReadOnlySpan<byte> name)
+        {
+            var atom = XInternAtom(
+                display,
+                atom_name: (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(name)),
+                only_if_exists: False
+            );
+            ThrowExternalExceptionIfZero(nameof(XInternAtom), atom);
+            return atom;
+        }
+
+        public static void ThrowExternalExceptionIfFailed(string methodName, int value)
+        {
+            if (value != Success)
+            {
+                ThrowExternalException(methodName, value);
+            }
+        }
+
+        public static void ThrowExternalExceptionIfZero(string methodName, int value)
+        {
+            if (value == 0)
+            {
+                ThrowExternalException(methodName, value);
+            }
+        }
+
+        public static void ThrowExternalExceptionIfZero(string methodName, UIntPtr value)
+        {
+            if (value == UIntPtr.Zero)
+            {
+                ThrowExternalExceptionForLastError(methodName);
+            }
+        }
+
+        public static void SendClientMessage(UIntPtr display, UIntPtr window, UIntPtr messageType, UIntPtr message, IntPtr data = default)
+        {
+            var clientEvent = new XClientMessageEvent {
+                type = ClientMessage,
+                serial = UIntPtr.Zero,
+                send_event = True,
+                display = display,
+                window = window,
+                message_type = messageType,
+                format = 32
+            };
+
+            if (Environment.Is64BitProcess)
+            {
+                var messageBits = message.ToUInt64();
+                clientEvent.data.l[0] = unchecked((IntPtr)(uint)messageBits);
+                clientEvent.data.l[1] = (IntPtr)(uint)(messageBits >> 32);
+                Assert(clientEvent.data.l[1] == IntPtr.Zero, Resources.ArgumentOutOfRangeExceptionMessage, nameof(message), message);
+
+                var dataBits = data.ToInt64();
+                clientEvent.data.l[2] = unchecked((IntPtr)(uint)dataBits);
+                clientEvent.data.l[3] = (IntPtr)(uint)(dataBits >> 32);
+            }
+            else
+            {
+                var messageBits = message.ToUInt32();
+                clientEvent.data.l[0] = (IntPtr)messageBits;
+
+                var dataBits = data.ToInt32();
+                clientEvent.data.l[1] = (IntPtr)dataBits;
+            }
+
+            ThrowExternalExceptionIfZero(nameof(XSendEvent), XSendEvent(
+                clientEvent.display,
+                clientEvent.window,
+                propagate: False,
+                (IntPtr)NoEventMask,
+                (XEvent*)&clientEvent
+            ));
+        }
+    }
+}

--- a/sources/Provider/Xlib/UI/DispatchProvider.cs
+++ b/sources/Provider/Xlib/UI/DispatchProvider.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using TerraFX.Interop;
@@ -11,6 +10,7 @@ using TerraFX.UI;
 using TerraFX.Utilities;
 using static TerraFX.Interop.Libc;
 using static TerraFX.Interop.Xlib;
+using static TerraFX.Provider.Xlib.HelperUtilities;
 using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
@@ -435,111 +435,23 @@ namespace TerraFX.Provider.Xlib.UI
         private static UIntPtr CreateDisplay()
         {
             var display = XOpenDisplay(display_name: null);
+            ThrowExternalExceptionIfZero(nameof(XOpenDisplay), display);
 
-            if (display == UIntPtr.Zero)
-            {
-                ThrowExternalExceptionForLastError(nameof(XOpenDisplay));
-            }
             _ = XSetErrorHandler(s_errorHandler);
-
             return display;
         }
 
-        private UIntPtr CreateDispatcherExitRequestedAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in DispatcherExitRequestedAtomName[0])),
-                only_if_exists: False
-            );
+        private UIntPtr CreateDispatcherExitRequestedAtom() => CreateAtom(Display, DispatcherExitRequestedAtomName);
 
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
+        private UIntPtr CreateSystemIntPtrAtom() => CreateAtom(Display, SystemIntPtrAtomName);
 
-            return atom;
-        }
+        private UIntPtr CreateWindowProviderCreateWindowAtom() => CreateAtom(Display, WindowProviderCreateWindowAtomName);
 
-        private UIntPtr CreateSystemIntPtrAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in SystemIntPtrAtomName[0])),
-                only_if_exists: False
-            );
+        private UIntPtr CreateWindowWindowProviderAtom() => CreateAtom(Display, WindowWindowProviderAtomName);
 
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
+        private UIntPtr CreateWmProtocolsAtom() => CreateAtom(Display, WmProtocolsAtomName);
 
-            return atom;
-        }
-
-        private UIntPtr CreateWindowProviderCreateWindowAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in WindowProviderCreateWindowAtomName[0])),
-                only_if_exists: False
-            );
-
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
-
-            return atom;
-        }
-
-        private UIntPtr CreateWindowWindowProviderAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in WindowWindowProviderAtomName[0])),
-                only_if_exists: False
-            );
-
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
-
-            return atom;
-        }
-
-        private UIntPtr CreateWmProtocolsAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in WmProtocolsAtomName[0])),
-                only_if_exists: False
-            );
-
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
-
-            return atom;
-        }
-
-        private UIntPtr CreateWmDeleteWindowAtom()
-        {
-            var atom = XInternAtom(
-                Display,
-                atom_name: (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in WmDeleteWindowAtomName[0])),
-                only_if_exists: False
-            );
-
-            if (atom == (UIntPtr)None)
-            {
-                ThrowExternalExceptionForLastError(nameof(XInternAtom));
-            }
-
-            return atom;
-        }
+        private UIntPtr CreateWmDeleteWindowAtom() => CreateAtom(Display, WmDeleteWindowAtomName);
 
         private void Dispose(bool isDisposing)
         {

--- a/sources/Provider/Xlib/UI/Window.cs
+++ b/sources/Provider/Xlib/UI/Window.cs
@@ -60,6 +60,9 @@ namespace TerraFX.Provider.Xlib.UI
             Dispose(isDisposing: false);
         }
 
+        /// <summary>Occurs when the <see cref="IWindow.Location" /> property changes.</summary>
+        public event EventHandler<PropertyChangedEventArgs<Vector2>>? LocationChanged;
+
         /// <summary>Occurs when the <see cref="IWindow.Size" /> property changes.</summary>
         public event EventHandler<PropertyChangedEventArgs<Vector2>>? SizeChanged;
 
@@ -517,6 +520,7 @@ namespace TerraFX.Provider.Xlib.UI
             if (currentLocation != previousLocation)
             {
                 _bounds = _bounds.WithLocation(currentLocation);
+                OnLocationChanged(previousLocation, currentLocation);
             }
 
             var previousSize = _bounds.Size;
@@ -546,6 +550,15 @@ namespace TerraFX.Provider.Xlib.UI
         }
 
         private void HandleXVisibility(XVisibilityEvent* xvisibility) => _isVisible = xvisibility->state != VisibilityFullyObscured;
+
+        private void OnLocationChanged(Vector2 previousLocation, Vector2 currentLocation)
+        {
+            if (LocationChanged != null)
+            {
+                var eventArgs = new PropertyChangedEventArgs<Vector2>(previousLocation, currentLocation);
+                LocationChanged(this, eventArgs);
+            }
+        }
 
         private void OnSizeChanged(Vector2 previousSize, Vector2 currentSize)
         {

--- a/sources/Provider/Xlib/UI/WindowProvider.cs
+++ b/sources/Provider/Xlib/UI/WindowProvider.cs
@@ -1,16 +1,17 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using TerraFX.Interop;
 using TerraFX.UI;
 using TerraFX.Utilities;
 using static TerraFX.Interop.Xlib;
+using static TerraFX.Provider.Xlib.HelperUtilities;
 using static TerraFX.Utilities.AssertionUtilities;
-using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Provider.Xlib.UI
@@ -21,7 +22,7 @@ namespace TerraFX.Provider.Xlib.UI
     [Shared]
     public sealed unsafe class WindowProvider : IDisposable, IWindowProvider
     {
-        private readonly ConcurrentDictionary<UIntPtr, Window> _windows;
+        private readonly ThreadLocal<Dictionary<UIntPtr, Window>> _windows;
 
         private ResettableLazy<GCHandle> _nativeHandle;
         private State _state;
@@ -31,7 +32,7 @@ namespace TerraFX.Provider.Xlib.UI
         public WindowProvider()
         {
             _nativeHandle = new ResettableLazy<GCHandle>(() => GCHandle.Alloc(this, GCHandleType.Normal));
-            _windows = new ConcurrentDictionary<UIntPtr, Window>();
+            _windows = new ThreadLocal<Dictionary<UIntPtr, Window>>(trackAllValues: true);
             _ = _state.Transition(to: Initialized);
         }
 
@@ -54,14 +55,14 @@ namespace TerraFX.Provider.Xlib.UI
             }
         }
 
-        /// <summary>Gets the <see cref="IWindow" /> objects created by the instance.</summary>
+        /// <summary>Gets the <see cref="IWindow" /> objects created by the instance which are associated with <see cref="Thread.CurrentThread" />.</summary>
         /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public IEnumerable<IWindow> Windows
+        public IEnumerable<IWindow> WindowsForCurrentThread
         {
             get
             {
                 _state.ThrowIfDisposedOrDisposing();
-                return _windows.Values;
+                return _windows.Value?.Values ?? Enumerable.Empty<Window>();
             }
         }
 
@@ -79,8 +80,16 @@ namespace TerraFX.Provider.Xlib.UI
         {
             _state.ThrowIfDisposedOrDisposing();
 
+            var windows = _windows.Value;
+
+            if (windows is null)
+            {
+                windows = new Dictionary<UIntPtr, Window>(capacity: 4);
+                _windows.Value = windows;
+            }
+
             var window = new Window(this);
-            _ = _windows.TryAdd(window.Handle, window);
+            _ = windows.TryAdd(window.Handle, window);
 
             return window;
         }
@@ -99,8 +108,8 @@ namespace TerraFX.Provider.Xlib.UI
 
                 if (Environment.Is64BitProcess)
                 {
-                    var lowerBits = unchecked((uint)xevent->xclient.data.l[1].ToInt64());
-                    var upperBits = unchecked((ulong)(uint)xevent->xclient.data.l[2].ToInt64());
+                    var lowerBits = unchecked((uint)xevent->xclient.data.l[2].ToInt64());
+                    var upperBits = unchecked((ulong)(uint)xevent->xclient.data.l[3].ToInt64());
                     userData = (IntPtr)((upperBits << 32) | lowerBits);
                 }
                 else
@@ -128,7 +137,7 @@ namespace TerraFX.Provider.Xlib.UI
                 UIntPtr bytesAfterReturn;
                 IntPtr* propReturn;
 
-                var status = XGetWindowProperty(
+                ThrowExternalExceptionIfFailed(nameof(XGetWindowProperty), XGetWindowProperty(
                     xevent->xany.display,
                     xevent->xany.window,
                     dispatchProvider.WindowWindowProviderAtom,
@@ -141,39 +150,57 @@ namespace TerraFX.Provider.Xlib.UI
                     &nitemsReturn,
                     &bytesAfterReturn,
                     (byte**)&propReturn
-                );
-
-                if (status != Success)
-                {
-                    ThrowExternalException(nameof(XGetWindowProperty), status);
-                }
+                ));
 
                 userData = *propReturn;
             }
 
             WindowProvider windowProvider = null!;
+            Dictionary<UIntPtr, Window>? windows = null;
             var forwardMessage = false;
             Window? window = null;
 
             if (userData != IntPtr.Zero)
             {
                 windowProvider = (WindowProvider)GCHandle.FromIntPtr(userData).Target!;
-                forwardMessage = windowProvider._windows.TryGetValue(xevent->xany.window, out window);
+                windows = windowProvider._windows.Value;
+                forwardMessage = (windows?.TryGetValue(xevent->xany.window, out window)).GetValueOrDefault();
             }
 
             if (forwardMessage)
             {
+                Assert(windows != null, Resources.ArgumentNullExceptionMessage, nameof(windows));
+                Assert(window != null, Resources.ArgumentNullExceptionMessage, nameof(window));
+
+                window.ProcessWindowEvent(xevent, isWmProtocolsEvent);
+
                 if (isWmProtocolsEvent && (xevent->xclient.data.l[0] == (IntPtr)(void*)dispatchProvider.WmDeleteWindowAtom))
                 {
                     // We forward the WM_DELETE_WINDOW message to the corresponding Window instance
                     // so that it can still be properly disposed of in the scenario that the
                     // xevent->xany.window was destroyed externally.
 
-                    _ = windowProvider._windows.TryRemove(xevent->xany.window, out window);
+                    _ = RemoveWindow(windows, xevent->xany.display, xevent->xany.window, dispatchProvider);
                 }
-
-                window!.ProcessWindowEvent(xevent, isWmProtocolsEvent);
             }
+        }
+
+        private static Window RemoveWindow(Dictionary<UIntPtr, Window> windows, UIntPtr display, UIntPtr windowHandle, DispatchProvider dispatchProvider)
+        {
+            _ = windows.Remove(windowHandle, out var window);
+            Assert(window != null, Resources.ArgumentNullExceptionMessage, nameof(window));
+
+            if (windows.Count == 0)
+            {
+                SendClientMessage(
+                    display,
+                    windowHandle,
+                    messageType: dispatchProvider.WmProtocolsAtom,
+                    message: dispatchProvider.DispatcherExitRequestedAtom
+                );
+            }
+
+            return window;
         }
 
         private void Dispose(bool isDisposing)
@@ -194,20 +221,29 @@ namespace TerraFX.Provider.Xlib.UI
 
             if (isDisposing)
             {
-                foreach (var windowHandle in _windows.Keys)
+                var threadWindows = _windows.Values;
+
+                for (var i = 0; i < threadWindows.Count; i++)
                 {
-                    if (_windows.TryRemove(windowHandle, out var createdWindow))
+                    var windows = threadWindows[i];
+
+                    if (windows != null)
                     {
-                        createdWindow.Dispose();
+                        var windowHandles = windows.Keys;
+
+                        foreach (var windowHandle in windowHandles)
+                        {
+                            var dispatchProvider = UI.DispatchProvider.Instance;
+                            var window = RemoveWindow(windows, dispatchProvider.Display, windowHandle, dispatchProvider);
+                            window.Dispose();
+                        }
+
+                        Assert(windows.Count == 0, Resources.ArgumentOutOfRangeExceptionMessage, nameof(windows.Count), windows.Count);
                     }
                 }
-            }
-            else
-            {
-                _windows.Clear();
-            }
 
-            Assert(_windows.IsEmpty, Resources.ArgumentOutOfRangeExceptionMessage, nameof(_windows.IsEmpty), _windows.IsEmpty);
+                _windows.Dispose();
+            }
         }
     }
 }

--- a/sources/UI/IWindow.cs
+++ b/sources/UI/IWindow.cs
@@ -12,6 +12,9 @@ namespace TerraFX.UI
     /// <summary>Defines a window.</summary>
     public interface IWindow
     {
+        /// <summary>Occurs when the <see cref="Location" /> property changes.</summary>
+        event EventHandler<PropertyChangedEventArgs<Vector2>>? LocationChanged;
+
         /// <summary>Occurs when the <see cref="Size" /> property changes.</summary>
         event EventHandler<PropertyChangedEventArgs<Vector2>>? SizeChanged;
 

--- a/sources/UI/IWindowProvider.cs
+++ b/sources/UI/IWindowProvider.cs
@@ -1,6 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace TerraFX.UI
 {
@@ -10,8 +11,8 @@ namespace TerraFX.UI
         /// <summary>Gets the <see cref="IDispatchProvider" /> for the instance.</summary>
         IDispatchProvider DispatchProvider { get; }
 
-        /// <summary>Gets the <see cref="IWindow" /> objects created by the instance.</summary>
-        IEnumerable<IWindow> Windows { get; }
+        /// <summary>Gets the <see cref="IWindow" /> objects created by the instance which are associated with <see cref="Thread.CurrentThread" />.</summary>
+        IEnumerable<IWindow> WindowsForCurrentThread { get; }
 
         /// <summary>Create a new <see cref="IWindow" /> instance.</summary>
         /// <returns>A new <see cref="IWindow" /> instance</returns>


### PR DESCRIPTION
This updates the WindowProvider to properly post a quit message to the dispatcher once all windows for the current thread have been destroyed.