### PR TITLE
Cleaning up the IGraphicsAdapter and IGraphicsProvider implementations.

### DIFF
--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -14,22 +14,22 @@ namespace TerraFX.Samples
 {
     public static unsafe class Program
     {
-        private static readonly Assembly s_d3d12Provider = Assembly.LoadFrom("TerraFX.Provider.D3D12.dll");
-        private static readonly Assembly s_vulkanProvider = Assembly.LoadFrom("TerraFX.Provider.Vulkan.dll");
+        private static readonly Assembly s_audioProviderPulseAudio = Assembly.LoadFrom("TerraFX.Audio.Providers.PulseAudio.dll");
 
-        private static readonly Assembly s_pulseAudioProvider = Assembly.LoadFrom("TerraFX.Provider.PulseAudio.dll");
+        private static readonly Assembly s_graphicsProviderD3D12 = Assembly.LoadFrom("TerraFX.Graphics.Providers.D3D12.dll");
+        private static readonly Assembly s_graphicsProviderVulkan = Assembly.LoadFrom("TerraFX.Graphics.Providers.Vulkan.dll");
 
         private static readonly Sample[] s_samples = {
-            new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_d3d12Provider),
-            new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_vulkanProvider),
+            new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_graphicsProviderD3D12),
+            new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_graphicsProviderVulkan),
 
-            new HelloWindow("D3D12.HelloWindow", s_d3d12Provider),
-            new HelloWindow("Vulkan.HelloWindow", s_vulkanProvider),
+            new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
+            new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
 
-            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_pulseAudioProvider),
-            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_pulseAudioProvider),
+            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
+            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),
 
-            new PlaySampleAudio("PulseAudio.PlaySampleAudio", s_pulseAudioProvider),
+            new PlaySampleAudio("PulseAudio.PlaySampleAudio", s_audioProviderPulseAudio),
         };
 
         public static void Main(string[] args)
@@ -52,11 +52,11 @@ namespace TerraFX.Samples
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                isSupported = !sample.CompositionAssemblies.Contains(s_pulseAudioProvider);
+                isSupported = !sample.CompositionAssemblies.Contains(s_audioProviderPulseAudio);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                isSupported = !sample.CompositionAssemblies.Contains(s_d3d12Provider);
+                isSupported = !sample.CompositionAssemblies.Contains(s_graphicsProviderD3D12);
             }
             else
             {

--- a/samples/TerraFX/Shared/Sample.cs
+++ b/samples/TerraFX/Shared/Sample.cs
@@ -9,8 +9,8 @@ namespace TerraFX.Samples
 {
     public abstract class Sample
     {
-        private static readonly Assembly s_win32Provider = Assembly.LoadFrom("TerraFX.Provider.Win32.dll");
-        private static readonly Assembly s_xlibProvider = Assembly.LoadFrom("TerraFX.Provider.Xlib.dll");
+        private static readonly Assembly s_uiProviderWin32 = Assembly.LoadFrom("TerraFX.UI.Providers.Win32.dll");
+        private static readonly Assembly s_uiProviderXlib = Assembly.LoadFrom("TerraFX.UI.Providers.Xlib.dll");
 
         private readonly string _name;
         private readonly Assembly[] _compositionAssemblies;
@@ -20,7 +20,7 @@ namespace TerraFX.Samples
             _name = name;
 
             _compositionAssemblies = new Assembly[compositionAssemblies.Length + 1];
-            _compositionAssemblies[0] = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? s_win32Provider : s_xlibProvider;
+            _compositionAssemblies[0] = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? s_uiProviderWin32 : s_uiProviderXlib;
 
             Array.Copy(compositionAssemblies, 0, _compositionAssemblies, 1, compositionAssemblies.Length);
         }

--- a/sources/Graphics/IGraphicsAdapter.cs
+++ b/sources/Graphics/IGraphicsAdapter.cs
@@ -4,25 +4,29 @@ using System;
 
 namespace TerraFX.Graphics
 {
-    /// <summary>Represents a graphics adapter.</summary>
-    public interface IGraphicsAdapter
+    /// <summary>A graphics adapter which can be used for computational or graphical operations.</summary>
+    public interface IGraphicsAdapter : IDisposable
     {
         /// <summary>Gets the PCI ID of the device.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
         uint DeviceId { get; }
 
         /// <summary>Gets the name of the device.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
         string DeviceName { get; }
 
         /// <summary>Gets the <see cref="IGraphicsProvider" /> for the instance.</summary>
         IGraphicsProvider GraphicsProvider { get; }
 
         /// <summary>Gets the PCI ID of the vendor.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
         uint VendorId { get; }
 
         /// <summary>Creates a new <see cref="IGraphicsContext" />.</summary>
         /// <param name="graphicsSurface">The <see cref="IGraphicsSurface" /> on which the graphics context can draw.</param>
         /// <returns>A new <see cref="IGraphicsContext" /> which utilizes the current instance and which can draw on <paramref name="graphicsSurface" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsSurface" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
         IGraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface);
     }
 }

--- a/sources/Graphics/IGraphicsProvider.cs
+++ b/sources/Graphics/IGraphicsProvider.cs
@@ -1,13 +1,26 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace TerraFX.Graphics
 {
-    /// <summary>Provides access to a graphics subsystem.</summary>
-    public interface IGraphicsProvider
+    /// <summary>Provides the base access required for interacting with a graphics subsystem.</summary>
+    public interface IGraphicsProvider : IDisposable
     {
+        /// <summary>A name of a switch that controls whether <c>debug mode</c> should be enabled for the graphics provider.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppContext.SetSwitch(string, bool)" />.</para>
+        ///     <para>Setting this switch after a graphics provider instance has been created has no affect.</para>
+        /// </remarks>
+        public const string EnableDebugModeSwitchName = "TerraFX.Graphics.IGraphicsProvider.EnableDebugMode";
+
+        /// <summary>Gets the value of the <see cref="EnableDebugModeSwitchName" /> switch when the instance was created.</summary>
+        /// <remarks>The exact behavior of <c>debug mode</c> may vary based on the implementation and configuration of the host machine.</remarks>
+        public bool DebugModeEnabled { get; }
+
         /// <summary>Gets the <see cref="IGraphicsAdapter" /> instances currently available.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
         IEnumerable<IGraphicsAdapter> GraphicsAdapters { get; }
     }
 }

--- a/sources/Providers/Graphics/D3D12/GraphicsAdapter.cs
+++ b/sources/Providers/Graphics/D3D12/GraphicsAdapter.cs
@@ -6,18 +6,19 @@ using TerraFX.Interop;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.InteropUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.D3D12
 {
-    /// <summary>Represents a graphics adapter.</summary>
-    public sealed unsafe class GraphicsAdapter : IDisposable, IGraphicsAdapter
+    /// <inheritdoc cref="IGraphicsAdapter" />
+    public sealed unsafe class GraphicsAdapter : IGraphicsAdapter
     {
         private readonly GraphicsProvider _graphicsProvider;
         private readonly IDXGIAdapter1* _adapter;
-        private readonly string _deviceName;
-        private readonly uint _vendorId;
-        private readonly uint _deviceId;
+
+        private ValueLazy<DXGI_ADAPTER_DESC1> _adapterDesc;
+        private ValueLazy<string> _deviceName;
 
         private State _state;
 
@@ -26,24 +27,14 @@ namespace TerraFX.Graphics.Providers.D3D12
             _graphicsProvider = graphicsProvider;
             _adapter = adapter;
 
-            DXGI_ADAPTER_DESC1 desc;
-            ThrowExternalExceptionIfFailed(nameof(IDXGIAdapter1.GetDesc1), adapter->GetDesc1(&desc));
-
-            _deviceName = Marshal.PtrToStringUni((IntPtr)desc.Description)!;
-            _vendorId = desc.VendorId;
-            _deviceId = desc.DeviceId;
+            _adapterDesc = new ValueLazy<DXGI_ADAPTER_DESC1>(GetAdapterDesc);
+            _deviceName = new ValueLazy<string>(GetDeviceName);
 
             _ = _state.Transition(to: Initialized);
         }
 
-        /// <inheritdoc />
-        public uint DeviceId => _deviceId;
-
-        /// <inheritdoc />
-        public string DeviceName => _deviceName;
-
-        /// <summary>Gets the <see cref="IDXGIAdapter1" /> pointer the instance represents.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        /// <summary>Gets the the underlying <see cref="IDXGIAdapter1" />.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
         public IDXGIAdapter1* Adapter
         {
             get
@@ -53,14 +44,24 @@ namespace TerraFX.Graphics.Providers.D3D12
             }
         }
 
+        /// <summary>Gets the <see cref="DXGI_ADAPTER_DESC1" /> for <see cref="Adapter" />.</summary>
+        /// <exception cref="ExternalException">The call to <see cref="IDXGIAdapter1.GetDesc1(DXGI_ADAPTER_DESC1*)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
+        public ref readonly DXGI_ADAPTER_DESC1 AdapterDesc => ref _adapterDesc.RefValue;
+
+        /// <inheritdoc />
+        public uint DeviceId => AdapterDesc.DeviceId;
+
+        /// <inheritdoc />
+        public string DeviceName => _deviceName.Value;
+
         /// <inheritdoc />
         public IGraphicsProvider GraphicsProvider => _graphicsProvider;
 
         /// <inheritdoc />
-        public uint VendorId => _vendorId;
+        public uint VendorId => AdapterDesc.VendorId;
 
         /// <inheritdoc />
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
         public IGraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface)
         {
             _state.ThrowIfDisposedOrDisposing();
@@ -81,20 +82,21 @@ namespace TerraFX.Graphics.Providers.D3D12
 
             if (priorState < Disposing)
             {
-                DisposeAdapter();
+                ReleaseIfNotNull(_adapter);
             }
 
             _state.EndDispose();
         }
 
-        private void DisposeAdapter()
+        private DXGI_ADAPTER_DESC1 GetAdapterDesc()
         {
-            _state.AssertDisposing();
+            _state.ThrowIfDisposedOrDisposing();
 
-            if (_adapter != null)
-            {
-                _ = _adapter->Release();
-            }
+            DXGI_ADAPTER_DESC1 desc;
+            ThrowExternalExceptionIfFailed(nameof(IDXGIAdapter1.GetDesc1), Adapter->GetDesc1(&desc));
+            return desc;
         }
+
+        private string GetDeviceName() => MarshalNullTerminatedStringUtf16(in AdapterDesc.Description[0], 128);
     }
 }

--- a/sources/Providers/Graphics/D3D12/GraphicsAdapter.cs
+++ b/sources/Providers/Graphics/D3D12/GraphicsAdapter.cs
@@ -97,6 +97,6 @@ namespace TerraFX.Graphics.Providers.D3D12
             return desc;
         }
 
-        private string GetDeviceName() => MarshalNullTerminatedStringUtf16(in AdapterDesc.Description[0], 128);
+        private string GetDeviceName() => MarshalNullTerminatedStringUtf16(in AdapterDesc.Description[0], 128).AsString() ?? string.Empty;
     }
 }

--- a/sources/Providers/Graphics/D3D12/HelperUtilities.cs
+++ b/sources/Providers/Graphics/D3D12/HelperUtilities.cs
@@ -1,13 +1,22 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
 
+using TerraFX.Interop;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.ExceptionUtilities;
 
 namespace TerraFX.Graphics.Providers.D3D12
 {
-    internal static partial class HelperUtilities
+    internal static unsafe partial class HelperUtilities
     {
-        #region Static Methods	
+        public static void ReleaseIfNotNull<TUnknown>(TUnknown* unknown)
+            where TUnknown : unmanaged
+        {
+            if (unknown != null)
+            {
+                _ = ((IUnknown*)unknown)->Release();
+            }
+        }
+
         public static void ThrowExternalExceptionIfFailed(string methodName, int hr)
         {
             if (FAILED(hr))
@@ -15,6 +24,5 @@ namespace TerraFX.Graphics.Providers.D3D12
                 ThrowExternalException(methodName, hr);
             }
         }
-        #endregion
     }
 }

--- a/sources/Providers/Graphics/D3D12/HelperUtilities.cs
+++ b/sources/Providers/Graphics/D3D12/HelperUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
 
 using TerraFX.Interop;
+using TerraFX.Utilities;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.ExceptionUtilities;
 
@@ -8,6 +9,15 @@ namespace TerraFX.Graphics.Providers.D3D12
 {
     internal static unsafe partial class HelperUtilities
     {
+        public static void ReleaseIfCreated<TUnknown>(ValueLazy<Pointer<TUnknown>> unknown)
+            where TUnknown : unmanaged
+        {
+            if (unknown.IsCreated)
+            {
+                ReleaseIfNotNull<TUnknown>(unknown.Value);
+            }
+        }
+
         public static void ReleaseIfNotNull<TUnknown>(TUnknown* unknown)
             where TUnknown : unmanaged
         {

--- a/sources/Providers/Graphics/Vulkan/GraphicsAdapter.cs
+++ b/sources/Providers/Graphics/Vulkan/GraphicsAdapter.cs
@@ -84,6 +84,6 @@ namespace TerraFX.Graphics.Providers.Vulkan
             return physicalDeviceProperties;
         }
 
-        private string GetDeviceName() => MarshalNullTerminatedStringUtf8(in PhysicalDeviceProperties.deviceName[0], 256);
+        private string GetDeviceName() => MarshalUtf8ToReadOnlySpan(in PhysicalDeviceProperties.deviceName[0], 256).AsString() ?? string.Empty;
     }
 }

--- a/sources/Providers/Graphics/Vulkan/GraphicsAdapter.cs
+++ b/sources/Providers/Graphics/Vulkan/GraphicsAdapter.cs
@@ -1,55 +1,89 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Runtime.InteropServices;
 using TerraFX.Interop;
+using TerraFX.Utilities;
 using static TerraFX.Interop.Vulkan;
 using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.Vulkan
 {
-    /// <summary>Represents a graphics adapter.</summary>
+    /// <inheritdoc cref="IGraphicsAdapter" />
     public sealed unsafe class GraphicsAdapter : IGraphicsAdapter
     {
         private readonly GraphicsProvider _graphicsProvider;
         private readonly VkPhysicalDevice _physicalDevice;
-        private readonly string _deviceName;
-        private readonly uint _vendorId;
-        private readonly uint _deviceId;
+
+        private ValueLazy<VkPhysicalDeviceProperties> _physicalDeviceProperties;
+        private ValueLazy<string> _deviceName;
+
+        private State _state;
 
         internal GraphicsAdapter(GraphicsProvider graphicsProvider, VkPhysicalDevice physicalDevice)
         {
             _graphicsProvider = graphicsProvider;
             _physicalDevice = physicalDevice;
 
-            VkPhysicalDeviceProperties properties;
-            vkGetPhysicalDeviceProperties(physicalDevice, &properties);
+            _physicalDeviceProperties = new ValueLazy<VkPhysicalDeviceProperties>(GetPhysicalDeviceProperties);
+            _deviceName = new ValueLazy<string>(GetDeviceName);
 
-            _deviceName = Marshal.PtrToStringAnsi((IntPtr)properties.deviceName)!;
-            _vendorId = properties.vendorID;
-            _deviceId = properties.deviceID;
+            _ = _state.Transition(to: Initialized);
         }
 
         /// <inheritdoc />
-        public uint DeviceId => _deviceId;
+        public uint DeviceId => PhysicalDeviceProperties.deviceID;
 
         /// <inheritdoc />
-        public string DeviceName => _deviceName;
+        public string DeviceName => _deviceName.Value;
 
         /// <inheritdoc />
         public IGraphicsProvider GraphicsProvider => _graphicsProvider;
 
-        /// <summary>Gets the physical device for the instance.</summary>
-        public VkPhysicalDevice PhysicalDevice => _physicalDevice;
+        /// <summary>Gets the underlying <see cref="VkPhysicalDevice" />.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        public VkPhysicalDevice PhysicalDevice
+        {
+            get
+            {
+                _state.ThrowIfDisposedOrDisposing();
+                return _physicalDevice;
+            }
+        }
+
+        /// <summary>Gets the <see cref="VkPhysicalDeviceProperties" /> for <see cref="PhysicalDevice" />.</summary>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
+        public ref readonly VkPhysicalDeviceProperties PhysicalDeviceProperties => ref _physicalDeviceProperties.RefValue;
 
         /// <inheritdoc />
-        public uint VendorId => _vendorId;
+        public uint VendorId => PhysicalDeviceProperties.vendorID;
 
         /// <inheritdoc />
         public IGraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface)
         {
+            _state.ThrowIfDisposedOrDisposing();
             ThrowIfNull(graphicsSurface, nameof(graphicsSurface));
             return new GraphicsContext(this, graphicsSurface);
         }
+
+        /// <inheritdoc />
+        /// <remarks>While there are no unmanaged resources to cleanup, we still want to mark the instance as disposed if the <see cref="GraphicsProvider" /> was disposed or if the adapter no longer exists.</remarks>
+        public void Dispose()
+        {
+            _ = _state.BeginDispose();
+            _state.EndDispose();
+        }
+
+        private VkPhysicalDeviceProperties GetPhysicalDeviceProperties()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            VkPhysicalDeviceProperties physicalDeviceProperties;
+            vkGetPhysicalDeviceProperties(PhysicalDevice, &physicalDeviceProperties);
+            return physicalDeviceProperties;
+        }
+
+        private string GetDeviceName() => MarshalNullTerminatedStringUtf8(in PhysicalDeviceProperties.deviceName[0], 256);
     }
 }

--- a/sources/Providers/Graphics/Vulkan/GraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/GraphicsContext.cs
@@ -246,12 +246,12 @@ namespace TerraFX.Graphics.Providers.Vulkan
         public void BeginFrame(ColorRgba backgroundColor)
         {
             uint frameIndex;
-            ThrowExternalExceptionIfFailed(nameof(vkAcquireNextImageKHR), vkAcquireNextImageKHR(Device, SwapChain, timeout: ulong.MaxValue, AcquireNextImageSemaphore, fence: VK_NULL_HANDLE, &frameIndex));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAcquireNextImageKHR), vkAcquireNextImageKHR(Device, SwapChain, timeout: ulong.MaxValue, AcquireNextImageSemaphore, fence: VK_NULL_HANDLE, &frameIndex));
             _frameIndex = frameIndex;
 
             var fence = Fences[frameIndex];
-            ThrowExternalExceptionIfFailed(nameof(vkWaitForFences), vkWaitForFences(Device, fenceCount: 1, (ulong*)&fence, waitAll: VK_TRUE, timeout: ulong.MaxValue));
-            ThrowExternalExceptionIfFailed(nameof(vkResetFences), vkResetFences(Device, 1, (ulong*)&fence));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkWaitForFences), vkWaitForFences(Device, fenceCount: 1, (ulong*)&fence, waitAll: VK_TRUE, timeout: ulong.MaxValue));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkResetFences), vkResetFences(Device, 1, (ulong*)&fence));
 
             var commandBufferBeginInfo = new VkCommandBufferBeginInfo {
                 sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
@@ -261,7 +261,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             };
 
             var commandBuffer = CommandBuffers[frameIndex];
-            ThrowExternalExceptionIfFailed(nameof(vkBeginCommandBuffer), vkBeginCommandBuffer(commandBuffer, &commandBufferBeginInfo));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkBeginCommandBuffer), vkBeginCommandBuffer(commandBuffer, &commandBufferBeginInfo));
 
             var clearValue = new VkClearValue {
                 depthStencil = new VkClearDepthStencilValue {
@@ -408,7 +408,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 pNext = null,
                 flags = 0,
             };
-            ThrowExternalExceptionIfFailed(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &acquireNextImageSemaphoreCreateInfo, pAllocator: null, (ulong*)&acquireNextImageSemaphore));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &acquireNextImageSemaphoreCreateInfo, pAllocator: null, (ulong*)&acquireNextImageSemaphore));
 
             return acquireNextImageSemaphore;
         }
@@ -427,7 +427,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             fixed (VkCommandBuffer* pCommandBuffers = commandBuffers)
             {
-                ThrowExternalExceptionIfFailed(nameof(vkAllocateCommandBuffers), vkAllocateCommandBuffers(Device, &commandBufferAllocateInfo, (IntPtr*)pCommandBuffers));
+                ThrowExternalExceptionIfNotSuccess(nameof(vkAllocateCommandBuffers), vkAllocateCommandBuffers(Device, &commandBufferAllocateInfo, (IntPtr*)pCommandBuffers));
             }
 
             return commandBuffers;
@@ -443,7 +443,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 flags = (uint)VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
                 queueFamilyIndex = GraphicsQueueFamilyIndex,
             };
-            ThrowExternalExceptionIfFailed(nameof(vkCreateCommandPool), vkCreateCommandPool(Device, &commandPoolCreateInfo, pAllocator: null, (ulong*)&commandPool));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateCommandPool), vkCreateCommandPool(Device, &commandPoolCreateInfo, pAllocator: null, (ulong*)&commandPool));
 
             return commandPool;
         }
@@ -538,7 +538,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 ppEnabledExtensionNames = enabledExtensionNames,
                 pEnabledFeatures = &physicalDeviceFeatures,
             };
-            ThrowExternalExceptionIfFailed(nameof(vkCreateDevice), vkCreateDevice(_graphicsAdapter.PhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&device));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDevice), vkCreateDevice(_graphicsAdapter.PhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&device));
 
             return device;
         }
@@ -563,7 +563,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             for (var i = 0; i < fences.Length; i++)
             {
                 VkFence fence;
-                ThrowExternalExceptionIfFailed(nameof(vkCreateFence), vkCreateFence(Device, &fenceCreateInfo, pAllocator: null, (ulong*)&fence));
+                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateFence), vkCreateFence(Device, &fenceCreateInfo, pAllocator: null, (ulong*)&fence));
                 fences[i] = fence;
             }
 
@@ -592,7 +592,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 attachments[0] = SwapChainImageViews[i];
 
                 VkFramebuffer frameBuffer;
-                ThrowExternalExceptionIfFailed(nameof(vkCreateFramebuffer), vkCreateFramebuffer(Device, &frameBufferCreateInfo, pAllocator: null, (ulong*)&frameBuffer));
+                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateFramebuffer), vkCreateFramebuffer(Device, &frameBufferCreateInfo, pAllocator: null, (ulong*)&frameBuffer));
                 frameBuffers[i] = frameBuffer;
             }
 
@@ -608,7 +608,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 pNext = null,
                 flags = 0,
             };
-            ThrowExternalExceptionIfFailed(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &queueSubmitSemaphoreCreateInfo, pAllocator: null, (ulong*)&queueSubmitSemaphore));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &queueSubmitSemaphoreCreateInfo, pAllocator: null, (ulong*)&queueSubmitSemaphore));
 
             return queueSubmitSemaphore;
         }
@@ -658,7 +658,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 dependencyCount = 0,
                 pDependencies = null,
             };
-            ThrowExternalExceptionIfFailed(nameof(vkCreateRenderPass), vkCreateRenderPass(Device, &renderPassCreateInfo, pAllocator: null, (ulong*)&renderPass));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateRenderPass), vkCreateRenderPass(Device, &renderPassCreateInfo, pAllocator: null, (ulong*)&renderPass));
 
             return renderPass;
         }
@@ -681,7 +681,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                         hwnd = _graphicsSurface.WindowHandle,
                     };
 
-                    ThrowExternalExceptionIfFailed(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
                     break;
                 }
 
@@ -695,7 +695,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                         window = (UIntPtr)(void*)_graphicsSurface.WindowHandle,
                     };
 
-                    ThrowExternalExceptionIfFailed(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
                     break;
                 }
 
@@ -708,7 +708,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             }
 
             uint supported;
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(_graphicsAdapter.PhysicalDevice, GraphicsQueueFamilyIndex, surface, &supported));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(_graphicsAdapter.PhysicalDevice, GraphicsQueueFamilyIndex, surface, &supported));
 
             if (supported == VK_FALSE)
             {
@@ -722,13 +722,13 @@ namespace TerraFX.Graphics.Providers.Vulkan
             VkSwapchainKHR swapChain;
 
             VkSurfaceCapabilitiesKHR surfaceCapabilities;
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceCapabilities));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceCapabilities));
 
             uint presentModeCount;
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(_graphicsAdapter.PhysicalDevice, Surface, &presentModeCount, pPresentModes: null));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(_graphicsAdapter.PhysicalDevice, Surface, &presentModeCount, pPresentModes: null));
 
             var presentModes = stackalloc VkPresentModeKHR[(int)presentModeCount];
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(_graphicsAdapter.PhysicalDevice, Surface, &presentModeCount, presentModes));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(_graphicsAdapter.PhysicalDevice, Surface, &presentModeCount, presentModes));
 
             if (((uint)_graphicsSurface.BufferCount < surfaceCapabilities.minImageCount) ||
                 ((surfaceCapabilities.maxImageCount != 0) && ((uint)_graphicsSurface.BufferCount > surfaceCapabilities.maxImageCount)))
@@ -766,10 +766,10 @@ namespace TerraFX.Graphics.Providers.Vulkan
             }
 
             uint surfaceFormatCount;
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceFormatCount, pSurfaceFormats: null));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceFormatCount, pSurfaceFormats: null));
 
             var surfaceFormats = stackalloc VkSurfaceFormatKHR[(int)surfaceFormatCount];
-            ThrowExternalExceptionIfFailed(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceFormatCount, surfaceFormats));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(_graphicsAdapter.PhysicalDevice, Surface, &surfaceFormatCount, surfaceFormats));
 
             for (var i = 0u; i <surfaceFormatCount; i++)
             {
@@ -780,7 +780,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     break;
                 }
             }
-            ThrowExternalExceptionIfFailed(nameof(vkCreateSwapchainKHR), vkCreateSwapchainKHR(Device, &swapChainCreateInfo, pAllocator: null, (ulong*)&swapChain));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSwapchainKHR), vkCreateSwapchainKHR(Device, &swapChainCreateInfo, pAllocator: null, (ulong*)&swapChain));
 
             _swapChainFormat = swapChainCreateInfo.imageFormat;
             return swapChain;
@@ -791,7 +791,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             var swapChainImageCount = (uint)_graphicsSurface.BufferCount;
             var swapChainImages = stackalloc VkImage[(int)swapChainImageCount];
 
-            ThrowExternalExceptionIfFailed(nameof(vkGetSwapchainImagesKHR), vkGetSwapchainImagesKHR(Device, SwapChain, &swapChainImageCount, (ulong*)swapChainImages));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetSwapchainImagesKHR), vkGetSwapchainImagesKHR(Device, SwapChain, &swapChainImageCount, (ulong*)swapChainImages));
 
             var swapChainImageViews = new VkImageView[swapChainImageCount];
 
@@ -822,7 +822,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 swapChainImageViewCreateInfo.image = swapChainImages[i];
 
                 VkImageView swapChainImageView;
-                ThrowExternalExceptionIfFailed(nameof(vkCreateImageView), vkCreateImageView(Device, &swapChainImageViewCreateInfo, pAllocator: null, (ulong*)&swapChainImageView));
+                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateImageView), vkCreateImageView(Device, &swapChainImageViewCreateInfo, pAllocator: null, (ulong*)&swapChainImageView));
 
                 swapChainImageViews[i] = swapChainImageView;
             }

--- a/sources/Providers/Graphics/Vulkan/GraphicsProvider.cs
+++ b/sources/Providers/Graphics/Vulkan/GraphicsProvider.cs
@@ -5,56 +5,146 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using TerraFX.Interop;
 using TerraFX.Utilities;
+using static TerraFX.Graphics.IGraphicsProvider;
 using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
 using static TerraFX.Interop.VkResult;
 using static TerraFX.Interop.VkStructureType;
 using static TerraFX.Interop.VkDebugReportFlagBitsEXT;
 using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.InteropUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.Vulkan
 {
-    /// <summary>Provides access to a Vulkan based graphics subsystem.</summary>
+    /// <inheritdoc cref="IGraphicsProvider" />
     [Export(typeof(IGraphicsProvider))]
     [Shared]
-    public sealed unsafe class GraphicsProvider : IDisposable, IGraphicsProvider
+    public sealed unsafe class GraphicsProvider : IGraphicsProvider
     {
-        // TerraFX
-        private static ReadOnlySpan<sbyte> s_engineName => new sbyte[] { 0x54, 0x65, 0x72, 0x72, 0x61, 0x46, 0x58, 0x00 };
+        /// <summary>The default engine name used if <see cref="EngineNameDataName" /> was not set.</summary>
+        public const string DefaultEngineName = "TerraFX";
 
-        // VK_LAYER_LUNARG_standard_validation
-        private static ReadOnlySpan<sbyte> VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME => new sbyte[] { 0x56, 0x4B, 0x5F, 0x4C, 0x41, 0x59, 0x45, 0x52, 0x5F, 0x4C, 0x55, 0x4E, 0x41, 0x52, 0x47, 0x5F, 0x73, 0x74, 0x61, 0x6E, 0x64, 0x61, 0x72, 0x64, 0x5F, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x00 };
+        /// <summary>The name of a data value that controls the engine name for <see cref="Instance" />.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppDomain.SetData(string, object)" />.</para>
+        ///     <para>Setting this data value after a graphics provider instance has been created has no affect.</para>
+        /// </remarks>
+        public const string EngineNameDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.EngineName";
 
-        // vkCreateDebugReportCallbackEXT
-        private static ReadOnlySpan<sbyte> VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+        /// <summary>The name of a data value that controls the optional extensions for <see cref="Instance" />.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppDomain.SetData(string, object)" />.</para>
+        ///     <para>Setting this data value after a graphics provider instance has been created has no affect.</para>
+        ///     <para>This data value is interpreted as a list of semicolon separated values.</para>
+        /// </remarks>
+        public const string OptionalExtensionNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.OptionalExtensionNames";
 
-        // vkDestroyDebugReportCallbackEXT
-        private static ReadOnlySpan<sbyte> VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x44, 0x65, 0x73, 0x74, 0x72, 0x6F, 0x79, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+        /// <summary>The name of a data value that controls the optional layers for <see cref="Instance" />.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppDomain.SetData(string, object)" />.</para>
+        ///     <para>Setting this data value after a graphics provider instance has been created has no affect.</para>
+        ///     <para>This data value is interpreted as a list of semicolon separated values.</para>
+        /// </remarks>
+        public const string OptionalLayerNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.OptionalLayerNames";
 
-#if DEBUG
-        private NativeDelegate<PFN_vkDebugReportCallbackEXT> _debugReportCallback;
-        private ulong _debugReportCallbackExt;
-#endif
+        /// <summary>The name of a data value that controls the required extensions for <see cref="Instance" />.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppDomain.SetData(string, object)" />.</para>
+        ///     <para>Setting this data value after a graphics provider instance has been created has no affect.</para>
+        ///     <para>This data value is interpreted as a list of semicolon separated values.</para>
+        /// </remarks>
+        public const string RequiredExtensionNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.RequiredExtensionNames";
 
-        private ValueLazy<ImmutableArray<GraphicsAdapter>> _adapters;
-        private ValueLazy<IntPtr> _instance;
+        /// <summary>The name of a data value that controls the required layers for <see cref="Instance" />.</summary>
+        /// <remarks>
+        ///     <para>This name is meant to be used with <see cref="AppDomain.SetData(string, object)" />.</para>
+        ///     <para>Setting this data value after a graphics provider instance has been created has no affect.</para>
+        ///     <para>This data value is interpreted as a list of semicolon separated values.</para>
+        /// </remarks>
+        public const string RequiredLayerNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.RequiredLayerNames";
 
+        private static readonly NativeDelegate<PFN_vkDebugReportCallbackEXT> s_debugReportCallback = new NativeDelegate<PFN_vkDebugReportCallbackEXT>(DebugReportCallback);
+
+        private readonly string _engineName;
+        private readonly string[] _requiredExtensionNames;
+        private readonly string[] _optionalExtensionNames;
+        private readonly string[] _requiredLayerNames;
+        private readonly string[] _optionalLayerNames;
+        private readonly bool _debugModeEnabled;
+
+        private ValueLazy<ImmutableArray<GraphicsAdapter>> _graphicsAdapters;
+        private ValueLazy<VkInstance> _instance;
+
+        private VkDebugReportCallbackEXT _debugReportCallbackExt;
         private State _state;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsProvider" /> class.</summary>
-        /// <exception cref="ExternalException">The call to <see cref="vkCreateInstance(VkInstanceCreateInfo*, VkAllocationCallbacks*, IntPtr*)" /> failed.</exception>
-        /// <exception cref="ExternalException">The call to <see cref="vkEnumeratePhysicalDevices(IntPtr, uint*, IntPtr*)" /> failed.</exception>
         [ImportingConstructor]
         public GraphicsProvider()
         {
-            _adapters = new ValueLazy<ImmutableArray<GraphicsAdapter>>(GetGraphicsAdapters);
-            _instance = new ValueLazy<IntPtr>(CreateInstance);
+            _engineName = GetEngineName();
+            _debugModeEnabled = GetDebugModeEnabled();
+
+            _requiredExtensionNames = GetNames(RequiredExtensionNamesDataName);
+            _optionalExtensionNames = GetNames(OptionalExtensionNamesDataName);
+
+            _requiredLayerNames = GetNames(RequiredLayerNamesDataName);
+            _optionalLayerNames = GetNames(OptionalLayerNamesDataName);
+
+            _graphicsAdapters = new ValueLazy<ImmutableArray<GraphicsAdapter>>(GetGraphicsAdapters);
+            _instance = new ValueLazy<VkInstance>(CreateInstance);
+
             _ = _state.Transition(to: Initialized);
+
+            static bool GetDebugModeEnabled()
+            {
+                if (!AppContext.TryGetSwitch(EnableDebugModeSwitchName, out var debugModeEnabled))
+                {
+#if DEBUG
+                    debugModeEnabled = true;
+#endif
+                }
+
+                if (debugModeEnabled)
+                {
+                    var optionalExtensionPropertyNames = AppContext.GetData(OptionalExtensionNamesDataName) as string;
+                    optionalExtensionPropertyNames += ";VK_EXT_debug_report";
+                    AppDomain.CurrentDomain.SetData(OptionalExtensionNamesDataName, optionalExtensionPropertyNames);
+
+                    var optionalLayerPropertyNames = AppContext.GetData(OptionalLayerNamesDataName) as string;
+                    optionalLayerPropertyNames += ";VK_LAYER_LUNARG_standard_validation";
+                    AppDomain.CurrentDomain.SetData(OptionalLayerNamesDataName, optionalLayerPropertyNames);
+                }
+
+                return debugModeEnabled;
+            }
+
+            static string GetEngineName()
+            {
+                var engineName = AppContext.GetData(EngineNameDataName) as string;
+
+                if (string.IsNullOrWhiteSpace(engineName))
+                {
+                    engineName = DefaultEngineName;
+                }
+
+                return engineName;
+            }
+
+            static string[] GetNames(string dataName)
+            {
+                var extensionPropertyNamesDataValue = AppContext.GetData(dataName) as string ?? string.Empty;
+                var extensionPropertyNames = extensionPropertyNamesDataValue.Split(';', StringSplitOptions.RemoveEmptyEntries);
+                return extensionPropertyNames.Distinct().ToArray();
+            }
         }
 
         /// <summary>Finalizes an instance of the <see cref="GraphicsProvider" /> class.</summary>
@@ -63,26 +153,43 @@ namespace TerraFX.Graphics.Providers.Vulkan
             Dispose(isDisposing: false);
         }
 
+        // vkCreateDebugReportCallbackEXT
+        private static ReadOnlySpan<sbyte> VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+
+        // vkDestroyDebugReportCallbackEXT
+        private static ReadOnlySpan<sbyte> VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME => new sbyte[] { 0x76, 0x6B, 0x44, 0x65, 0x73, 0x74, 0x72, 0x6F, 0x79, 0x44, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x70, 0x6F, 0x72, 0x74, 0x43, 0x61, 0x6C, 0x6C, 0x62, 0x61, 0x63, 0x6B, 0x45, 0x58, 0x54, 0x00 };
+
         /// <inheritdoc />
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
+        public bool DebugModeEnabled => _debugModeEnabled;
+
+        /// <inheritdoc />
+        /// <exception cref="ExternalException">The call to <see cref="vkEnumeratePhysicalDevices(IntPtr, uint*, IntPtr*)" /> failed.</exception>
         public IEnumerable<IGraphicsAdapter> GraphicsAdapters
         {
             get
             {
                 _state.ThrowIfDisposedOrDisposing();
-                return _adapters.Value;
+                return _graphicsAdapters.Value;
             }
         }
 
-        /// <summary>Gets the <c>vkInstance</c> for the current instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public IntPtr Instance
+        /// <summary>Gets the underlying <see cref="VkInstance" />.</summary>
+        /// <exception cref="ExternalException">The call to <see cref="vkCreateInstance(VkInstanceCreateInfo*, VkAllocationCallbacks*, IntPtr*)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        public VkInstance Instance
         {
             get
             {
                 _state.ThrowIfDisposedOrDisposing();
                 return _instance.Value;
             }
+        }
+
+        private static uint DebugReportCallback(uint flags, VkDebugReportObjectTypeEXT objectType, ulong @object, UIntPtr location, int messageCode, sbyte* pLayerPrefix, sbyte* pMessage, void* pUserData)
+        {
+            var message = MarshalUtf8ToReadOnlySpan(pMessage).AsString();
+            Debug.WriteLine(message);
+            return VK_FALSE;
         }
 
         /// <inheritdoc />
@@ -92,193 +199,249 @@ namespace TerraFX.Graphics.Providers.Vulkan
             GC.SuppressFinalize(this);
         }
 
-        private IntPtr CreateInstance()
+        private VkInstance CreateInstance()
         {
-            var enabledExtensionCount = 0u;
-            var isSurfaceExtensionSupported = false;
-            var isWin32SurfaceExtensionSupported = false;
-            var isXlibSurfaceExtensionSupported = false;
-            var isDebugReportExtensionSupported = false;
+            _state.AssertNotDisposedOrDisposing();
 
-            var extensionPropertyCount = 0u;
-            ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &extensionPropertyCount, pProperties: null));
+            sbyte* requiredExtensionNamesBuffer = null;
+            sbyte* optionalExtensionNamesBuffer = null;
+            sbyte** enabledExtensionNames = null;
 
-            var extensionProperties = new VkExtensionProperties[extensionPropertyCount];
+            sbyte* requiredLayerNamesBuffer = null;
+            sbyte* optionalLayerNamesBuffer = null;
+            sbyte** enabledLayerNames = null;
 
-            fixed (VkExtensionProperties* pExtensionProperties = extensionProperties)
+            try
             {
-                ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &extensionPropertyCount, pExtensionProperties));
-            }
+                VkInstance instance;
 
-            for (var i = 0; i < extensionProperties.Length; i++)
-            {
-                var extensionName = new ReadOnlySpan<sbyte>(Unsafe.AsPointer(ref extensionProperties[i].extensionName[0]), int.MaxValue);
-                extensionName = extensionName.Slice(0, extensionName.IndexOf((sbyte)'\0') + 1);
+                var enabledExtensionCount = EnableExtensionProperties(_requiredExtensionNames, _optionalExtensionNames, out requiredExtensionNamesBuffer, out optionalExtensionNamesBuffer, out enabledExtensionNames);
+                var enabledLayerCount = EnableLayerProperties(_requiredLayerNames, _optionalLayerNames, out requiredLayerNamesBuffer, out optionalLayerNamesBuffer, out enabledLayerNames);
 
-                if (!isSurfaceExtensionSupported && VK_KHR_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                fixed (sbyte* engineName = MarshalStringToUtf8(_engineName))
                 {
-                    isSurfaceExtensionSupported = true;
-                    enabledExtensionCount++;
+                    var applicationInfo = new VkApplicationInfo {
+                        sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+                        applicationVersion = 1,
+                        pEngineName = engineName,
+                        engineVersion = VK_MAKE_VERSION(0, 1, 0),
+                        apiVersion = VK_API_VERSION_1_0,
+                    };
+
+                    var createInfo = new VkInstanceCreateInfo {
+                        sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                        pApplicationInfo = &applicationInfo,
+                        enabledLayerCount = enabledLayerCount,
+                        ppEnabledLayerNames = enabledLayerNames,
+                        enabledExtensionCount = enabledExtensionCount,
+                        ppEnabledExtensionNames = enabledExtensionNames,
+                    };
+
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateInstance), vkCreateInstance(&createInfo, pAllocator: null, (IntPtr*)&instance));
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (DebugModeEnabled)
                 {
-                    if (!isWin32SurfaceExtensionSupported && VK_KHR_WIN32_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                    _debugReportCallbackExt = TryCreateDebugReportCallbackExt(instance);
+                }
+
+                return instance;
+            }
+            finally
+            {
+                if (enabledLayerNames != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)enabledLayerNames);
+                }
+
+                if (optionalLayerNamesBuffer != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)optionalLayerNamesBuffer);
+                }
+
+                if (requiredLayerNamesBuffer != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)requiredLayerNamesBuffer);
+                }
+
+                if (enabledExtensionNames != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)enabledExtensionNames);
+                }
+
+                if (optionalExtensionNamesBuffer != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)optionalExtensionNamesBuffer);
+                }
+
+                if (requiredExtensionNamesBuffer != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)requiredExtensionNamesBuffer);
+                }
+            }
+
+            static uint EnableExtensionProperties(string[] requiredExtensionNames, string[] optionalExtensionNames, out sbyte* requiredExtensionNamesBuffer, out sbyte* optionalExtensionNamesBuffer, out sbyte** enabledExtensionNames)
+            {
+                var requiredExtensionNamesCount = MarshalNames(requiredExtensionNames, out requiredExtensionNamesBuffer);
+                var optionalExtensionNamesCount = MarshalNames(optionalExtensionNames, out optionalExtensionNamesBuffer);
+
+                enabledExtensionNames = (sbyte**)Marshal.AllocHGlobal((requiredExtensionNamesCount + optionalExtensionNamesCount) * sizeof(sbyte*));
+                var extensionProperties = GetExtensionProperties();
+
+                var enabledExtensionCount = EnableExtensionNames(extensionProperties, requiredExtensionNamesBuffer, requiredExtensionNamesCount, enabledExtensionNames);
+
+                if (enabledExtensionCount != requiredExtensionNamesCount)
+                {
+                    ThrowNotSupportedExceptionForMissingFeature(nameof(VkExtensionProperties));
+                }
+                enabledExtensionCount += EnableExtensionNames(extensionProperties, optionalExtensionNamesBuffer, optionalExtensionNamesCount, enabledExtensionNames + enabledExtensionCount);
+
+                return enabledExtensionCount;
+
+                static uint EnableExtensionNames(VkExtensionProperties[] extensionProperties, sbyte* extensionNames, int extensionNamesCount, sbyte** enabledExtensionNames)
+                {
+                    uint enabledExtensionCount = 0;
+                    var pCurrent = extensionNames;
+
+                    for (var i = 0; i < extensionNamesCount; i++)
                     {
-                        isWin32SurfaceExtensionSupported = true;
-                        enabledExtensionCount++;
+                        var extensionNameLength = *(int*)pCurrent;
+                        pCurrent += IntPtr.Size;
+                        var extensionName = new ReadOnlySpan<sbyte>(pCurrent, extensionNameLength + 1);
+
+                        for (var n = 0; n < extensionProperties.Length; n++)
+                        {
+                            var extensionPropertyName = MemoryMarshal.CreateReadOnlySpan(ref extensionProperties[n].extensionName[0], extensionNameLength + 1);
+
+                            if (extensionPropertyName.SequenceEqual(extensionName))
+                            {
+                                enabledExtensionNames[enabledExtensionCount] = pCurrent;
+                                enabledExtensionCount += 1;
+                                break;
+                            }
+                        }
+                        pCurrent += VK_MAX_EXTENSION_NAME_SIZE;
                     }
+
+                    return enabledExtensionCount;
                 }
-                else
+
+                static VkExtensionProperties[] GetExtensionProperties()
                 {
-                    if (!isXlibSurfaceExtensionSupported && VK_KHR_XLIB_SURFACE_EXTENSION_NAME.SequenceEqual(extensionName))
+                    uint propertyCount = 0;
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &propertyCount, pProperties: null));
+
+                    var extensionProperties = new VkExtensionProperties[propertyCount];
+
+                    fixed (VkExtensionProperties* pExtensionProperties = extensionProperties)
                     {
-                        isXlibSurfaceExtensionSupported = true;
-                        enabledExtensionCount++;
+                        ThrowExternalExceptionIfNotSuccess(nameof(vkEnumerateInstanceExtensionProperties), vkEnumerateInstanceExtensionProperties(pLayerName: null, &propertyCount, pExtensionProperties));
                     }
-                }
 
-#if DEBUG
-                if (!isDebugReportExtensionSupported && VK_EXT_DEBUG_REPORT_EXTENSION_NAME.SequenceEqual(extensionName))
+                    return extensionProperties;
+                }
+            }
+
+            static uint EnableLayerProperties(string[] requiredLayerNames, string[] optionalLayerNames, out sbyte* requiredLayerNamesBuffer, out sbyte* optionalLayerNamesBuffer, out sbyte** enabledLayerNames)
+            {
+                var requiredLayerNamesCount = MarshalNames(requiredLayerNames, out requiredLayerNamesBuffer);
+                var optionalLayerNamesCount = MarshalNames(optionalLayerNames, out optionalLayerNamesBuffer);
+
+                enabledLayerNames = (sbyte**)Marshal.AllocHGlobal((requiredLayerNamesCount + optionalLayerNamesCount) * sizeof(sbyte*));
+                var layerProperties = GetLayerProperties();
+
+                var enabledLayerCount = EnableLayerNames(layerProperties, requiredLayerNamesBuffer, requiredLayerNamesCount, enabledLayerNames);
+
+                if (enabledLayerCount != requiredLayerNamesCount)
                 {
-                    isDebugReportExtensionSupported = true;
-                    enabledExtensionCount++;
+                    ThrowNotSupportedExceptionForMissingFeature(nameof(VkLayerProperties));
                 }
-#endif
-            }
+                enabledLayerCount += EnableLayerNames(layerProperties, optionalLayerNamesBuffer, optionalLayerNamesCount, enabledLayerNames + enabledLayerCount);
 
-            var enabledExtensionNames = stackalloc sbyte*[(int)enabledExtensionCount];
+                return enabledLayerCount;
 
-            if (!isSurfaceExtensionSupported)
-            {
-                ThrowInvalidOperationException(nameof(isSurfaceExtensionSupported), isSurfaceExtensionSupported);
-            }
-
-            enabledExtensionNames[0] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_SURFACE_EXTENSION_NAME));
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                if (!isWin32SurfaceExtensionSupported)
+                static uint EnableLayerNames(VkLayerProperties[] layerProperties, sbyte* layerNames, int layerNamesCount, sbyte** enabledLayerNames)
                 {
-                    ThrowInvalidOperationException(nameof(isWin32SurfaceExtensionSupported), isWin32SurfaceExtensionSupported);
+                    uint enabledLayerCount = 0;
+                    var pCurrent = layerNames;
+
+                    for (var i = 0; i < layerNamesCount; i++)
+                    {
+                        var layerNameLength = *(int*)pCurrent;
+                        pCurrent += IntPtr.Size;
+                        var layerName = new ReadOnlySpan<sbyte>(pCurrent, layerNameLength + 1);
+
+                        for (var n = 0; n < layerProperties.Length; n++)
+                        {
+                            var layerPropertyName = MemoryMarshal.CreateReadOnlySpan(ref layerProperties[n].layerName[0], layerNameLength + 1);
+
+                            if (layerPropertyName.SequenceEqual(layerName))
+                            {
+                                enabledLayerNames[enabledLayerCount] = pCurrent;
+                                enabledLayerCount += 1;
+                                break;
+                            }
+                        }
+                        pCurrent += VK_MAX_EXTENSION_NAME_SIZE;
+                    }
+
+                    return enabledLayerCount;
                 }
 
-                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_WIN32_SURFACE_EXTENSION_NAME));
-            }
-            else
-            {
-                if (!isXlibSurfaceExtensionSupported)
+                static VkLayerProperties[] GetLayerProperties()
                 {
-                    ThrowInvalidOperationException(nameof(isXlibSurfaceExtensionSupported), isXlibSurfaceExtensionSupported);
+                    uint propertyCount = 0;
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&propertyCount, pProperties: null));
+
+                    var layerProperties = new VkLayerProperties[propertyCount];
+
+                    fixed (VkLayerProperties* pLayerProperties = layerProperties)
+                    {
+                        ThrowExternalExceptionIfNotSuccess(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&propertyCount, pLayerProperties));
+                    }
+
+                    return layerProperties;
                 }
-
-                enabledExtensionNames[1] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_XLIB_SURFACE_EXTENSION_NAME));
             }
 
-            if (isDebugReportExtensionSupported)
+            static int MarshalNames(string[] names, out sbyte* marshaledNames)
             {
-                // We don't want to throw if the debug extension isn't available
-                enabledExtensionNames[2] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_EXT_DEBUG_REPORT_EXTENSION_NAME));
-            }
+                var sizePerEntry = IntPtr.Size + VK_MAX_EXTENSION_NAME_SIZE;
+                marshaledNames = (sbyte*)Marshal.AllocHGlobal(names.Length * sizePerEntry);
 
-            var enabledLayerCount = 0u;
-            var isLunarGStandardValidationLayerSupported = false;
+                var pCurrent = marshaledNames;
 
-#if DEBUG
-            var layerPropertyCount = 0u;
-            ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&layerPropertyCount, pProperties: null));
-
-            var layerProperties = new VkLayerProperties[layerPropertyCount];
-
-            fixed (VkLayerProperties* pLayerProperties = layerProperties)
-            {
-                ThrowExternalExceptionIfFailed(nameof(vkEnumerateInstanceLayerProperties), vkEnumerateInstanceLayerProperties(&layerPropertyCount, pLayerProperties));
-            }
-
-            for (var i = 0; i < layerProperties.Length; i++)
-            {
-                var layerName = new ReadOnlySpan<sbyte>(Unsafe.AsPointer(ref layerProperties[i].layerName[0]), int.MaxValue);
-                layerName = layerName.Slice(0, layerName.IndexOf((sbyte)'\0') + 1);
-
-                if (!isLunarGStandardValidationLayerSupported && VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME.SequenceEqual(layerName))
+                for (var i = 0; i < names.Length; i++)
                 {
-                    isLunarGStandardValidationLayerSupported = true;
-                    enabledLayerCount++;
+                    var destination = new Span<byte>(pCurrent + IntPtr.Size, VK_MAX_EXTENSION_NAME_SIZE);
+                    var length = Encoding.UTF8.GetBytes(names[i], destination);
+
+                    pCurrent[IntPtr.Size + length] = (sbyte)'\0';
+
+                    *(int*)pCurrent = length;
+                    pCurrent += sizePerEntry;
                 }
-            }
-#endif
 
-            var enabledLayerNames = stackalloc sbyte*[(int)enabledLayerCount];
-
-            if (isLunarGStandardValidationLayerSupported)
-            {
-                enabledLayerNames[0] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_LAYER_LUNARG_STANDARD_VALIDATION_LAYER_NAME));
+                return names.Length;
             }
 
-            var applicationInfo = new VkApplicationInfo {
-                sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
-                pNext = null,
-                pApplicationName = null,
-                applicationVersion = 1,
-                pEngineName = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(s_engineName)),
-                engineVersion = VK_MAKE_VERSION(0, 1, 0),
-                apiVersion = VK_API_VERSION_1_0,
-            };
-
-            var createInfo = new VkInstanceCreateInfo {
-                sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                pApplicationInfo = &applicationInfo,
-                enabledLayerCount = enabledLayerCount,
-                ppEnabledLayerNames = enabledLayerNames,
-                enabledExtensionCount = enabledExtensionCount,
-                ppEnabledExtensionNames = enabledExtensionNames,
-            };
-
-            IntPtr instance;
-            var result = vkCreateInstance(&createInfo, null, &instance);
-
-            if (result != VK_SUCCESS)
+            static VkDebugReportCallbackEXT TryCreateDebugReportCallbackExt(VkInstance instance)
             {
-                ThrowExternalException(nameof(vkCreateInstance), (int)result);
-            }
-
-            if (isDebugReportExtensionSupported && isLunarGStandardValidationLayerSupported)
-            {
-#if DEBUG
-                ulong debugReportCallbackExt;
-
-                _debugReportCallback = new NativeDelegate<PFN_vkDebugReportCallbackEXT>(DebugReportCallback);
+                VkDebugReportCallbackEXT debugReportCallbackExt;
 
                 var debugReportCallbackCreateInfo = new VkDebugReportCallbackCreateInfoEXT {
                     sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
-                    pNext = null,
                     flags = (uint)(VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT),
-                    pfnCallback = _debugReportCallback,
-                    pUserData = null,
+                    pfnCallback = s_debugReportCallback,
                 };
 
                 // We don't want to fail if creating the debug report callback failed
-                var vkCreateDebugReportCallbackEXT = vkGetInstanceProcAddr(instance, (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME)));
-                _ = Marshal.GetDelegateForFunctionPointer<PFN_vkCreateDebugReportCallbackEXT>(vkCreateDebugReportCallbackEXT)(instance, &debugReportCallbackCreateInfo, pAllocator: null, &debugReportCallbackExt);
-                _debugReportCallbackExt = debugReportCallbackExt;
-#endif
+                var vkCreateDebugReportCallbackEXT = vkGetInstanceProcAddr(instance, VKCREATEDEBUGREPORTCALLBACKEXT_FUNCTION_NAME.AsPointer());
+                _ = MarshalFunctionPointer<PFN_vkCreateDebugReportCallbackEXT>(vkCreateDebugReportCallbackEXT)(instance, &debugReportCallbackCreateInfo, pAllocator: null, (ulong*)&debugReportCallbackExt);
+
+                return debugReportCallbackExt;
             }
-
-            return instance;
         }
-
-#if DEBUG
-        private static uint DebugReportCallback(uint flags, VkDebugReportObjectTypeEXT objectType, ulong @object, UIntPtr location, int messageCode, sbyte* pLayerPrefix, sbyte* pMessage, void* pUserData)
-        {
-            var messageLength = new ReadOnlySpan<sbyte>(pMessage, int.MaxValue).IndexOf((sbyte)'\0') + 1;
-            var message = new string(pMessage, 0, messageLength);
-
-            Debug.WriteLine(message);
-            return VK_FALSE;
-        }
-#endif
 
         private void Dispose(bool isDisposing)
         {
@@ -298,41 +461,33 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             if (_instance.IsCreated)
             {
-#if DEBUG
-                if (_debugReportCallbackExt != 0)
-                {
-                    var vkDestroyDebugReportCallbackEXT = vkGetInstanceProcAddr(_instance.Value, (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME)));
-                    Marshal.GetDelegateForFunctionPointer<PFN_vkDestroyDebugReportCallbackEXT>(vkDestroyDebugReportCallbackEXT)(_instance.Value, _debugReportCallbackExt, pAllocator: null);
-                }
-#endif
+                var instance = _instance.Value;
 
-                vkDestroyInstance(_instance.Value, pAllocator: null);
+                if (_debugReportCallbackExt != VK_NULL_HANDLE)
+                {
+                    var vkDestroyDebugReportCallbackEXT = vkGetInstanceProcAddr(instance, VKDESTROYDEBUGREPORTCALLBACKEXT_FUNCTION_NAME.AsPointer());
+                    MarshalFunctionPointer<PFN_vkDestroyDebugReportCallbackEXT>(vkDestroyDebugReportCallbackEXT)(instance, _debugReportCallbackExt, pAllocator: null);
+                }
+
+                vkDestroyInstance(instance, pAllocator: null);
             }
         }
 
         private ImmutableArray<GraphicsAdapter> GetGraphicsAdapters()
         {
+            _state.AssertNotDisposedOrDisposing();
+
             var instance = _instance.Value;
 
-            var physicalDeviceCount = 0u;
-            var result = vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, pPhysicalDevices: null);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkEnumeratePhysicalDevices), (int)result);
-            }
+            uint physicalDeviceCount;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkEnumeratePhysicalDevices), vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, pPhysicalDevices: null));
 
             var physicalDevices = stackalloc IntPtr[unchecked((int)physicalDeviceCount)];
-            result = vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkEnumeratePhysicalDevices), (int)result);
-            }
+            ThrowExternalExceptionIfNotSuccess(nameof(vkEnumeratePhysicalDevices), vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices));
 
             var adapters = ImmutableArray.CreateBuilder<GraphicsAdapter>(unchecked((int)physicalDeviceCount));
 
-            for (var index = 0u; index < physicalDeviceCount; index++)
+            for (uint index = 0; index < physicalDeviceCount; index++)
             {
                 var adapter = new GraphicsAdapter(this, physicalDevices[index]);
                 adapters.Add(adapter);

--- a/sources/Providers/Graphics/Vulkan/HelperUtilities.cs
+++ b/sources/Providers/Graphics/Vulkan/HelperUtilities.cs
@@ -8,7 +8,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
 {
     internal static partial class HelperUtilities
     {
-        public static void ThrowExternalExceptionIfFailed(string methodName, VkResult result)
+        public static void ThrowExternalExceptionIfNotSuccess(string methodName, VkResult result)
         {
             if (result != VK_SUCCESS)
             {

--- a/sources/Providers/UI/Win32/WindowProvider.cs
+++ b/sources/Providers/UI/Win32/WindowProvider.cs
@@ -22,6 +22,8 @@ namespace TerraFX.UI.Providers.Win32
     [Shared]
     public sealed unsafe class WindowProvider : IDisposable, IWindowProvider
     {
+        private const string VulkanRequiredExtensionNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.RequiredExtensionNames";
+
         /// <summary>A <see cref="HINSTANCE" /> to the entry point module.</summary>
         public static readonly HINSTANCE EntryPointModule = GetModuleHandleW(lpModuleName: null);
 
@@ -38,6 +40,10 @@ namespace TerraFX.UI.Providers.Win32
         [ImportingConstructor]
         public WindowProvider()
         {
+            var vulkanRequiredExtensionNamesDataName = AppContext.GetData(VulkanRequiredExtensionNamesDataName) as string;
+            vulkanRequiredExtensionNamesDataName += ";VK_KHR_surface;VK_KHR_win32_surface";
+            AppDomain.CurrentDomain.SetData(VulkanRequiredExtensionNamesDataName, vulkanRequiredExtensionNamesDataName);
+
             _classAtom = new ValueLazy<ushort>(CreateClassAtom);
             _nativeHandle = new ValueLazy<GCHandle>(CreateNativeHandle);
 

--- a/sources/Providers/UI/Xlib/WindowProvider.cs
+++ b/sources/Providers/UI/Xlib/WindowProvider.cs
@@ -20,6 +20,8 @@ namespace TerraFX.UI.Providers.Xlib
     [Shared]
     public sealed unsafe class WindowProvider : IDisposable, IWindowProvider
     {
+        private const string VulkanRequiredExtensionNamesDataName = "TerraFX.Graphics.Providers.Vulkan.GraphicsProvider.RequiredExtensionNames";
+
         private readonly ThreadLocal<Dictionary<UIntPtr, Window>> _windows;
 
         private ValueLazy<GCHandle> _nativeHandle;
@@ -29,6 +31,10 @@ namespace TerraFX.UI.Providers.Xlib
         [ImportingConstructor]
         public WindowProvider()
         {
+            var vulkanRequiredExtensionNamesDataName = AppContext.GetData(VulkanRequiredExtensionNamesDataName) as string;
+            vulkanRequiredExtensionNamesDataName += ";VK_KHR_surface;VK_KHR_xlib_surface";
+            AppDomain.CurrentDomain.SetData(VulkanRequiredExtensionNamesDataName, vulkanRequiredExtensionNamesDataName);
+
             _nativeHandle = new ValueLazy<GCHandle>(() => GCHandle.Alloc(this, GCHandleType.Normal));
             _windows = new ThreadLocal<Dictionary<UIntPtr, Window>>(trackAllValues: true);
             _ = _state.Transition(to: Initialized);

--- a/sources/Utilities/DisposeUtilities.cs
+++ b/sources/Utilities/DisposeUtilities.cs
@@ -1,0 +1,66 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using static TerraFX.Utilities.AssertionUtilities;
+
+namespace TerraFX.Utilities
+{
+    /// <summary>Provides a set of methods for disposing values.</summary>
+    public static class DisposeUtilities
+    {
+        /// <summary>Disposes of a <see cref="ValueLazy{T}" /> if <see cref="ValueLazy{T}.IsCreated" /> returns <c>true</c>.</summary>
+        /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The lazy <typeparamref name="T" /> to dispose.</param>
+        public static void DisposeIfCreated<T>(ValueLazy<T> value)
+            where T : IDisposable
+        {
+            if (value.IsCreated)
+            {
+                DisposeIfNotNull(value.Value);
+            }
+        }
+
+        /// <summary>Disposes of each element in a <see cref="ValueLazy{T}" /> if <see cref="ValueLazy{T}.IsCreated" /> returns <c>true</c>.</summary>
+        /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
+        /// <param name="values">The lazy <see cref="IEnumerable{T}" /> containing the values to dispose.</param>
+        public static void DisposeIfCreated<T>(ValueLazy<ImmutableArray<T>> values)
+            where T : IDisposable
+        {
+            if (values.IsCreated)
+            {
+                DisposeIfNotNull(values.Value);
+            }
+        }
+
+        /// <summary>Disposes of a given <typeparamref name="T" /> if it is not <c>null</c>.</summary>
+        /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The <typeparamref name="T" /> to dispose.</param>
+        public static void DisposeIfNotNull<T>(T value)
+            where T : IDisposable
+        {
+            if (value != null)
+            {
+                value.Dispose();
+            }
+        }
+
+        /// <summary>Disposes of a each element in an <see cref="IEnumerable{T}" /> if that element is not <c>null</c>.</summary>
+        /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
+        /// <param name="values">The <see cref="IEnumerable{T}" /> containing the values to dispose.</param>
+        public static void DisposeIfNotNull<T>(IEnumerable<T> values)
+            where T : IDisposable
+        {
+            AssertNotNull(values, nameof(values));
+
+            if (values != null)
+            {
+                foreach (var value in values)
+                {
+                    DisposeIfNotNull(value);
+                }
+            }
+        }
+    }
+}

--- a/sources/Utilities/ExceptionUtilities.cs
+++ b/sources/Utilities/ExceptionUtilities.cs
@@ -131,6 +131,17 @@ namespace TerraFX.Utilities
         }
 
         /// <summary>Throws an instance of the <see cref="NotSupportedException" /> class.</summary>
+        /// <param name="featureName">The name of the unavailable feature.</param>
+        /// <exception cref="ExternalException">One or more of the requested <paramref name="featureName" /> is unavailable.</exception>
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowNotSupportedExceptionForMissingFeature(string featureName)
+        {
+            var message = string.Format(Resources.NotSupportedExceptionForMissingFeatureMessage, featureName);
+            throw new NotSupportedException(message);
+        }
+
+        /// <summary>Throws an instance of the <see cref="NotSupportedException" /> class.</summary>
         /// <exception cref="ExternalException">The collection is read-only.</exception>
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/sources/Utilities/InteropUtilities.cs
+++ b/sources/Utilities/InteropUtilities.cs
@@ -11,75 +11,161 @@ namespace TerraFX.Utilities
     /// <summary>Provides a set of methods for simplifying interop code.</summary>
     public static unsafe class InteropUtilities
     {
-        /// <summary>Reinterprets a <typeparamref name="T" /> reference as a pointer.</summary>
-        /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The reference to reinterpret.</param>
-        /// <returns>A pointer reinterpretation of <paramref name="value" />.</returns>
-        public static T* AsPointer<T>(ref T value)
-            where T : unmanaged => (T*)Unsafe.AsPointer(ref value);
+        /// <summary>Gets the underlying pointer for a <typeparamref name="T" /> reference.</summary>
+        /// <typeparam name="T">The type of <paramref name="source" />.</typeparam>
+        /// <param name="source">The reference for which to get the underlying pointer.</param>
+        /// <returns>The underlying pointer for <paramref name="source" />.</returns>
+        public static T* AsPointer<T>(ref T source)
+            where T : unmanaged => (T*)Unsafe.AsPointer(ref source);
 
-        /// <summary>Reinterprets a <see cref="ReadOnlySpan{T}" /> as a pointer.</summary>
-        /// <typeparam name="T">The type of elements contained in <paramref name="span" />.</typeparam>
-        /// <param name="span">The span to reinterpret.</param>
-        /// <returns>A pointer reinterpretation of <paramref name="span" />.</returns>
-        public static T* AsPointer<T>(ReadOnlySpan<T> span)
-            where T : unmanaged => AsPointer(ref MemoryMarshal.GetReference(span));
+        /// <summary>Gets the underlying pointer for a <see cref="Span{T}" />.</summary>
+        /// <typeparam name="T">The type of elements contained in <paramref name="source" />.</typeparam>
+        /// <param name="source">The span for which to get the underlying pointer.</param>
+        /// <returns>The underlying pointer for <paramref name="source" />.</returns>
+        public static T* AsPointer<T>(this Span<T> source)
+            where T : unmanaged => AsPointer(ref source.AsRef());
 
-        /// <summary>Gets a reference of <typeparamref name="T" /> from a given <see cref="int" />.</summary>
-        /// <typeparam name="T">The type of the reference to retrieve.</typeparam>
-        /// <param name="source">The <see cref="int" /> for which to get the reference from.</param>
-        /// <returns>A reference of <typeparamref name="T" /> from <paramref name="source" />.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T AsRef<T>(int source) => ref Unsafe.AsRef<T>((void*)source);
+        /// <summary>Gets the underlying pointer for a <see cref="ReadOnlySpan{T}" />.</summary>
+        /// <typeparam name="T">The type of elements contained in <paramref name="source" />.</typeparam>
+        /// <param name="source">The span for which to get the underlying pointer.</param>
+        /// <returns>The underlying pointer for <paramref name="source" />.</returns>
+        public static T* AsPointer<T>(this ReadOnlySpan<T> source)
+            where T : unmanaged => AsPointer(ref source.AsRef());
 
         /// <summary>Gets a reference of <typeparamref name="T" /> from a given <see cref="IntPtr" />.</summary>
-        /// <typeparam name="T">The type of the reference to retrieve.</typeparam>
-        /// <param name="source">The <see cref="IntPtr" /> for which to get the reference from.</param>
+        /// <typeparam name="T">The type of the reference.</typeparam>
+        /// <param name="source">The <see cref="IntPtr" /> for which to get the reference.</param>
         /// <returns>A reference of <typeparamref name="T" /> from <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AsRef<T>(IntPtr source) => ref Unsafe.AsRef<T>((void*)source);
 
         /// <summary>Gets a reference of <typeparamref name="T" /> from a given <see cref="UIntPtr" />.</summary>
-        /// <typeparam name="T">The type of the reference to retrieve.</typeparam>
-        /// <param name="source">The <see cref="UIntPtr" /> for which to get the reference from.</param>
+        /// <typeparam name="T">The type of the reference.</typeparam>
+        /// <param name="source">The <see cref="UIntPtr" /> for which to get the reference.</param>
         /// <returns>A reference of <typeparamref name="T" /> from <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AsRef<T>(UIntPtr source) => ref Unsafe.AsRef<T>((void*)source);
 
         /// <summary>Gets a reference of <typeparamref name="T" /> from a given pointer.</summary>
-        /// <typeparam name="T">The type of the reference to retrieve.</typeparam>
-        /// <param name="source">The pointer for which to get the reference from.</param>
+        /// <typeparam name="T">The type of the reference.</typeparam>
+        /// <param name="source">The pointer for which to get the reference.</param>
         /// <returns>A reference of <typeparamref name="T" /> from <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AsRef<T>(void* source) => ref Unsafe.AsRef<T>(source);
 
         /// <summary>Gets a reference of <typeparamref name="T" /> from a given readonly reference.</summary>
-        /// <typeparam name="T">The type of the reference to retrieve.</typeparam>
-        /// <param name="source">The readonly reference for which to get the reference from.</param>
+        /// <typeparam name="T">The type of <paramref name="source" />.</typeparam>
+        /// <param name="source">The readonly reference for which to get the reference.</param>
         /// <returns>A reference of <typeparamref name="T" /> from <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T AsRef<T>(in T source) => ref Unsafe.AsRef<T>(in source);
+        public static ref T AsRef<T>(in T source) => ref Unsafe.AsRef(in source);
 
-        /// <summary>Marshals a function pointer to get a corresponding managed delegate.</summary>
-        /// <typeparam name="TDelegate">The type of the managed delegate to get.</typeparam>
-        /// <param name="function">The function pointer to marshal.</param>
+        /// <summary>Gets the underlying reference for a <see cref="Span{T}" />.</summary>
+        /// <typeparam name="T">The type of elements contained in <paramref name="source" />.</typeparam>
+        /// <param name="source">The span for which to get the underlying reference.</param>
+        /// <returns>The underlying reference for <paramref name="source" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T AsRef<T>(this Span<T> source) => ref MemoryMarshal.GetReference(source);
+
+        /// <summary>Gets the underlying reference for a <see cref="ReadOnlySpan{T}" />.</summary>
+        /// <typeparam name="T">The type of elements contained in <paramref name="source" />.</typeparam>
+        /// <param name="source">The span for which to get the underlying reference.</param>
+        /// <returns>The underlying reference for <paramref name="source" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T AsRef<T>(this ReadOnlySpan<T> source) => ref MemoryMarshal.GetReference(source);
+
+        /// <summary>Gets a string for a given <see cref="ReadOnlySpan{SByte}" />.</summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{SByte}" /> for which to create the string.</param>
+        /// <returns>A string created from <paramref name="source" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string? AsString(this ReadOnlySpan<sbyte> source)
+        {
+            string? result = null;
+
+            if (source.AsPointer() != null)
+            {
+                var bytes = MemoryMarshal.Cast<sbyte, byte>(source);
+                result = Encoding.UTF8.GetString(bytes);
+            }
+
+            return result;
+        }
+
+        /// <summary>Gets a string for a given <see cref="ReadOnlySpan{UInt16}" />.</summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt16}" /> for which to create the string.</param>
+        /// <returns>A string created from <paramref name="source" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string? AsString(this ReadOnlySpan<ushort> source)
+        {
+            string? result = null;
+
+            if (source.AsPointer() != null)
+            {
+                var chars = MemoryMarshal.Cast<ushort, char>(source);
+                result = new string(chars);
+            }
+
+            return result;
+        }
+
+        /// <summary>Marshals a managed delegate to get a function pointer which will invoke it.</summary>
+        /// <typeparam name="TDelegate">The type of the managed delegate.</typeparam>
+        /// <param name="function">The managed delegate for which to marshal.</param>
+        /// <returns>A function pointer that invokes <paramref name="function" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IntPtr MarshalDelegate<TDelegate>(TDelegate function)
+            where TDelegate : notnull => Marshal.GetFunctionPointerForDelegate(function);
+
+        /// <summary>Marshals a function pointer to get a managed delegate which will invoke it.</summary>
+        /// <typeparam name="TDelegate">The type of the managed delegate.</typeparam>
+        /// <param name="function">The function pointer for which to marshal.</param>
         /// <returns>A managed delegate that invokes <paramref name="function" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TDelegate MarshalFunction<TDelegate>(IntPtr function) => Marshal.GetDelegateForFunctionPointer<TDelegate>(function);
+        public static TDelegate MarshalFunctionPointer<TDelegate>(IntPtr function) => Marshal.GetDelegateForFunctionPointer<TDelegate>(function);
 
-        /// <summary>Marshals a native null-terminated UTF8 string to get a corresponding managed UTF16 string.</summary>
-        /// <param name="source">The pointer to the native null-terminated UTF8 string.</param>
-        /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
-        /// <returns>A managed <see cref="string" /> that is equivalent to <paramref name="source" />.</returns>
+        /// <summary>Marshals a string to a null-terminated UTF8 string.</summary>
+        /// <param name="source">The string for which to marshal.</param>
+        /// <returns>A null-terminated UTF8 string that is equivalent to <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string? MarshalNullTerminatedStringUtf8(sbyte* source, int maxLength = -1) => (source != null) ? MarshalNullTerminatedStringUtf8(in *source, maxLength) : null;
+        public static ReadOnlySpan<sbyte> MarshalStringToUtf8(string? source)
+        {
+            ReadOnlySpan<sbyte> result;
 
-        /// <summary>Marshals a native null-terminated UTF8 string to get a corresponding managed UTF16 string.</summary>
-        /// <param name="source">The pointer to the native null-terminated UTF8 string.</param>
-        /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
-        /// <returns>A managed <see cref="string" /> that is equivalent to <paramref name="source" />.</returns>
+            if (source is null)
+            {
+                result = null;
+            }
+            else
+            {
+                var maxLength = Encoding.UTF8.GetMaxByteCount(source.Length);
+                var bytes = new sbyte[maxLength + 1];
+
+                var length = Encoding.UTF8.GetBytes(source, MemoryMarshal.Cast<sbyte, byte>(bytes));
+                result = bytes.AsSpan(0, length);
+            }
+
+            return result;
+        }
+
+        /// <summary>Marshals a string to a null-terminated UTF16 string.</summary>
+        /// <param name="source">The string for which to marshal.</param>
+        /// <returns>A null-terminated UTF16 string that is equivalent to <paramref name="source" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string MarshalNullTerminatedStringUtf8(in sbyte source, int maxLength = -1)
+        public static ReadOnlySpan<ushort> MarshalStringToUtf16(string? source) => MemoryMarshal.Cast<char, ushort>(source.AsSpan());
+
+        /// <summary>Marshals a null-terminated UTF8 string to a <see cref="ReadOnlySpan{SByte}" />.</summary>
+        /// <param name="source">The pointer to the null-terminated UTF8 string.</param>
+        /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
+        /// <returns>A <see cref="ReadOnlySpan{SByte}" /> that starts at <paramref name="source" /> and extends to <paramref name="maxLength" /> or the first null character, whichever comes first.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<sbyte> MarshalUtf8ToReadOnlySpan(sbyte* source, int maxLength = -1) => (source != null) ? MarshalUtf8ToReadOnlySpan(in *source, maxLength) : default;
+
+        /// <summary>Marshals a null-terminated UTF8 string to a <see cref="ReadOnlySpan{SByte}" />.</summary>
+        /// <param name="source">The pointer to the null-terminated UTF8 string.</param>
+        /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
+        /// <returns>A <see cref="ReadOnlySpan{SByte}" /> that starts at <paramref name="source" /> and extends to <paramref name="maxLength" /> or the first null character, whichever comes first.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<sbyte> MarshalUtf8ToReadOnlySpan(in sbyte source, int maxLength = -1)
         {
             if (maxLength < 0)
             {
@@ -94,23 +180,22 @@ namespace TerraFX.Utilities
                 span = span.Slice(0, length);
             }
 
-            var bytes = MemoryMarshal.AsBytes(span);
-            return Encoding.UTF8.GetString(bytes);
+            return span;
         }
 
-        /// <summary>Marshals a native null-terminated UTF16 string to get a corresponding managed UTF16 string.</summary>
-        /// <param name="source">The pointer to the native null-terminated UTF16 string.</param>
+        /// <summary>Marshals a null-terminated UTF16 string to a <see cref="ReadOnlySpan{UInt16}" />.</summary>
+        /// <param name="source">The pointer to the null-terminated UTF16 string.</param>
         /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
-        /// <returns>A managed <see cref="string" /> that is equivalent to <paramref name="source" />.</returns>
+        /// <returns>A <see cref="ReadOnlySpan{UInt16}" /> that starts at <paramref name="source" /> and extends to <paramref name="maxLength" /> or the first null character, whichever comes first.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string? MarshalNullTerminatedStringUtf16(ushort* source, int maxLength = -1) => (source != null) ? MarshalNullTerminatedStringUtf16(in *source, maxLength) : null;
+        public static ReadOnlySpan<ushort> MarshalUtf16ToReadOnlySpan(ushort* source, int maxLength = -1) => (source != null) ? MarshalNullTerminatedStringUtf16(in *source, maxLength) : null;
 
-        /// <summary>Marshals a native null-terminated UTF16 string to get a corresponding managed UTF16 string.</summary>
-        /// <param name="source">The pointer to the native null-terminated UTF16 string.</param>
+        /// <summary>Marshals a null-terminated UTF16 string to a <see cref="ReadOnlySpan{UInt16}" />.</summary>
+        /// <param name="source">The pointer to the null-terminated UTF16 string.</param>
         /// <param name="maxLength">The maxmimum length of <paramref name="source" /> or <c>-1</c> if the maximum length is unknown.</param>
-        /// <returns>A managed <see cref="string" /> that is equivalent to <paramref name="source" />.</returns>
+        /// <returns>A <see cref="ReadOnlySpan{UInt16}" /> that starts at <paramref name="source" /> and extends to <paramref name="maxLength" /> or the first null character, whichever comes first.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string MarshalNullTerminatedStringUtf16(in ushort source, int maxLength = -1)
+        public static ReadOnlySpan<ushort> MarshalNullTerminatedStringUtf16(in ushort source, int maxLength = -1)
         {
             if (maxLength < 0)
             {
@@ -125,8 +210,7 @@ namespace TerraFX.Utilities
                 span = span.Slice(0, length);
             }
 
-            var bytes = MemoryMarshal.AsBytes(span);
-            return Encoding.Unicode.GetString(bytes);
+            return span;
         }
 
         /// <summary>Gets a null reference of <typeparamref name="T"/>.</summary>

--- a/sources/Utilities/Resources.cs
+++ b/sources/Utilities/Resources.cs
@@ -44,6 +44,9 @@ namespace TerraFX.Utilities
         /// <summary>Gets a localized <see cref="string" /> similar to <c>An I/O error occurred</c>.</summary>
         public static string IOExceptionMessage => ResourceManager.GetString(nameof(IOExceptionMessage), Culture)!;
 
+        /// <summary>Gets a localized <see cref="string" /> similar to <c>One or more of the requested {0} is unavailable</c>.</summary>
+        public static string NotSupportedExceptionForMissingFeatureMessage => ResourceManager.GetString(nameof(NotSupportedExceptionForMissingFeatureMessage), Culture)!;
+
         /// <summary>Gets a localized <see cref="string" /> similar to <c>The collection is read-only</c>.</summary>
         public static string NotSupportedExceptionForReadOnlyCollectionMessage => ResourceManager.GetString(nameof(NotSupportedExceptionForReadOnlyCollectionMessage), Culture)!;
 

--- a/sources/Utilities/Resources.resx
+++ b/sources/Utilities/Resources.resx
@@ -135,6 +135,9 @@
   <data name="IOExceptionMessage" xml:space="preserve">
     <value>An I/O error occurred</value>
   </data>
+  <data name="NotSupportedExceptionForMissingFeatureMessage" xml:space="preserve">
+    <value>One or more of the requested {0} is unavailable</value>
+  </data>
   <data name="NotSupportedExceptionForReadOnlyCollectionMessage" xml:space="preserve">
     <value>The collection is read-only</value>
   </data>

--- a/tests/Utilities/InteropUtilities.cs
+++ b/tests/Utilities/InteropUtilities.cs
@@ -1,5 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
+using System.Runtime.InteropServices;
 using System.Text;
 using NUnit.Framework;
 
@@ -9,24 +11,7 @@ namespace TerraFX.Utilities.UnitTests
     [TestFixture(Author = "Tanner Gooding", TestOf = typeof(InteropUtilities))]
     public static unsafe class InteropUtilitiesTests
     {
-        /// <summary>Provides validation of the <see cref="InteropUtilities.MarshalNullTerminatedStringUtf8(sbyte*, int)" /> static method.</summary>
-        [TestCase("param", -1, "param")]
-        [TestCase("param", +3, "par")]
-        [TestCase("para\0m", -1, "para")]
-        [TestCase("para\0m", +3, "par")]
-        public static void MarshalNullTerminatedStringUtf8(string value, int maxLength, string expectedResult)
-        {
-            string? result;
-
-            fixed (byte* pValue = Encoding.UTF8.GetBytes(value))
-            {
-                result = InteropUtilities.MarshalNullTerminatedStringUtf8((sbyte*)pValue, maxLength);
-            }
-
-            Assert.That(result, Is.EqualTo(expectedResult));
-        }
-
-        /// <summary>Provides validation of the <see cref="InteropUtilities.MarshalNullTerminatedStringUtf16(ushort*, int)" /> static method.</summary>
+        /// <summary>Provides validation of the <see cref="InteropUtilities.MarshalUtf8ToReadOnlySpan(sbyte*, int)" /> static method.</summary>
         [TestCase(null, -1, null)]
         [TestCase(null, +3, null)]
         [TestCase("", -1, "")]
@@ -35,15 +20,26 @@ namespace TerraFX.Utilities.UnitTests
         [TestCase("param", +3, "par")]
         [TestCase("para\0m", -1, "para")]
         [TestCase("para\0m", +3, "par")]
-        public static void MarshalNullTerminatedStringUtf16(string value, int maxLength, string expectedResult)
+        public static void MarshalUtf8ToReadOnlySpan(string value, int maxLength, string expectedResult)
         {
-            string? result;
+            var span = InteropUtilities.MarshalStringToUtf8(value);
+            var result = InteropUtilities.MarshalUtf8ToReadOnlySpan(span.AsPointer(), maxLength).AsString();
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
 
-            fixed (char* pValue = value)
-            {
-                result = InteropUtilities.MarshalNullTerminatedStringUtf16((ushort*)pValue, maxLength);
-            }
-
+        /// <summary>Provides validation of the <see cref="InteropUtilities.MarshalUtf16ToReadOnlySpan(ushort*, int)" /> static method.</summary>
+        [TestCase(null, -1, null)]
+        [TestCase(null, +3, null)]
+        [TestCase("", -1, "")]
+        [TestCase("", +3, "")]
+        [TestCase("param", -1, "param")]
+        [TestCase("param", +3, "par")]
+        [TestCase("para\0m", -1, "para")]
+        [TestCase("para\0m", +3, "par")]
+        public static void MarshalUtf16ToReadOnlySpan(string value, int maxLength, string expectedResult)
+        {
+            var span = InteropUtilities.MarshalStringToUtf16(value);
+            var result = InteropUtilities.MarshalUtf16ToReadOnlySpan(span.AsPointer(), maxLength).AsString();
             Assert.That(result, Is.EqualTo(expectedResult));
         }
     }


### PR DESCRIPTION
This does some code cleanup of the IGraphicsAdapter and IGraphicsProvider implementations.

The big new feature is that `IGraphicsProvider` is now using `AppContext.GetData` and `AppContext.TryGetSwitch` to control certain behaviors.

Namely, there is now a shared switch, "TerraFX.Graphics.IGraphicsProvider.EnableDebugMode", which can be set to enable the D3D12/Vulkan debug layers in Release builds.

The Vulkan provider additional has its own data entries that are used to enable required and/or optional extensions and layers. This is being used alongside the debug mode switch for the debug extension/layer and is being used by the UI providers to enforce the required surface extensions to be enabled.