### PR TITLE
Adding basic debugging support to the D3D12 and Vulkan providers

### DIFF
--- a/samples/TerraFX/Graphics/HelloWindow.cs
+++ b/samples/TerraFX/Graphics/HelloWindow.cs
@@ -21,6 +21,21 @@ namespace TerraFX.Samples.Graphics
         {
         }
 
+        public override void Cleanup()
+        {
+            if (_graphicsContext is IDisposable graphicsContext)
+            {
+                graphicsContext.Dispose();
+            }
+
+            if (_window is IDisposable window)
+            {
+                window.Dispose();
+            }
+
+            base.Cleanup();
+        }
+
         public override void Initialize(Application application)
         {
             ExceptionUtilities.ThrowIfNull(application, nameof(application));

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -87,6 +87,8 @@ namespace TerraFX.Samples
                 sample.Initialize(application);
             }
             application.Run();
+
+            sample.Cleanup();
         }
 
         private static void RunSamples(string[] args)

--- a/samples/TerraFX/Shared/Sample.cs
+++ b/samples/TerraFX/Shared/Sample.cs
@@ -29,6 +29,10 @@ namespace TerraFX.Samples
 
         public string Name => _name;
 
+        public virtual void Cleanup()
+        {
+        }
+
         public virtual void Initialize(Application application)
         {
             application.Idle += OnIdle;

--- a/sources/Provider/Vulkan/Graphics/GraphicsProvider.cs
+++ b/sources/Provider/Vulkan/Graphics/GraphicsProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using TerraFX.Graphics;
@@ -11,7 +12,9 @@ using TerraFX.Interop;
 using TerraFX.Utilities;
 using static TerraFX.Interop.VkResult;
 using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.VkDebugReportFlagBitsEXT;
 using static TerraFX.Interop.Vulkan;
+using static TerraFX.Provider.Vulkan.HelperUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
 
@@ -19,10 +22,26 @@ namespace TerraFX.Provider.Vulkan.Graphics
 {
     /// <summary>Provides access to a Vulkan based graphics subsystem.</summary>
     [Export(typeof(IGraphicsProvider))]
-    [Export(typeof(GraphicsProvider))]
     [Shared]
     public sealed unsafe class GraphicsProvider : IDisposable, IGraphicsProvider
     {
+        // TerraFX
+        private static ReadOnlySpan<sbyte> s_engineName => new sbyte[] { 0x54, 0x65, 0x72, 0x72, 0x61, 0x46, 0x58, 0x00 };
+
+        // VK_LAYER_LUNARG_standard_validation
+        private static ReadOnlySpan<sbyte> VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME => new sbyte[] { 0x56, 0x4B, 0x5F, 0x4C, 0x41, 0x59, 0x45, 0x52, 0x5F, 0x4C, 0x55, 0x4E, 0x41, 0x52, 0x47, 0x5F, 0x73, 0x74, 0x61, 0x6E, 0x64, 0x61, 0x72, 0x64, 0x5F, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x00 };
+
+        // vkCreateDebugReportCallbackEXT
+        private static ReadOnlySpan<sbyte> VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+
+        // vkDestroyDebugReportCallbackEXT
+        private static ReadOnlySpan<sbyte> VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x44, 0x65, 0x73, 0x74, 0x72, 0x6F, 0x79, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+
+#if DEBUG
+        private NativeDelegate<PFN_vkDebugReportCallbackEXT> _debugReportCallback;
+        private ulong _debugReportCallbackExt;
+#endif
+
         private ResettableLazy<ImmutableArray<GraphicsAdapter>> _adapters;
         private ResettableLazy<IntPtr> _instance;
 
@@ -74,29 +93,146 @@ namespace TerraFX.Provider.Vulkan.Graphics
             GC.SuppressFinalize(this);
         }
 
-        private static IntPtr CreateInstance()
+        private IntPtr CreateInstance()
         {
-            var enabledExtensionCount = 2u;
+            var enabledExtensionCount = 0u;
+            var isSurfaceExtensionSupported = false;
+            var isWin32SurfaceExtensionSupported = false;
+            var isXlibSurfaceExtensionSupported = false;
+            var isDebugReportExtensionSupported = false;
+
+            var extensionPropertyCount = 0u;
+            ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &extensionPropertyCount, pProperties: null));
+
+            var extensionProperties = new VkExtensionProperties[extensionPropertyCount];
+
+            fixed (VkExtensionProperties* pExtensionProperties = extensionProperties)
+            {
+                ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &extensionPropertyCount, pExtensionProperties));
+            }
+
+            for (var i = 0; i < extensionProperties.Length; i++)
+            {
+                var extensionName = new ReadOnlySpan<sbyte>(Unsafe.AsPointer(ref extensionProperties[i].extensionName[0]), int.MaxValue);
+                extensionName = extensionName.Slice(0, extensionName.IndexOf((sbyte)'\0') + 1);
+
+                if (!isSurfaceExtensionSupported && VK_KHR_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                {
+                    isSurfaceExtensionSupported = true;
+                    enabledExtensionCount++;
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (!isWin32SurfaceExtensionSupported && VK_KHR_WIN32_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                    {
+                        isWin32SurfaceExtensionSupported = true;
+                        enabledExtensionCount++;
+                    }
+                }
+                else
+                {
+                    if (!isXlibSurfaceExtensionSupported && VK_KHR_XLIB_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                    {
+                        isXlibSurfaceExtensionSupported = true;
+                        enabledExtensionCount++;
+                    }
+                }
+
+#if DEBUG
+                if (!isDebugReportExtensionSupported && VK_EXT_DEBUG_REPORT_EXTENSION_NAME.SequenceEqual(extensionName))
+                {
+                    isDebugReportExtensionSupported = true;
+                    enabledExtensionCount++;
+                }
+#endif
+            }
 
             var enabledExtensionNames = stackalloc sbyte*[(int)enabledExtensionCount];
-            enabledExtensionNames[0] = (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in VK_KHR_SURFACE_EXTENSION_NAME[0]));
+
+            if (!isSurfaceExtensionSupported)
+            {
+                ThrowInvalidOperationException(nameof(isSurfaceExtensionSupported), isSurfaceExtensionSupported);
+            }
+
+            enabledExtensionNames[0] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_SURFACE_EXTENSION_NAME));
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in VK_KHR_WIN32_SURFACE_EXTENSION_NAME[0]));
+                if (!isWin32SurfaceExtensionSupported)
+                {
+                    ThrowInvalidOperationException(nameof(isWin32SurfaceExtensionSupported), isWin32SurfaceExtensionSupported);
+                }
+
+                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_WIN32_SURFACE_EXTENSION_NAME));
             }
             else
             {
-                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref Unsafe.AsRef(in VK_KHR_XLIB_SURFACE_EXTENSION_NAME[0]));
+                if (!isXlibSurfaceExtensionSupported)
+                {
+                    ThrowInvalidOperationException(nameof(isXlibSurfaceExtensionSupported), isXlibSurfaceExtensionSupported);
+                }
+
+                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_XLIB_SURFACE_EXTENSION_NAME));
             }
+
+            if (isDebugReportExtensionSupported)
+            {
+                // We don't want to throw if the debug extension isn't available
+                enabledExtensionNames[2] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_EXT_DEBUG_REPORT_EXTENSION_NAME));
+            }
+
+            var enabledLayerCount = 0u;
+            var isLunarGStandardValidationLayerSupported = false;
+
+#if DEBUG
+            var layerPropertyCount = 0u;
+            ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&layerPropertyCount, pProperties: null));
+
+            var layerProperties = new VkLayerProperties[layerPropertyCount];
+
+            fixed (VkLayerProperties* pLayerProperties = layerProperties)
+            {
+                ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&layerPropertyCount, pLayerProperties));
+            }
+
+            for (var i = 0; i < layerProperties.Length; i++)
+            {
+                var layerName = new ReadOnlySpan<sbyte>(Unsafe.AsPointer(ref layerProperties[i].layerName[0]), int.MaxValue);
+                layerName = layerName.Slice(0, layerName.IndexOf((sbyte)'\0') + 1);
+
+                if (!isLunarGStandardValidationLayerSupported && VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME.SequenceEqual(layerName))
+                {
+                    isLunarGStandardValidationLayerSupported = true;
+                    enabledLayerCount++;
+                }
+            }
+#endif
+
+            var enabledLayerNames = stackalloc sbyte*[(int)enabledLayerCount];
+
+            if (isLunarGStandardValidationLayerSupported)
+            {
+                enabledLayerNames[0] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME));
+            }
+
+            var applicationInfo = new VkApplicationInfo {
+                sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+                pNext = null,
+                pApplicationName = null,
+                applicationVersion = 1,
+                pEngineName = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(s_engineName)),
+                engineVersion = VK_MAKE_VERSION(0, 1, 0),
+                apiVersion = VK_API_VERSION_1_0,
+            };
 
             var createInfo = new VkInstanceCreateInfo {
                 sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
                 pNext = null,
                 flags = 0,
-                pApplicationInfo = null,
-                enabledLayerCount = 0,
-                ppEnabledLayerNames = null,
+                pApplicationInfo = &applicationInfo,
+                enabledLayerCount = enabledLayerCount,
+                ppEnabledLayerNames = enabledLayerNames,
                 enabledExtensionCount = enabledExtensionCount,
                 ppEnabledExtensionNames = enabledExtensionNames,
             };
@@ -109,8 +245,41 @@ namespace TerraFX.Provider.Vulkan.Graphics
                 ThrowExternalException(nameof(vkCreateInstance), (int)result);
             }
 
+            if (isDebugReportExtensionSupported && isLunarGStandardValidationLayerSupported)
+            {
+#if DEBUG
+                ulong debugReportCallbackExt;
+
+                _debugReportCallback = new NativeDelegate<PFN_vkDebugReportCallbackEXT>(DebugReportCallback);
+
+                var debugReportCallbackCreateInfo = new VkDebugReportCallbackCreateInfoEXT {
+                    sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
+                    pNext = null,
+                    flags = (uint)(VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT),
+                    pfnCallback = _debugReportCallback,
+                    pUserData = null,
+                };
+
+                // We don't want to fail if creating the debug report callback failed
+                var vkCreateDebugReportCallbackEXT = vkGetInstanceProcAddr(instance, (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME)));
+                _ = Marshal.GetDelegateForFunctionPointer<PFN_vkCreateDebugReportCallbackEXT>(vkCreateDebugReportCallbackEXT)(instance, &debugReportCallbackCreateInfo, pAllocator: null, &debugReportCallbackExt);
+                _debugReportCallbackExt = debugReportCallbackExt;
+#endif
+            }
+
             return instance;
         }
+
+#if DEBUG
+        private static uint DebugReportCallback(uint flags, VkDebugReportObjectTypeEXT objectType, ulong @object, UIntPtr location, int messageCode, sbyte* pLayerPrefix, sbyte* pMessage, void* pUserData)
+        {
+            var messageLength = new ReadOnlySpan<sbyte>(pMessage, int.MaxValue).IndexOf((sbyte)'\0') + 1;
+            var message = new string(pMessage, 0, messageLength);
+
+            Debug.WriteLine(message);
+            return VK_FALSE;
+        }
+#endif
 
         private void Dispose(bool isDisposing)
         {
@@ -130,7 +299,15 @@ namespace TerraFX.Provider.Vulkan.Graphics
 
             if (_instance.IsCreated)
             {
-                vkDestroyInstance(_instance.Value, null);
+#if DEBUG
+                if (_debugReportCallbackExt != 0)
+                {
+                    var vkDestroyDebugReportCallbackEXT = vkGetInstanceProcAddr(_instance.Value, (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME)));
+                    Marshal.GetDelegateForFunctionPointer<PFN_vkDestroyDebugReportCallbackEXT>(vkDestroyDebugReportCallbackEXT)(_instance.Value, _debugReportCallbackExt, pAllocator: null);
+                }
+#endif
+
+                vkDestroyInstance(_instance.Value, pAllocator: null);
             }
         }
 
@@ -139,7 +316,7 @@ namespace TerraFX.Provider.Vulkan.Graphics
             var instance = _instance.Value;
 
             var physicalDeviceCount = 0u;
-            var result = vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, null);
+            var result = vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, pPhysicalDevices: null);
 
             if (result != VK_SUCCESS)
             {

--- a/sources/Provider/Vulkan/HelperUtilities.cs
+++ b/sources/Provider/Vulkan/HelperUtilities.cs
@@ -1,0 +1,19 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
+
+using TerraFX.Interop;
+using static TerraFX.Interop.VkResult;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Provider.Vulkan
+{
+    internal static partial class HelperUtilities
+    {
+        public static void ThrowExternalExceptionIfFailed(string methodName, VkResult result)
+        {
+            if (result != VK_SUCCESS)
+            {
+                ThrowExternalException(methodName, (int)result);
+            }
+        }
+    }
+}

--- a/sources/Provider/Win32/UI/WindowProvider.cs
+++ b/sources/Provider/Win32/UI/WindowProvider.cs
@@ -11,10 +11,8 @@ using TerraFX.UI;
 using TerraFX.Utilities;
 using static TerraFX.Interop.Kernel32;
 using static TerraFX.Interop.User32;
-using static TerraFX.Interop.Windows;
 using static TerraFX.Provider.Win32.HelperUtilities;
 using static TerraFX.Utilities.AssertionUtilities;
-using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.InteropUtilities;
 using static TerraFX.Utilities.State;
 

--- a/sources/Provider/Xlib/UI/WindowProvider.cs
+++ b/sources/Provider/Xlib/UI/WindowProvider.cs
@@ -18,7 +18,6 @@ namespace TerraFX.Provider.Xlib.UI
 {
     /// <summary>Provides access to an X11 based window subsystem.</summary>
     [Export(typeof(IWindowProvider))]
-    [Export(typeof(WindowProvider))]
     [Shared]
     public sealed unsafe class WindowProvider : IDisposable, IWindowProvider
     {


### PR DESCRIPTION
This enables the debug validation layers for the D3D12 and Vulkan providers. It also does some minimal sample cleanup to ensure cleanup is happening.