### PR TITLE
Updating the TerraFX.Interop.Windows dependencies to 10.0.15063-alpha-20190928.1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,11 +26,11 @@
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Update="System.Composition" Version="1.3.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.6.0" />
-    <PackageReference Update="TerraFX.Interop.D3D12" Version="10.0.15063-alpha-20190924.3" />
-    <PackageReference Update="TerraFX.Interop.Kernel32" Version="10.0.15063-alpha-20190924.3" />
+    <PackageReference Update="TerraFX.Interop.D3D12" Version="10.0.15063-alpha-20190928.1" />
+    <PackageReference Update="TerraFX.Interop.Kernel32" Version="10.0.15063-alpha-20190928.1" />
     <PackageReference Update="TerraFX.Interop.Libc" Version="1.2017.0-alpha-20190924.2" />
     <PackageReference Update="TerraFX.Interop.PulseAudio" Version="12.2.0-alpha-20190924.2" />
-    <PackageReference Update="TerraFX.Interop.User32" Version="10.0.15063-alpha-20190924.3" />
+    <PackageReference Update="TerraFX.Interop.User32" Version="10.0.15063-alpha-20190928.1" />
     <PackageReference Update="TerraFX.Interop.Vulkan" Version="1.1.123-alpha-20190924.5" />
     <PackageReference Update="TerraFX.Interop.Xlib" Version="6.3.0-alpha-20190924.4" />
   </ItemGroup>

--- a/sources/Provider/Win32/UI/Dispatcher.cs
+++ b/sources/Provider/Win32/UI/Dispatcher.cs
@@ -48,7 +48,7 @@ namespace TerraFX.Provider.Win32.UI
             ThrowIfNotThread(_parentThread);
 
             MSG msg;
-            while (PeekMessage(&msg, wMsgFilterMin: WM_NULL, wMsgFilterMax: WM_NULL, wRemoveMsg: PM_REMOVE) != FALSE)
+            while (PeekMessage(&msg, hWnd: IntPtr.Zero, wMsgFilterMin: WM_NULL, wMsgFilterMax: WM_NULL, wRemoveMsg: PM_REMOVE) != FALSE)
             {
                 if (msg.message != WM_QUIT)
                 {

--- a/sources/Provider/Win32/UI/Window.cs
+++ b/sources/Provider/Win32/UI/Window.cs
@@ -356,7 +356,7 @@ namespace TerraFX.Provider.Win32.UI
 
         private IntPtr HandleWmActivate(UIntPtr wParam)
         {
-            _isActive = LOWORD(wParam) != WA_INACTIVE;
+            _isActive = LOWORD((uint)wParam) != WA_INACTIVE;
             return IntPtr.Zero;
         }
 
@@ -402,7 +402,7 @@ namespace TerraFX.Provider.Win32.UI
         private IntPtr HandleWmMove(IntPtr lParam)
         {
             var previousLocation = _bounds.Location;
-            var currentLocation = new Vector2(x: LOWORD(lParam), y: HIWORD(lParam));
+            var currentLocation = new Vector2(x: LOWORD((uint)lParam), y: HIWORD((uint)lParam));
 
             _bounds = _bounds.WithLocation(currentLocation);
             OnLocationChanged(previousLocation, currentLocation);
@@ -425,7 +425,7 @@ namespace TerraFX.Provider.Win32.UI
 
         private IntPtr HandleWmShowWindow(UIntPtr wParam)
         {
-            _isVisible = LOWORD(wParam) != FALSE;
+            _isVisible = LOWORD((uint)wParam) != FALSE;
             return IntPtr.Zero;
         }
 
@@ -435,7 +435,7 @@ namespace TerraFX.Provider.Win32.UI
             Assert(Enum.IsDefined(typeof(WindowState), _windowState), Resources.ArgumentOutOfRangeExceptionMessage, nameof(wParam), wParam);
 
             var previousSize = _bounds.Size;
-            var currentSize = new Vector2(x: LOWORD(lParam), y: HIWORD(lParam));
+            var currentSize = new Vector2(x: LOWORD((uint)lParam), y: HIWORD((uint)lParam));
 
             _bounds = _bounds.WithSize(currentSize);
             OnSizeChanged(previousSize, currentSize);

--- a/sources/Provider/Win32/UI/WindowProvider.cs
+++ b/sources/Provider/Win32/UI/WindowProvider.cs
@@ -195,6 +195,7 @@ namespace TerraFX.Provider.Win32.UI
             WNDCLASSEX desktopWindowClass;
 
             ThrowExternalExceptionIfFalse(nameof(GetClassInfoEx), GetClassInfoEx(
+                hInstance: IntPtr.Zero,
                 lpszClass: desktopClassName,
                 lpwcx: &desktopWindowClass
             ));


### PR DESCRIPTION
Updates to the newer dependencies, which includes complete bindings for User32.