### PR TITLE
Adding a .lfsconfig file which points to Azure

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+  url = https://tagoo@dev.azure.com/tagoo/terrafx/_git/terrafx.git/info/lfs


### PR DESCRIPTION
Adding a .lfsconfig file which points to Azure.  This is separate from https://github.com/terrafx/terrafx/pull/48 to try and convince CI to pull from the right LFS location.