### PR TITLE
Splitting GraphicsContext into multiple classes

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,12 +26,12 @@
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Update="System.Composition" Version="1.4.0" />
     <PackageReference Update="System.IO.Pipelines" Version="4.7.0" />
-    <PackageReference Update="TerraFX.Interop.D3D12" Version="10.0.18362-alpha-20191209.3" />
-    <PackageReference Update="TerraFX.Interop.DXGIDebug" Version="10.0.18362-alpha-20191209.3" />
-    <PackageReference Update="TerraFX.Interop.Kernel32" Version="10.0.18362-alpha-20191209.3" />
+    <PackageReference Update="TerraFX.Interop.D3D12" Version="10.0.18362-alpha-20191212.1" />
+    <PackageReference Update="TerraFX.Interop.DXGIDebug" Version="10.0.18362-alpha-20191212.1" />
+    <PackageReference Update="TerraFX.Interop.Kernel32" Version="10.0.18362-alpha-20191212.1" />
     <PackageReference Update="TerraFX.Interop.Libc" Version="1.2017.0-alpha-20191206.1" />
     <PackageReference Update="TerraFX.Interop.PulseAudio" Version="12.2.0-alpha-20191206.1" />
-    <PackageReference Update="TerraFX.Interop.User32" Version="10.0.18362-alpha-20191209.3" />
+    <PackageReference Update="TerraFX.Interop.User32" Version="10.0.18362-alpha-20191212.1" />
     <PackageReference Update="TerraFX.Interop.Vulkan" Version="1.1.126-alpha-20191209.1" />
     <PackageReference Update="TerraFX.Interop.Xlib" Version="6.3.0-alpha-20191206.1" />
   </ItemGroup>

--- a/samples/TerraFX/Graphics/EnumerateGraphicsAdapters.cs
+++ b/samples/TerraFX/Graphics/EnumerateGraphicsAdapters.cs
@@ -25,7 +25,7 @@ namespace TerraFX.Samples.Graphics
 
                 foreach (var graphicsAdapter in graphicsProvider.GraphicsAdapters)
                 {
-                    Console.WriteLine($"    Name: {graphicsAdapter.DeviceName}");
+                    Console.WriteLine($"    Name: {graphicsAdapter.Name}");
                     Console.WriteLine($"        Device ID: {graphicsAdapter.DeviceId}");
                     Console.WriteLine($"        Vendor ID: {graphicsAdapter.VendorId}");
                 }

--- a/samples/TerraFX/Graphics/HelloWindow.cs
+++ b/samples/TerraFX/Graphics/HelloWindow.cs
@@ -12,7 +12,7 @@ namespace TerraFX.Samples.Graphics
 {
     public sealed class HelloWindow : Sample
     {
-        private GraphicsContext _graphicsContext = null!;
+        private GraphicsDevice _graphicsDevice = null!;
         private Window _window = null!;
         private TimeSpan _elapsedTime;
 
@@ -23,15 +23,8 @@ namespace TerraFX.Samples.Graphics
 
         public override void Cleanup()
         {
-            if (_graphicsContext is IDisposable graphicsContext)
-            {
-                graphicsContext.Dispose();
-            }
-
-            if (_window is IDisposable window)
-            {
-                window.Dispose();
-            }
+            _graphicsDevice?.Dispose();
+            _window?.Dispose();
 
             base.Cleanup();
         }
@@ -48,7 +41,7 @@ namespace TerraFX.Samples.Graphics
             var graphicsAdapter = graphicsProvider.GraphicsAdapters.First();
 
             var graphicsSurface = _window.CreateGraphicsSurface(bufferCount: 2);
-            _graphicsContext = graphicsAdapter.CreateGraphicsContext(graphicsSurface);
+            _graphicsDevice = graphicsAdapter.CreateGraphicsDevice(graphicsSurface);
 
             base.Initialize(application);
         }
@@ -67,11 +60,14 @@ namespace TerraFX.Samples.Graphics
 
             if (_window.IsVisible)
             {
-                var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
-                _graphicsContext.BeginFrame(backgroundColor);
+                var graphicsDevice = _graphicsDevice;
+                var graphicsContext = graphicsDevice.GraphicsContexts[graphicsDevice.GraphicsContextIndex];
 
-                _graphicsContext.EndFrame();
-                _graphicsContext.PresentFrame();
+                var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
+                graphicsContext.BeginFrame(backgroundColor);
+
+                graphicsContext.EndFrame();
+                graphicsDevice.PresentFrame();
             }
         }
     }

--- a/samples/TerraFX/Properties/launchSettings.json
+++ b/samples/TerraFX/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "TerraFX.Samples": {
       "commandName": "Project",
-      "commandLineArgs": "all"
+      "commandLineArgs": "all",
+      "nativeDebugging": true
     }
   }
 }

--- a/sources/Graphics/GraphicsAdapter.cs
+++ b/sources/Graphics/GraphicsAdapter.cs
@@ -34,12 +34,12 @@ namespace TerraFX.Graphics
         /// <exception cref="ObjectDisposedException">The adapter has been disposed and the value was not otherwise cached.</exception>
         public abstract uint VendorId { get; }
 
-        /// <summary>Creates a new graphics context which utilizes the adapter to render to a graphics surface.</summary>
+        /// <summary>Creates a new graphics device which utilizes the adapter to render to a graphics surface.</summary>
         /// <param name="graphicsSurface">The graphics surface to which the context can render.</param>
-        /// <returns>A new graphics context which utilizes the the adapter to render to <paramref name="graphicsSurface" />.</returns>
+        /// <returns>A new graphics device which utilizes the the adapter to render to <paramref name="graphicsSurface" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsSurface" /> is <c>null</c>.</exception>
         /// <exception cref="ObjectDisposedException">The adapter has been disposed.</exception>
-        public abstract GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface);
+        public abstract GraphicsDevice CreateGraphicsDevice(IGraphicsSurface graphicsSurface);
 
         /// <inheritdoc />
         public void Dispose()

--- a/sources/Graphics/GraphicsAdapter.cs
+++ b/sources/Graphics/GraphicsAdapter.cs
@@ -19,26 +19,26 @@ namespace TerraFX.Graphics
             _graphicsProvider = graphicsProvider;
         }
 
-        /// <summary>Gets the PCI ID of the device.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
+        /// <summary>Gets the PCI Device ID (DID) for the adapter.</summary>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed and the value was not otherwise cached.</exception>
         public abstract uint DeviceId { get; }
 
-        /// <summary>Gets the name of the device.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
-        public abstract string DeviceName { get; }
-
-        /// <summary>Gets the <see cref="Graphics.GraphicsProvider" /> for the instance.</summary>
+        /// <summary>Gets the graphics provider which enumerated the adapter.</summary>
         public GraphicsProvider GraphicsProvider => _graphicsProvider;
 
-        /// <summary>Gets the PCI ID of the vendor.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
+        /// <summary>Gets the name of the adapter.</summary>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed and the value was not otherwise cached.</exception>
+        public abstract string Name { get; }
+
+        /// <summary>Gets the PCI Vendor ID (VID) for the adapter.</summary>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed and the value was not otherwise cached.</exception>
         public abstract uint VendorId { get; }
 
-        /// <summary>Creates a new <see cref="GraphicsContext" />.</summary>
-        /// <param name="graphicsSurface">The <see cref="IGraphicsSurface" /> on which the graphics context can draw.</param>
-        /// <returns>A new <see cref="GraphicsContext" /> which utilizes the current instance and which can draw on <paramref name="graphicsSurface" />.</returns>
+        /// <summary>Creates a new graphics context which utilizes the adapter to render to a graphics surface.</summary>
+        /// <param name="graphicsSurface">The graphics surface to which the context can render.</param>
+        /// <returns>A new graphics context which utilizes the the adapter to render to <paramref name="graphicsSurface" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsSurface" /> is <c>null</c>.</exception>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed.</exception>
         public abstract GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface);
 
         /// <inheritdoc />

--- a/sources/Graphics/GraphicsContext.cs
+++ b/sources/Graphics/GraphicsContext.cs
@@ -8,28 +8,32 @@ namespace TerraFX.Graphics
     /// <summary>Represents a graphics context, which can be used for rendering images.</summary>
     public abstract class GraphicsContext : IDisposable
     {
-        private readonly GraphicsAdapter _graphicsAdapter;
-        private readonly IGraphicsSurface _graphicsSurface;
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly int _index;
 
-        /// <summary>Initializes a new instance of the <see cref="GraphicsContext" /> class.</summary>
-        /// <param name="graphicsAdapter">The underlying graphics adapter for the context.</param>
-        /// <param name="graphicsSurface">The graphics surface on which the context can render.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="graphicsAdapter" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="graphicsSurface" /> is <c>null</c>.</exception>
-        protected GraphicsContext(GraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
+        /// <summary>Initializes a new instance of the <see cref="GraphicsDevice" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the context was created.</param>
+        /// <param name="index">An index which can be used to lookup the context via <see cref="GraphicsDevice.GraphicsContexts" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is <c>negative</c>.</exception>
+        protected GraphicsContext(GraphicsDevice graphicsDevice, int index)
         {
-            ThrowIfNull(graphicsAdapter, nameof(graphicsAdapter));
-            ThrowIfNull(graphicsSurface, nameof(graphicsSurface));
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+            ThrowIfNegative(index, nameof(index));
 
-            _graphicsAdapter = graphicsAdapter;
-            _graphicsSurface = graphicsSurface;
+            _graphicsDevice = graphicsDevice;
+            _index = index;
         }
 
-        /// <summary>Gets the <see cref="Graphics.GraphicsAdapter" /> for the instance.</summary>
-        public GraphicsAdapter GraphicsAdapter => _graphicsAdapter;
+        /// <summary>Gets the <see cref="GraphicsDevice" /> for the instance.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
 
-        /// <summary>Gets the <see cref="IGraphicsSurface" /> for the instance.</summary>
-        public IGraphicsSurface GraphicsSurface => _graphicsSurface;
+        /// <summary>Gets the graphics fence used by the context for synchronization.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public abstract GraphicsFence GraphicsFence { get; }
+
+        /// <summary>Gets an index which can be used to lookup the context via <see cref="GraphicsDevice.GraphicsContexts" />.</summary>
+        public int Index => _index;
 
         /// <summary>Begins a new frame for rendering.</summary>
         /// <param name="backgroundColor">A color to which the background should be cleared.</param>
@@ -46,10 +50,6 @@ namespace TerraFX.Graphics
         /// <summary>Ends the frame currently be rendered.</summary>
         /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
         public abstract void EndFrame();
-
-        /// <summary>Presents the last frame rendered.</summary>
-        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
-        public abstract void PresentFrame();
 
         /// <inheritdoc cref="Dispose()" />
         /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>

--- a/sources/Graphics/GraphicsDevice.cs
+++ b/sources/Graphics/GraphicsDevice.cs
@@ -1,0 +1,59 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics device which provides state management and isolation for a graphics adapter.</summary>
+    public abstract class GraphicsDevice : IDisposable
+    {
+        private readonly GraphicsAdapter _graphicsAdapter;
+        private readonly IGraphicsSurface _graphicsSurface;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsDevice" /> class.</summary>
+        /// <param name="graphicsAdapter">The underlying graphics adapter for the device.</param>
+        /// <param name="graphicsSurface">The graphics surface on which the device can render.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsAdapter" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsSurface" /> is <c>null</c>.</exception>
+        protected GraphicsDevice(GraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
+        {
+            ThrowIfNull(graphicsAdapter, nameof(graphicsAdapter));
+            ThrowIfNull(graphicsSurface, nameof(graphicsSurface));
+
+            _graphicsAdapter = graphicsAdapter;
+            _graphicsSurface = graphicsSurface;
+        }
+
+        /// <summary>Gets the <see cref="Graphics.GraphicsAdapter" /> for the instance.</summary>
+        public GraphicsAdapter GraphicsAdapter => _graphicsAdapter;
+
+        /// <summary>Gets the graphics contexts for the device.</summary>
+        public abstract ReadOnlySpan<GraphicsContext> GraphicsContexts { get; }
+
+        /// <summary>Gets an index which can be used to lookup the current graphics context.</summary>
+        public abstract int GraphicsContextIndex { get; }
+
+        /// <summary>Gets the <see cref="IGraphicsSurface" /> for the instance.</summary>
+        public IGraphicsSurface GraphicsSurface => _graphicsSurface;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>Presents the last frame rendered.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract void PresentFrame();
+
+        /// <summary>Waits for the device to become idle.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract void WaitForIdle();
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsFence.cs
+++ b/sources/Graphics/GraphicsFence.cs
@@ -1,0 +1,89 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Threading;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics fence which can be used to synchronize the processor and a graphics context.</summary>
+    public abstract class GraphicsFence : IDisposable
+    {
+        private readonly GraphicsContext _graphicsContext;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsFence" /> class.</summary>
+        /// <param name="graphicsContext">The graphics context for which the fence provides synchronization.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsContext" /> is <c>null</c>.</exception>
+        protected GraphicsFence(GraphicsContext graphicsContext)
+        {
+            ThrowIfNull(graphicsContext, nameof(graphicsContext));
+            _graphicsContext = graphicsContext;
+        }
+
+        /// <summary>Gets the graphics context for which the fence provides synchronization.</summary>
+        public GraphicsContext GraphicsContext => _graphicsContext;
+
+        /// <summary>Gets <c>true</c> if the fence is in the signalled state; otherwise, <c>false</c>.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        public abstract bool IsSignalled { get; }
+
+        /// <summary>Resets the fence to the unsignalled state.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        /// <remarks>This method does nothing if the fence is already in the unsignalled state.</remarks>
+        public abstract void Reset();
+
+        /// <summary>Waits for the fence to transition to the signalled state or the timeout to be reached, whichever occurs first.</summary>
+        /// <param name="millisecondsTimeout">The amount of time, in milliseconds, to wait for the fence to transition to the signalled state before failing.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout" /> is negative and is not <see cref="Timeout.Infinite" />.</exception>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        /// <exception cref="TimeoutException"><paramref name="millisecondsTimeout" /> was reached before the fence transitioned to the signalled state.</exception>
+        /// <remarks>This method treats <see cref="Timeout.Infinite" /> as having no timeout.</remarks>
+        public void Wait(int millisecondsTimeout = Timeout.Infinite)
+        {
+            if (!TryWait(millisecondsTimeout))
+            {
+                ThrowTimeoutException(TimeSpan.FromMilliseconds(millisecondsTimeout));
+            }
+        }
+
+        /// <summary>Waits for the fence to transition to the signalled state or the timeout to be reached, whichever occurs first.</summary>
+        /// <param name="timeout">The amount of time to wait for the fence to transition to the signalled state before failing.</param>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        /// <exception cref="TimeoutException"><paramref name="timeout" /> was reached before the fence transitioned to the signalled state.</exception>
+        /// <remarks>This method treats <see cref="Timeout.Infinite" /> as having no timeout.</remarks>
+        public void Wait(TimeSpan timeout)
+        {
+            if (!TryWait(timeout))
+            {
+                ThrowTimeoutException(timeout);
+            }
+        }
+
+        /// <summary>Waits for the fence to transition to the signalled state or the timeout to be reached, whichever occurs first.</summary>
+        /// <param name="millisecondsTimeout">The amount of time, in milliseconds, to wait for the fence to transition to the signalled state before failing.</param>
+        /// <returns><c>true</c> if the fence transitioned to the signalled state; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout" /> is negative and is not <see cref="Timeout.Infinite" />.</exception>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        /// <remarks>This method treats <see cref="Timeout.Infinite" /> as having no timeout.</remarks>
+        public abstract bool TryWait(int millisecondsTimeout = Timeout.Infinite);
+
+        /// <summary>Waits for the fence to transition to the signalled state or the timeout to be reached, whichever occurs first.</summary>
+        /// <param name="timeout">The amount of time to wait for the fence to transition to the signalled state before failing.</param>
+        /// <returns><c>true</c> if the fence transitioned to the signalled state; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout" /> is negative and is not <see cref="Timeout.InfiniteTimeSpan" />.</exception>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        /// <remarks>This method treats <see cref="Timeout.InfiniteTimeSpan" /> as having no timeout.</remarks>
+        public abstract bool TryWait(TimeSpan timeout);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsFence.cs
+++ b/sources/Graphics/GraphicsFence.cs
@@ -9,19 +9,19 @@ namespace TerraFX.Graphics
     /// <summary>A graphics fence which can be used to synchronize the processor and a graphics context.</summary>
     public abstract class GraphicsFence : IDisposable
     {
-        private readonly GraphicsContext _graphicsContext;
+        private readonly GraphicsDevice _graphicsDevice;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsFence" /> class.</summary>
-        /// <param name="graphicsContext">The graphics context for which the fence provides synchronization.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="graphicsContext" /> is <c>null</c>.</exception>
-        protected GraphicsFence(GraphicsContext graphicsContext)
+        /// <param name="graphicsDevice">The graphics device for which the fence provides synchronization.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        protected GraphicsFence(GraphicsDevice graphicsDevice)
         {
-            ThrowIfNull(graphicsContext, nameof(graphicsContext));
-            _graphicsContext = graphicsContext;
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+            _graphicsDevice = graphicsDevice;
         }
 
-        /// <summary>Gets the graphics context for which the fence provides synchronization.</summary>
-        public GraphicsContext GraphicsContext => _graphicsContext;
+        /// <summary>Gets the graphics device for which the fence provides synchronization.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
 
         /// <summary>Gets <c>true</c> if the fence is in the signalled state; otherwise, <c>false</c>.</summary>
         /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>

--- a/sources/Graphics/GraphicsProvider.cs
+++ b/sources/Graphics/GraphicsProvider.cs
@@ -8,10 +8,10 @@ namespace TerraFX.Graphics
     /// <summary>Provides the base access required for interacting with a graphics subsystem.</summary>
     public abstract class GraphicsProvider : IDisposable
     {
-        /// <summary>A name of a switch that controls whether <c>debug mode</c> should be enabled for the graphics provider.</summary>
+        /// <summary>The name of a switch that controls whether debug mode should be enabled for the provider.</summary>
         /// <remarks>
         ///     <para>This name is meant to be used with <see cref="AppContext.SetSwitch(string, bool)" />.</para>
-        ///     <para>Setting this switch after a graphics provider instance has been created has no affect.</para>
+        ///     <para>Setting this switch has no affect on providers that have already been created.</para>
         /// </remarks>
         public const string EnableDebugModeSwitchName = "TerraFX.Graphics.GraphicsProvider.EnableDebugMode";
 
@@ -36,12 +36,12 @@ namespace TerraFX.Graphics
             }
         }
 
-        /// <summary>Gets the value of the <see cref="EnableDebugModeSwitchName" /> switch when the instance was created.</summary>
-        /// <remarks>The exact behavior of <c>debug mode</c> may vary based on the implementation and configuration of the host machine.</remarks>
+        /// <summary>Gets the value of the <see cref="EnableDebugModeSwitchName" /> switch from when the provider was created.</summary>
+        /// <remarks>The exact behavior of debug mode may vary based on the provider and configuration of the host machine.</remarks>
         public bool DebugModeEnabled => _debugModeEnabled;
 
-        /// <summary>Gets the <see cref="GraphicsAdapter" /> instances currently available.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        /// <summary>Gets the graphics adapters available to the provider.</summary>
+        /// <exception cref="ObjectDisposedException">The provider has been disposed.</exception>
         public abstract IEnumerable<GraphicsAdapter> GraphicsAdapters { get; }
 
         /// <inheritdoc />

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsAdapter.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsAdapter.cs
@@ -62,15 +62,15 @@ namespace TerraFX.Graphics.Providers.D3D12
         /// <inheritdoc />
         public override uint VendorId => DxgiAdapterDesc.VendorId;
 
-        /// <inheritdoc cref="CreateGraphicsContext(IGraphicsSurface)" />
-        public D3D12GraphicsContext CreateD3D12GraphicsContext(IGraphicsSurface graphicsSurface)
+        /// <inheritdoc cref="CreateGraphicsDevice(IGraphicsSurface)" />
+        public D3D12GraphicsDevice CreateD3D12GraphicsDevice(IGraphicsSurface graphicsSurface)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new D3D12GraphicsContext(this, graphicsSurface);
+            return new D3D12GraphicsDevice(this, graphicsSurface);
         }
 
         /// <inheritdoc />
-        public override GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface) => CreateD3D12GraphicsContext(graphicsSurface);
+        public override GraphicsDevice CreateGraphicsDevice(IGraphicsSurface graphicsSurface) => CreateD3D12GraphicsDevice(graphicsSurface);
 
         /// <inheritdoc />
         protected override void Dispose(bool isDisposing)

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -459,7 +459,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             {
                 case GraphicsSurfaceKind.Win32:
                 {
-                    ThrowExternalExceptionIfFailed(nameof(IDXGIFactory2.CreateSwapChainForHwnd), graphicsProvider.Factory->CreateSwapChainForHwnd((IUnknown*)CommandQueue, GraphicsSurface.WindowHandle, &swapChainDesc, pFullscreenDesc: null, pRestrictToOutput: null, (IDXGISwapChain1**)&swapChain));
+                    ThrowExternalExceptionIfFailed(nameof(IDXGIFactory2.CreateSwapChainForHwnd), graphicsProvider.DxgiFactory->CreateSwapChainForHwnd((IUnknown*)CommandQueue, GraphicsSurface.WindowHandle, &swapChainDesc, pFullscreenDesc: null, pRestrictToOutput: null, (IDXGISwapChain1**)&swapChain));
                     break;
                 }
 
@@ -472,7 +472,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             }
 
             // Fullscreen transitions are not currently supported
-            ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.Factory->MakeWindowAssociation(GraphicsSurface.WindowHandle, DXGI_MWA_NO_ALT_ENTER));
+            ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(GraphicsSurface.WindowHandle, DXGI_MWA_NO_ALT_ENTER));
 
             return swapChain;
         }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -316,7 +316,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             ID3D12Device* device;
 
             var iid = IID_ID3D12Device;
-            ThrowExternalExceptionIfFailed(nameof(D3D12CreateDevice), D3D12CreateDevice((IUnknown*)((D3D12GraphicsAdapter)GraphicsAdapter).Adapter, D3D_FEATURE_LEVEL_11_0, &iid, (void**)&device));
+            ThrowExternalExceptionIfFailed(nameof(D3D12CreateDevice), D3D12CreateDevice((IUnknown*)((D3D12GraphicsAdapter)GraphicsAdapter).DxgiAdapter, D3D_FEATURE_LEVEL_11_0, &iid, (void**)&device));
 
             return device;
         }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -5,83 +5,43 @@ using TerraFX.Interop;
 using TerraFX.Numerics;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
-using static TerraFX.Interop.D3D_FEATURE_LEVEL;
 using static TerraFX.Interop.D3D12;
 using static TerraFX.Interop.D3D12_COMMAND_LIST_TYPE;
-using static TerraFX.Interop.D3D12_COMMAND_QUEUE_FLAGS;
-using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_FLAGS;
 using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_TYPE;
-using static TerraFX.Interop.D3D12_RESOURCE_BARRIER_TYPE;
-using static TerraFX.Interop.D3D12_RESOURCE_BARRIER_FLAGS;
 using static TerraFX.Interop.D3D12_RESOURCE_STATES;
 using static TerraFX.Interop.D3D12_RTV_DIMENSION;
-using static TerraFX.Interop.DXGI;
-using static TerraFX.Interop.DXGI_ALPHA_MODE;
 using static TerraFX.Interop.DXGI_FORMAT;
-using static TerraFX.Interop.DXGI_SCALING;
-using static TerraFX.Interop.DXGI_SWAP_EFFECT;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.DisposeUtilities;
-using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.D3D12
 {
-    /// <summary>Represents a graphics context, which can be used for rendering images.</summary>
+    /// <inheritdoc />
     public sealed unsafe class D3D12GraphicsContext : GraphicsContext
     {
-        private readonly D3D12GraphicsFence _waitForIdleGraphicsFence;
+        private readonly D3D12GraphicsFence _graphicsFence;
+        private readonly D3D12GraphicsFence _waitForExecuteCompletionGraphicsFence;
 
-        private ValueLazy<ID3D12CommandAllocator*[]> _commandAllocators;
-        private ValueLazy<Pointer<ID3D12CommandQueue>> _commandQueue;
-        private ValueLazy<Pointer<ID3D12Device>> _device;
-        private ValueLazy<ID3D12GraphicsCommandList*[]> _graphicsCommandLists;
-        private ValueLazy<Pointer<ID3D12DescriptorHeap>> _renderTargetsHeap;
-        private ValueLazy<ID3D12Resource*[]> _renderTargets;
-        private ValueLazy<Pointer<IDXGISwapChain3>> _swapChain;
-
-        private D3D12GraphicsFence[] _graphicsFences;
-
-        private uint _frameIndex;
+        private ValueLazy<Pointer<ID3D12CommandAllocator>> _d3d12CommandAllocator;
+        private ValueLazy<Pointer<ID3D12GraphicsCommandList>> _d3d12GraphicsCommandList;
+        private ValueLazy<Pointer<ID3D12Resource>> _d3d12RenderTargetResource;
+        private ValueLazy<D3D12_CPU_DESCRIPTOR_HANDLE> _d3d12RenderTargetView;
 
         private State _state;
 
-        internal D3D12GraphicsContext(D3D12GraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
-            : base(graphicsAdapter, graphicsSurface)
+        internal D3D12GraphicsContext(D3D12GraphicsDevice graphicsDevice, int index)
+            : base(graphicsDevice, index)
         {
-            _waitForIdleGraphicsFence = new D3D12GraphicsFence(this);
+            _graphicsFence = new D3D12GraphicsFence(graphicsDevice);
+            _waitForExecuteCompletionGraphicsFence = new D3D12GraphicsFence(graphicsDevice);
 
-            _commandAllocators = new ValueLazy<ID3D12CommandAllocator*[]>(CreateCommandAllocators);
-            _commandQueue = new ValueLazy<Pointer<ID3D12CommandQueue>>(CreateCommandQueue);
-            _device = new ValueLazy<Pointer<ID3D12Device>>(CreateDevice);
-            _graphicsCommandLists = new ValueLazy<ID3D12GraphicsCommandList*[]>(CreateGraphicsCommandLists);
-            _renderTargets = new ValueLazy<ID3D12Resource*[]>(CreateRenderTargets);
-            _renderTargetsHeap = new ValueLazy<Pointer<ID3D12DescriptorHeap>>(CreateRenderTargetsHeap);
-            _swapChain = new ValueLazy<Pointer<IDXGISwapChain3>>(CreateSwapChain);
-
-            _graphicsFences = CreateGraphicsFences(this, graphicsSurface);
+            _d3d12CommandAllocator = new ValueLazy<Pointer<ID3D12CommandAllocator>>(CreateD3D12CommandAllocator);
+            _d3d12GraphicsCommandList = new ValueLazy<Pointer<ID3D12GraphicsCommandList>>(CreateD3D12GraphicsCommandList);
+            _d3d12RenderTargetView = new ValueLazy<D3D12_CPU_DESCRIPTOR_HANDLE>(CreateD3D12RenderTargetDescriptor);
+            _d3d12RenderTargetResource = new ValueLazy<Pointer<ID3D12Resource>>(CreateD3D12RenderTargetResource);
 
             _ = _state.Transition(to: Initialized);
-
-            // We want to ensure the idle fence is created up front so disposal can cleanup nicely
-            WaitForIdleGraphicsFence.Reset();
-
-            // Do event hookups after we are in the initialized state, since an event could
-            // technically fire while the constructor is still running.
-
-            graphicsSurface.SizeChanged += HandleGraphicsSurfaceSizeChanged;
-
-            static D3D12GraphicsFence[] CreateGraphicsFences(D3D12GraphicsContext graphicsContext, IGraphicsSurface graphicsSurface)
-            {
-                var graphicsFences = new D3D12GraphicsFence[graphicsSurface.BufferCount];
-
-                for (var i = 0; i < graphicsFences.Length; i++)
-                {
-                    graphicsFences[i] = new D3D12GraphicsFence(graphicsContext);
-                }
-
-                return graphicsFences;
-            }
         }
 
         /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsContext" /> class.</summary>
@@ -90,354 +50,93 @@ namespace TerraFX.Graphics.Providers.D3D12
             Dispose(isDisposing: false);
         }
 
-        /// <summary>Gets an array of <see cref="ID3D12CommandAllocator" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12CommandAllocator*[] CommandAllocators
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _commandAllocators.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="ID3D12CommandAllocator" /> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public ID3D12CommandAllocator* D3D12CommandAllocator => _d3d12CommandAllocator.Value;
 
-        /// <summary>Gets the <see cref="ID3D12CommandQueue" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12CommandQueue* CommandQueue
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _commandQueue.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="ID3D12GraphicsCommandList" /> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public ID3D12GraphicsCommandList* D3D12GraphicsCommandList => _d3d12GraphicsCommandList.Value;
 
-        /// <summary>Gets an array of <see cref="GraphicsFence" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public D3D12GraphicsFence[] D3D12GraphicsFences
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _graphicsFences;
-            }
-        }
+        /// <inheritdoc cref="GraphicsContext.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
 
-        /// <summary>Gets the <see cref="ID3D12Device" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12Device* Device
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _device.Value;
-            }
-        }
+        /// <inheritdoc cref="GraphicsFence" />
+        public D3D12GraphicsFence D3D12GraphicsFence => _graphicsFence;
 
-        /// <summary>Gets an array of <see cref="ID3D12GraphicsCommandList" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12GraphicsCommandList*[] GraphicsCommandLists
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _graphicsCommandLists.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="ID3D12Resource" /> for the render target used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public ID3D12Resource* D3D12RenderTargetResource => _d3d12RenderTargetResource.Value;
 
+        /// <summary>Gets the <see cref="D3D12_CPU_DESCRIPTOR_HANDLE" /> for the render target used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public D3D12_CPU_DESCRIPTOR_HANDLE D3D12RenderTargetView => _d3d12RenderTargetView.Value;
 
+        /// <inheritdoc />
+        public override GraphicsFence GraphicsFence => D3D12GraphicsFence;
 
-        /// <summary>Gets an array of <see cref="ID3D12Resource" /> representing the render targets for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12Resource*[] RenderTargets
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _renderTargets.Value;
-            }
-        }
-
-        /// <summary>Gets the <see cref="ID3D12DescriptorHeap" /> for the <see cref="RenderTargets" />.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ID3D12DescriptorHeap* RenderTargetsHeap
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _renderTargetsHeap.Value;
-            }
-        }
-
-        /// <summary>Gets the <see cref="IDXGISwapChain3" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public IDXGISwapChain3* SwapChain
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _swapChain.Value;
-            }
-        }
-
-        /// <summary>Gets a graphics fence that is used to wait for the context to become idle.</summary>
-        public D3D12GraphicsFence WaitForIdleGraphicsFence
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _waitForIdleGraphicsFence;
-            }
-        }
+        /// <summary>Gets a graphics fence that is used to wait for the context to finish execution.</summary>
+        public D3D12GraphicsFence WaitForExecuteCompletionGraphicsFence => _waitForExecuteCompletionGraphicsFence;
 
         /// <inheritdoc />
         public override void BeginFrame(ColorRgba backgroundColor)
         {
-            var frameIndex = SwapChain->GetCurrentBackBufferIndex();
-            _frameIndex = frameIndex;
-
-            var graphicsFence = D3D12GraphicsFences[frameIndex];
+            var graphicsFence = D3D12GraphicsFence;
 
             graphicsFence.Wait();
             graphicsFence.Reset();
 
-            var commandAllocator = CommandAllocators[frameIndex];
+            var commandAllocator = D3D12CommandAllocator;
             ThrowExternalExceptionIfFailed(nameof(ID3D12CommandAllocator.Reset), commandAllocator->Reset());
 
-            var graphicsCommandList = GraphicsCommandLists[frameIndex];
+            var graphicsCommandList = D3D12GraphicsCommandList;
             ThrowExternalExceptionIfFailed(nameof(ID3D12GraphicsCommandList.Reset), graphicsCommandList->Reset(commandAllocator, pInitialState: null));
 
-            var renderTargetDescriptorSize = Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-            var renderTargetHandle = RenderTargetsHeap->GetCPUDescriptorHandleForHeapStart();
+            var renderTargetResourceBarrier = D3D12_RESOURCE_BARRIER.InitTransition(D3D12RenderTargetResource, D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+            graphicsCommandList->ResourceBarrier(1, &renderTargetResourceBarrier);
 
-            _ = renderTargetHandle.Offset((int)frameIndex, renderTargetDescriptorSize);
-            graphicsCommandList->OMSetRenderTargets(1, &renderTargetHandle, RTsSingleHandleToDescriptorRange: TRUE, pDepthStencilDescriptor: null);
+            var renderTargetView = D3D12RenderTargetView;
+            graphicsCommandList->OMSetRenderTargets(1, &renderTargetView, RTsSingleHandleToDescriptorRange: TRUE, pDepthStencilDescriptor: null);
+
+            var graphicsSurface = D3D12GraphicsDevice.GraphicsSurface;
+
+            var graphicsSurfaceWidth = graphicsSurface.Width;
+            var graphicsSurfaceHeight = graphicsSurface.Height;
 
             var viewport = new D3D12_VIEWPORT {
-                TopLeftX = 0.0f,
-                TopLeftY = 0.0f,
-                Width = GraphicsSurface.Width,
-                Height = GraphicsSurface.Height,
-                MinDepth = 0.0f,
-                MaxDepth = 1.0f,
+                Width = graphicsSurfaceWidth,
+                Height = graphicsSurfaceHeight,
+                MinDepth = D3D12_MIN_DEPTH,
+                MaxDepth = D3D12_MAX_DEPTH,
             };
             graphicsCommandList->RSSetViewports(1, &viewport);
 
             var scissorRect = new RECT {
-                left = 0,
-                top = 0,
-                right = (int)GraphicsSurface.Width,
-                bottom = (int)GraphicsSurface.Height,
+                right = (int)graphicsSurfaceWidth,
+                bottom = (int)graphicsSurfaceHeight,
             };
             graphicsCommandList->RSSetScissorRects(1, &scissorRect);
 
-            var barrier = new D3D12_RESOURCE_BARRIER {
-                Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
-                Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE,
-                Anonymous = new D3D12_RESOURCE_BARRIER._Anonymous_e__Union {
-                    Transition = new D3D12_RESOURCE_TRANSITION_BARRIER {
-                        pResource = RenderTargets[frameIndex],
-                        Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
-                        StateBefore = D3D12_RESOURCE_STATE_PRESENT,
-                        StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET,
-                    },
-                },
-            };
-            graphicsCommandList->ResourceBarrier(1, &barrier);
-
-            graphicsCommandList->ClearRenderTargetView(renderTargetHandle, (float*)&backgroundColor, NumRects: 0, pRects: null);
+            graphicsCommandList->ClearRenderTargetView(renderTargetView, (float*)&backgroundColor, NumRects: 0, pRects: null);
         }
 
         /// <inheritdoc />
         public override void EndFrame()
         {
-            var frameIndex = _frameIndex;
+            var graphicsCommandList = D3D12GraphicsCommandList;
 
-            var barrier = new D3D12_RESOURCE_BARRIER {
-                Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
-                Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE,
-                Anonymous = new D3D12_RESOURCE_BARRIER._Anonymous_e__Union {
-                    Transition = new D3D12_RESOURCE_TRANSITION_BARRIER {
-                        pResource = RenderTargets[frameIndex],
-                        Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
-                        StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET,
-                        StateAfter = D3D12_RESOURCE_STATE_PRESENT,
-                    },
-                },
-            };
+            var renderTargetResourceBarrier = D3D12_RESOURCE_BARRIER.InitTransition(D3D12RenderTargetResource, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
+            graphicsCommandList->ResourceBarrier(1, &renderTargetResourceBarrier);
 
-            var graphicsCommandList = GraphicsCommandLists[frameIndex];
-            graphicsCommandList->ResourceBarrier(1, &barrier);
-
+            var commandQueue = D3D12GraphicsDevice.D3D12CommandQueue;
             ThrowExternalExceptionIfFailed(nameof(ID3D12GraphicsCommandList.Close), graphicsCommandList->Close());
-            CommandQueue->ExecuteCommandLists(1, (ID3D12CommandList**)&graphicsCommandList);
-        }
+            commandQueue->ExecuteCommandLists(1, (ID3D12CommandList**)&graphicsCommandList);
 
-        /// <inheritdoc />
-        public override void PresentFrame()
-        {
-            var frameIndex = _frameIndex;
-            ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.Present), SwapChain->Present(1, 0));
+            var executeGraphicsFence = WaitForExecuteCompletionGraphicsFence;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12CommandQueue.Signal), commandQueue->Signal(executeGraphicsFence.D3D12Fence, executeGraphicsFence.D3D12FenceSignalValue));
 
-            var graphicsFence = D3D12GraphicsFences[frameIndex];
-            ThrowExternalExceptionIfFailed(nameof(ID3D12CommandQueue.Signal), CommandQueue->Signal(graphicsFence.D3D12Fence, graphicsFence.D3D12FenceSignalValue));
-        }
-
-        private ID3D12CommandAllocator*[] CreateCommandAllocators()
-        {
-            var commandAllocators = new ID3D12CommandAllocator*[GraphicsSurface.BufferCount];
-            var iid = IID_ID3D12CommandAllocator;
-
-            for (var i = 0; i < commandAllocators.Length; i++)
-            {
-                ID3D12CommandAllocator* commandAllocator;
-                ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandAllocator), Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, &iid, (void**)&commandAllocator));
-                commandAllocators[i] = commandAllocator;
-            }
-
-            return commandAllocators;
-        }
-
-        private Pointer<ID3D12CommandQueue> CreateCommandQueue()
-        {
-            ID3D12CommandQueue* commandQueue;
-
-            var commandQueueDesc = new D3D12_COMMAND_QUEUE_DESC {
-                Type = D3D12_COMMAND_LIST_TYPE_DIRECT,
-                Priority = 0,
-                Flags = D3D12_COMMAND_QUEUE_FLAG_NONE,
-                NodeMask = 0,
-            };
-
-            var iid = IID_ID3D12CommandQueue;
-            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandQueue), Device->CreateCommandQueue(&commandQueueDesc, &iid, (void**)&commandQueue));
-
-            return commandQueue;
-        }
-
-        private Pointer<ID3D12Device> CreateDevice()
-        {
-            ID3D12Device* device;
-
-            var iid = IID_ID3D12Device;
-            ThrowExternalExceptionIfFailed(nameof(D3D12CreateDevice), D3D12CreateDevice((IUnknown*)((D3D12GraphicsAdapter)GraphicsAdapter).DxgiAdapter, D3D_FEATURE_LEVEL_11_0, &iid, (void**)&device));
-
-            return device;
-        }
-
-        private ID3D12GraphicsCommandList*[] CreateGraphicsCommandLists()
-        {
-            var graphicsCommandLists = new ID3D12GraphicsCommandList*[GraphicsSurface.BufferCount];
-            var iid = IID_ID3D12GraphicsCommandList;
-
-            for (var i = 0; i < graphicsCommandLists.Length; i++)
-            {
-                ID3D12GraphicsCommandList* graphicsCommandList;
-                ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandList), Device->CreateCommandList(nodeMask: 0, D3D12_COMMAND_LIST_TYPE_DIRECT, CommandAllocators[i], pInitialState: null, &iid, (void**)&graphicsCommandList));
-
-                // Command lists are created in the recording state, but there is nothing
-                // to record yet. The main loop expects it to be closed, so close it now.
-                ThrowExternalExceptionIfFailed(nameof(ID3D12GraphicsCommandList.Close), graphicsCommandList->Close());
-
-                graphicsCommandLists[i] = graphicsCommandList;
-            }
-
-            return graphicsCommandLists;
-        }
-
-        private ID3D12Resource*[] CreateRenderTargets()
-        {
-            var renderTargets = new ID3D12Resource*[GraphicsSurface.BufferCount];
-            var iid = IID_ID3D12Resource;
-
-            var renderTargetDescriptorSize = Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-            var renderTargetHandle = RenderTargetsHeap->GetCPUDescriptorHandleForHeapStart();
-
-            var renderTargetViewDesc = new D3D12_RENDER_TARGET_VIEW_DESC {
-                Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
-                ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D,
-                Anonymous = new D3D12_RENDER_TARGET_VIEW_DESC._Anonymous_e__Union {
-                    Texture2D = new D3D12_TEX2D_RTV {
-                        MipSlice = 0,
-                        PlaneSlice = 0,
-                    },
-                },
-            };
-
-            for (var i = 0; i < renderTargets.Length; i++)
-            {
-                ID3D12Resource* renderTarget;
-                ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.GetBuffer), SwapChain->GetBuffer((uint)i, &iid, (void**)&renderTarget));
-                renderTargets[i] = renderTarget;
-
-                Device->CreateRenderTargetView(renderTarget, &renderTargetViewDesc, renderTargetHandle);
-                _ = renderTargetHandle.Offset((int)renderTargetDescriptorSize);
-            }
-
-            return renderTargets;
-        }
-
-        private Pointer<ID3D12DescriptorHeap> CreateRenderTargetsHeap()
-        {
-            ID3D12DescriptorHeap* renderTargetDescriptorHeap;
-
-            var renderTargetDescriptorHeapDesc = new D3D12_DESCRIPTOR_HEAP_DESC {
-                Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
-                NumDescriptors = (uint)GraphicsSurface.BufferCount,
-                Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
-                NodeMask = 0,
-            };
-
-            var iid = IID_ID3D12DescriptorHeap;
-            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateDescriptorHeap), Device->CreateDescriptorHeap(&renderTargetDescriptorHeapDesc, &iid, (void**)&renderTargetDescriptorHeap));
-
-            return renderTargetDescriptorHeap;
-        }
-
-        private Pointer<IDXGISwapChain3> CreateSwapChain()
-        {
-            IDXGISwapChain3* swapChain;
-
-            var swapChainDesc = new DXGI_SWAP_CHAIN_DESC1 {
-                Width = (uint)GraphicsSurface.Width,
-                Height = (uint)GraphicsSurface.Height,
-                Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-                Stereo = FALSE,
-                SampleDesc = new DXGI_SAMPLE_DESC {
-                    Count = 1,
-                    Quality = 0,
-                },
-                BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                BufferCount = (uint)GraphicsSurface.BufferCount,
-                Scaling = DXGI_SCALING_NONE,                
-                SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,
-                AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED,
-                Flags = 0
-            };
-
-            var graphicsProvider = (D3D12GraphicsProvider)GraphicsAdapter.GraphicsProvider;
-            var iid = IID_IDXGISwapChain3;
-
-            switch (GraphicsSurface.Kind)
-            {
-                case GraphicsSurfaceKind.Win32:
-                {
-                    ThrowExternalExceptionIfFailed(nameof(IDXGIFactory2.CreateSwapChainForHwnd), graphicsProvider.DxgiFactory->CreateSwapChainForHwnd((IUnknown*)CommandQueue, GraphicsSurface.WindowHandle, &swapChainDesc, pFullscreenDesc: null, pRestrictToOutput: null, (IDXGISwapChain1**)&swapChain));
-                    break;
-                }
-
-                default:
-                {
-                    ThrowInvalidOperationException(nameof(GraphicsSurface), GraphicsSurface);
-                    swapChain = null;
-                    break;
-                }
-            }
-
-            // Fullscreen transitions are not currently supported
-            ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(GraphicsSurface.WindowHandle, DXGI_MWA_NO_ALT_ENTER));
-
-            return swapChain;
+            executeGraphicsFence.Wait();
+            executeGraphicsFence.Reset();
         }
 
         /// <inheritdoc />
@@ -447,156 +146,92 @@ namespace TerraFX.Graphics.Providers.D3D12
 
             if (priorState < Disposing)
             {
-                WaitForIdle();
-                DisposeIfNotNull(_waitForIdleGraphicsFence);
-                DisposeGraphicsCommandLists();
-                DisposeCommandAllocators();
-                DisposeRenderTargetsHeap();
-                DisposeRenderTargets();
-                DisposeIfNotNull(_graphicsFences);
-                DisposeSwapChain();
-                DisposeCommandQueue();
-                DisposeDevice();
+                _d3d12GraphicsCommandList.Dispose(ReleaseIfNotNull);
+                _d3d12CommandAllocator.Dispose(ReleaseIfNotNull);
+                _d3d12RenderTargetView.Dispose();
+                _d3d12RenderTargetResource.Dispose(ReleaseIfNotNull);
+
+                DisposeIfNotNull(_waitForExecuteCompletionGraphicsFence);
+                DisposeIfNotNull(_graphicsFence);
             }
 
             _state.EndDispose();
         }
 
-        private void DisposeCommandAllocators()
+        internal void OnGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> eventArgs)
         {
-            _state.AssertDisposing();
-
-            if (_commandAllocators.IsCreated)
+            if (_d3d12RenderTargetView.IsCreated)
             {
-                var commandAllocators = _commandAllocators.Value;
-
-                foreach (var commandAllocator in commandAllocators)
-                {
-                    if (commandAllocator != null)
-                    {
-                        _ = commandAllocator->Release();
-                    }
-                }
+                ReleaseIfNotNull(_d3d12RenderTargetResource.Value);
+                _d3d12RenderTargetResource.Reset(CreateD3D12RenderTargetResource);
             }
         }
 
-        private void DisposeCommandQueue()
+        private Pointer<ID3D12CommandAllocator> CreateD3D12CommandAllocator()
         {
-            _state.AssertDisposing();
+            _state.ThrowIfDisposedOrDisposing();
 
-            if (_commandQueue.IsCreated)
-            {
-                var commandQueue = (ID3D12CommandQueue*)_commandQueue.Value;
-                _ = commandQueue->Release();
-            }
+            ID3D12CommandAllocator* d3d12CommandAllocator;
+
+            var iid = IID_ID3D12CommandAllocator;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandAllocator), D3D12GraphicsDevice.D3D12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, &iid, (void**)&d3d12CommandAllocator));
+
+            return d3d12CommandAllocator;
         }
 
-        private void DisposeDevice()
+        private Pointer<ID3D12GraphicsCommandList> CreateD3D12GraphicsCommandList()
         {
-            _state.AssertDisposing();
+            _state.ThrowIfDisposedOrDisposing();
 
-            if (_device.IsCreated)
-            {
-                var device = (ID3D12Device*)_device.Value;
-                _ = device->Release();
-            }
+            ID3D12GraphicsCommandList* d3d12GraphicsCommandList;
+
+            var iid = IID_ID3D12GraphicsCommandList;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandList), D3D12GraphicsDevice.D3D12Device->CreateCommandList(nodeMask: 0, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12CommandAllocator, pInitialState: null, &iid, (void**)&d3d12GraphicsCommandList));
+
+            // Command lists are created in the recording state, but there is nothing
+            // to record yet. The main loop expects it to be closed, so close it now.
+            ThrowExternalExceptionIfFailed(nameof(ID3D12GraphicsCommandList.Close), d3d12GraphicsCommandList->Close());
+
+            return d3d12GraphicsCommandList;
         }
 
-        private void DisposeGraphicsCommandLists()
+        private Pointer<ID3D12Resource> CreateD3D12RenderTargetResource()
         {
-            _state.AssertDisposing();
+            _state.ThrowIfDisposedOrDisposing();
 
-            if (_graphicsCommandLists.IsCreated)
-            {
-                var graphicsCommandLists = _graphicsCommandLists.Value;
+            ID3D12Resource* renderTargetResource;
 
-                foreach (var graphicsCommandList in graphicsCommandLists)
-                {
-                    if (graphicsCommandList != null)
-                    {
-                        _ = graphicsCommandList->Release();
-                    }
-                }
-            }
+            var iid = IID_ID3D12Resource;
+            ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.GetBuffer), D3D12GraphicsDevice.DxgiSwapChain->GetBuffer(unchecked((uint)Index), &iid, (void**)&renderTargetResource));
+
+            return renderTargetResource;
         }
 
-        private void DisposeRenderTargetsHeap()
+        private D3D12_CPU_DESCRIPTOR_HANDLE CreateD3D12RenderTargetDescriptor()
         {
-            _state.AssertDisposing();
+            _state.ThrowIfDisposedOrDisposing();
 
-            if (_renderTargetsHeap.IsCreated)
-            {
-                var renderTargetsHeap = (ID3D12DescriptorHeap*)_renderTargetsHeap.Value;
-                _ = renderTargetsHeap->Release();
-            }
-        }
+            D3D12_CPU_DESCRIPTOR_HANDLE renderTargetViewHandle;
 
-        private void DisposeRenderTargets()
-        {
-            _state.AssertDisposing();
+            var graphicsDevice = D3D12GraphicsDevice;
+            var d3d12Device = graphicsDevice.D3D12Device;
 
-            if (_renderTargets.IsCreated)
-            {
-                var renderTargets = _renderTargets.Value;
+            var renderTargetViewDesc = new D3D12_RENDER_TARGET_VIEW_DESC {
+                Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+                ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D,
+                Anonymous = new D3D12_RENDER_TARGET_VIEW_DESC._Anonymous_e__Union {
+                    Texture2D = new D3D12_TEX2D_RTV(),
+                },
+            };
 
-                foreach (var renderTarget in renderTargets)
-                {
-                    if (renderTarget != null)
-                    {
-                        _ = renderTarget->Release();
-                    }
-                }
-            }
-        }
+            var renderTargetDescriptorIncrementSize = d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
 
-        private void DisposeSwapChain()
-        {
-            _state.AssertDisposing();
+            renderTargetViewHandle = graphicsDevice.D3D12RenderTargetDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
+            _ = renderTargetViewHandle.Offset(Index, renderTargetDescriptorIncrementSize);
 
-            if (_swapChain.IsCreated)
-            {
-                var swapChain = (IDXGISwapChain3*)_swapChain.Value;
-                _ = swapChain->Release();
-            }
-        }
+            d3d12Device->CreateRenderTargetView(D3D12RenderTargetResource, &renderTargetViewDesc, renderTargetViewHandle);
 
-        private void HandleGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> e)
-        {
-            WaitForIdle();
-
-            if (_renderTargets.IsCreated)
-            {
-                var renderTargets = _renderTargets.Value;
-
-                foreach (var renderTarget in renderTargets)
-                {
-                    if (renderTarget != null)
-                    {
-                        _ = renderTarget->Release();
-                    }
-                }
-
-                _renderTargets.Reset(CreateRenderTargets);
-            }
-
-            if (_swapChain.IsCreated)
-            {
-                ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.ResizeBuffers), SwapChain->ResizeBuffers((uint)GraphicsSurface.BufferCount, (uint)GraphicsSurface.Width, (uint)GraphicsSurface.Height, DXGI_FORMAT_R8G8B8A8_UNORM, SwapChainFlags: 0));
-            }
-        }
-
-        private void WaitForIdle()
-        {
-            if (_commandQueue.IsCreated)
-            {
-                ID3D12CommandQueue* commandQueue = _commandQueue.Value;
-                var waitForIdleGraphicsFence = _waitForIdleGraphicsFence;
-
-                ThrowExternalExceptionIfFailed(nameof(ID3D12CommandQueue.Signal), commandQueue->Signal(waitForIdleGraphicsFence.D3D12Fence, waitForIdleGraphicsFence.D3D12FenceSignalValue));
-
-                waitForIdleGraphicsFence.Wait();
-                waitForIdleGraphicsFence.Reset();
-            }
+            return renderTargetViewHandle;
         }
     }
 }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -1,0 +1,250 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Numerics;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D_FEATURE_LEVEL;
+using static TerraFX.Interop.D3D12;
+using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_TYPE;
+using static TerraFX.Interop.DXGI;
+using static TerraFX.Interop.DXGI_FORMAT;
+using static TerraFX.Interop.DXGI_SWAP_EFFECT;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsDevice : GraphicsDevice
+    {
+        private readonly D3D12GraphicsFence _idleGraphicsFence;
+
+        private ValueLazy<Pointer<ID3D12CommandQueue>> _d3d12CommandQueue;
+        private ValueLazy<Pointer<ID3D12Device>> _d3d12Device;
+        private ValueLazy<Pointer<ID3D12DescriptorHeap>> _d3d12RenderTargetDescriptorHeap;
+        private ValueLazy<Pointer<IDXGISwapChain3>> _dxgiSwapChain;
+
+        private D3D12GraphicsContext[] _graphicsContexts;
+        private int _graphicsContextIndex;
+
+        private State _state;
+
+        internal D3D12GraphicsDevice(D3D12GraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
+            : base(graphicsAdapter, graphicsSurface)
+        {
+            _idleGraphicsFence = new D3D12GraphicsFence(this);
+
+            _d3d12CommandQueue = new ValueLazy<Pointer<ID3D12CommandQueue>>(CreateD3D12CommandQueue);
+            _d3d12Device = new ValueLazy<Pointer<ID3D12Device>>(CreateD3D12Device);
+            _d3d12RenderTargetDescriptorHeap = new ValueLazy<Pointer<ID3D12DescriptorHeap>>(CreateD3D12RenderTargetDescriptorHeap);
+            _dxgiSwapChain = new ValueLazy<Pointer<IDXGISwapChain3>>(CreateDxgiSwapChain);
+
+            _graphicsContexts = CreateGraphicsContexts(this, graphicsSurface);
+
+            _ = _state.Transition(to: Initialized);
+
+            WaitForIdleGraphicsFence.Reset();
+            graphicsSurface.SizeChanged += OnGraphicsSurfaceSizeChanged;
+
+            static D3D12GraphicsContext[] CreateGraphicsContexts(D3D12GraphicsDevice graphicsDevice, IGraphicsSurface graphicsSurface)
+            {
+                var graphicsContexts = new D3D12GraphicsContext[graphicsSurface.BufferCount];
+
+                for (var index = 0; index < graphicsContexts.Length; index++)
+                {
+                    graphicsContexts[index] = new D3D12GraphicsContext(graphicsDevice, index);
+                }
+
+                return graphicsContexts;
+            }
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsDevice" /> class.</summary>
+        ~D3D12GraphicsDevice()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <summary>Gets the <see cref="ID3D12CommandQueue" /> used by the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public ID3D12CommandQueue* D3D12CommandQueue => _d3d12CommandQueue.Value;
+
+        /// <summary>Gets the underlying <see cref="ID3D12Device" /> for the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public ID3D12Device* D3D12Device => _d3d12Device.Value;
+
+        /// <inheritdoc cref="GraphicsDevice.GraphicsAdapter" />
+        public D3D12GraphicsAdapter D3D12GraphicsAdapter => (D3D12GraphicsAdapter)GraphicsAdapter;
+
+        /// <inheritdoc cref="GraphicsContexts" />
+        public ReadOnlySpan<D3D12GraphicsContext> D3D12GraphicsContexts => _graphicsContexts;
+
+        /// <summary>Gets the <see cref="ID3D12DescriptorHeap" /> used by the device for render target resources.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public ID3D12DescriptorHeap* D3D12RenderTargetDescriptorHeap => _d3d12RenderTargetDescriptorHeap.Value;
+
+        /// <summary>Gets the <see cref="IDXGISwapChain3" /> for the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public IDXGISwapChain3* DxgiSwapChain => _dxgiSwapChain.Value;
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<GraphicsContext> GraphicsContexts => _graphicsContexts;
+
+        /// <inheritdoc />
+        public override int GraphicsContextIndex => _graphicsContextIndex;
+
+        /// <summary>Gets a graphics fence that is used to wait for the device to become idle.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public D3D12GraphicsFence WaitForIdleGraphicsFence => _idleGraphicsFence;
+
+        /// <inheritdoc />
+        public override void PresentFrame()
+        {
+            ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.Present), DxgiSwapChain->Present(1, 0));
+
+            var graphicsFence = D3D12GraphicsContexts[GraphicsContextIndex].D3D12GraphicsFence;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12CommandQueue.Signal), D3D12CommandQueue->Signal(graphicsFence.D3D12Fence, graphicsFence.D3D12FenceSignalValue));
+
+            _graphicsContextIndex = unchecked((int)DxgiSwapChain->GetCurrentBackBufferIndex());
+        }
+
+        /// <inheritdoc />
+        public override void WaitForIdle()
+        {
+            if (_d3d12CommandQueue.IsCreated)
+            {
+                var waitForIdleGraphicsFence = WaitForIdleGraphicsFence;
+
+                ThrowExternalExceptionIfFailed(nameof(ID3D12CommandQueue.Signal), D3D12CommandQueue->Signal(waitForIdleGraphicsFence.D3D12Fence, waitForIdleGraphicsFence.D3D12FenceSignalValue));
+
+                waitForIdleGraphicsFence.Wait();
+                waitForIdleGraphicsFence.Reset();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                WaitForIdle();
+                DisposeIfNotNull(_graphicsContexts);
+
+                _d3d12RenderTargetDescriptorHeap.Dispose(ReleaseIfNotNull);
+                _dxgiSwapChain.Dispose(ReleaseIfNotNull);
+                _d3d12CommandQueue.Dispose(ReleaseIfNotNull);
+
+                DisposeIfNotNull(_idleGraphicsFence);
+
+                _d3d12Device.Dispose(ReleaseIfNotNull);
+            }
+
+            _state.EndDispose();
+        }
+
+        private Pointer<ID3D12CommandQueue> CreateD3D12CommandQueue()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3D12CommandQueue* d3d12CommandQueue;
+
+            var commandQueueDesc = new D3D12_COMMAND_QUEUE_DESC();
+            var iid = IID_ID3D12CommandQueue;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommandQueue), D3D12Device->CreateCommandQueue(&commandQueueDesc, &iid, (void**)&d3d12CommandQueue));
+
+            return d3d12CommandQueue;
+        }
+
+        private Pointer<ID3D12Device> CreateD3D12Device()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3D12Device* d3d12Device;
+
+            var iid = IID_ID3D12Device;
+            ThrowExternalExceptionIfFailed(nameof(D3D12CreateDevice), D3D12CreateDevice((IUnknown*)D3D12GraphicsAdapter.DxgiAdapter, D3D_FEATURE_LEVEL_11_0, &iid, (void**)&d3d12Device));
+
+            return d3d12Device;
+        }
+
+        private Pointer<ID3D12DescriptorHeap> CreateD3D12RenderTargetDescriptorHeap()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3D12DescriptorHeap* renderTargetDescriptorHeap;
+
+            var renderTargetDescriptorHeapDesc = new D3D12_DESCRIPTOR_HEAP_DESC {
+                Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                NumDescriptors = (uint)GraphicsSurface.BufferCount,
+            };
+
+            var iid = IID_ID3D12DescriptorHeap;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateDescriptorHeap), D3D12Device->CreateDescriptorHeap(&renderTargetDescriptorHeapDesc, &iid, (void**)&renderTargetDescriptorHeap));
+
+            return renderTargetDescriptorHeap;
+        }
+
+        private Pointer<IDXGISwapChain3> CreateDxgiSwapChain()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            IDXGISwapChain3* dxgiSwapChain;
+
+            var swapChainDesc = new DXGI_SWAP_CHAIN_DESC1 {
+                Width = (uint)GraphicsSurface.Width,
+                Height = (uint)GraphicsSurface.Height,
+                Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+                SampleDesc = new DXGI_SAMPLE_DESC(count: 1, quality: 0),
+                BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                BufferCount = (uint)GraphicsSurface.BufferCount,
+                SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,
+            };
+
+            var graphicsProvider = D3D12GraphicsAdapter.D3D12GraphicsProvider;
+            var iid = IID_IDXGISwapChain3;
+
+            switch (GraphicsSurface.Kind)
+            {
+                case GraphicsSurfaceKind.Win32:
+                {
+                    ThrowExternalExceptionIfFailed(nameof(IDXGIFactory2.CreateSwapChainForHwnd), graphicsProvider.DxgiFactory->CreateSwapChainForHwnd((IUnknown*)D3D12CommandQueue, GraphicsSurface.WindowHandle, &swapChainDesc, pFullscreenDesc: null, pRestrictToOutput: null, (IDXGISwapChain1**)&dxgiSwapChain));
+                    break;
+                }
+
+                default:
+                {
+                    ThrowInvalidOperationException(nameof(GraphicsSurface), GraphicsSurface);
+                    dxgiSwapChain = null;
+                    break;
+                }
+            }
+
+            // Fullscreen transitions are not currently supported
+            ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(GraphicsSurface.WindowHandle, DXGI_MWA_NO_ALT_ENTER));
+
+            return dxgiSwapChain;
+        }
+
+        /// <inheritdoc />
+        private void OnGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> eventArgs)
+        {
+            WaitForIdle();
+
+            foreach (var graphicsContext in D3D12GraphicsContexts)
+            {
+                graphicsContext.OnGraphicsSurfaceSizeChanged(sender, eventArgs);
+            }
+
+            if (_dxgiSwapChain.IsCreated)
+            {
+                var graphicsSurface = GraphicsSurface;
+                ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.ResizeBuffers), DxgiSwapChain->ResizeBuffers((uint)graphicsSurface.BufferCount, (uint)graphicsSurface.Width, (uint)graphicsSurface.Height, DXGI_FORMAT_R8G8B8A8_UNORM, SwapChainFlags: 0));
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsFence.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsFence.cs
@@ -1,0 +1,189 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Threading;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D12;
+using static TerraFX.Interop.D3D12_FENCE_FLAGS;
+using static TerraFX.Interop.Kernel32;
+using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsFence : GraphicsFence
+    {
+        private ValueLazy<Pointer<ID3D12Fence>> _d3d12Fence;
+        private ValueLazy<HANDLE> _d3d12FenceSignalEvent;
+
+        private ulong _d3d12FenceSignalValue;
+
+        private State _state;
+
+        internal D3D12GraphicsFence(GraphicsContext graphicsContext)
+            : base(graphicsContext)
+        {
+            _d3d12Fence = new ValueLazy<Pointer<ID3D12Fence>>(CreateD3D12Fence);
+            _d3d12FenceSignalEvent = new ValueLazy<HANDLE>(CreateEventHandle);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsFence" /> class.</summary>
+        ~D3D12GraphicsFence()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <summary>Gets the underlying <see cref="ID3D12Fence" /> for the fence.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        public ID3D12Fence* D3D12Fence => _d3d12Fence.Value;
+
+        /// <summary>Gets a <see cref="HANDLE" /> to an event which is raised when the fence enters the signalled state.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        public HANDLE D3D12FenceSignalEvent => _d3d12FenceSignalEvent.Value;
+
+        /// <summary>Gets the value at which the fence will enter the signalled state.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        public ulong D3D12FenceSignalValue => _d3d12FenceSignalValue;
+
+        /// <inheritdoc cref="GraphicsFence.GraphicsContext" />
+        public D3D12GraphicsContext D3D12GraphicsContext => (D3D12GraphicsContext)GraphicsContext;
+
+        /// <inheritdoc />
+        public override bool IsSignalled => D3D12Fence->GetCompletedValue() >= D3D12FenceSignalValue;
+
+        /// <inheritdoc />
+        public override void Reset()
+        {
+            if (IsSignalled)
+            {
+                _d3d12FenceSignalValue = D3D12Fence->GetCompletedValue() + 1;
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool TryWait(int millisecondsTimeout = -1)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            if (millisecondsTimeout < Timeout.Infinite)
+            {
+                ThrowArgumentOutOfRangeException(nameof(millisecondsTimeout), millisecondsTimeout);
+            }
+            return TryWait(unchecked((uint)millisecondsTimeout));
+        }
+
+        /// <inheritdoc />
+        public override bool TryWait(TimeSpan timeout)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            var remainingMilliseconds = (long)timeout.TotalMilliseconds;
+
+            if (remainingMilliseconds < Timeout.Infinite)
+            {
+                ThrowArgumentOutOfRangeException(nameof(timeout), timeout);
+            }
+
+            var fenceSignalled = false;
+
+            while (remainingMilliseconds > INFINITE)
+            {
+                const uint millisecondsTimeout = INFINITE - 1;
+
+                if (TryWait(millisecondsTimeout))
+                {
+                    fenceSignalled = true;
+                    break;
+                }
+
+                remainingMilliseconds -= millisecondsTimeout;
+            }
+
+            return fenceSignalled || TryWait(unchecked((uint)remainingMilliseconds));
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _d3d12Fence.Dispose(ReleaseIfNotNull);
+                _d3d12FenceSignalEvent.Dispose(DisposeEventHandle);
+            }
+
+            _state.EndDispose();
+        }
+
+        private Pointer<ID3D12Fence> CreateD3D12Fence()
+        {
+            _state.AssertNotDisposedOrDisposing();
+
+            ID3D12Fence* d3d12Fence;
+
+            var iid = IID_ID3D12Fence;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateFence), D3D12GraphicsContext.Device->CreateFence(InitialValue: 0, D3D12_FENCE_FLAG_NONE, &iid, (void**)&d3d12Fence));
+
+            return d3d12Fence;
+        }
+
+        private HANDLE CreateEventHandle()
+        {
+            _state.AssertNotDisposedOrDisposing();
+
+            HANDLE eventHandle = CreateEventW(lpEventAttributes: null, bManualReset: FALSE, bInitialState: FALSE, lpName: null);
+
+            if (eventHandle == null)
+            {
+                ThrowExternalExceptionForLastHRESULT(nameof(CreateEventW));
+            }
+
+            return eventHandle;
+        }
+
+        private void DisposeEventHandle(HANDLE eventHandle)
+        {
+            _state.AssertDisposing();
+
+            if (eventHandle != null)
+            {
+                _ = CloseHandle(eventHandle);
+            }
+        }
+
+        private bool TryWait(uint millisecondsTimeout)
+        {
+            _state.AssertNotDisposedOrDisposing();
+
+            var fenceSignalled = IsSignalled;
+
+            var fence = D3D12Fence;
+            var fenceSignalEvent = D3D12FenceSignalEvent;
+
+            if (!fenceSignalled)
+            {
+                ThrowExternalExceptionIfFailed(nameof(ID3D12Fence.SetEventOnCompletion), D3D12Fence->SetEventOnCompletion(D3D12FenceSignalValue, fenceSignalEvent));
+
+                var result = WaitForSingleObject(fenceSignalEvent, millisecondsTimeout);
+
+                if (result == WAIT_OBJECT_0)
+                {
+                    fenceSignalled = true;
+                }
+                else if (result != WAIT_TIMEOUT)
+                {
+                    ThrowExternalExceptionForLastError(nameof(WaitForSingleObject));
+                }
+            }
+
+            return fenceSignalled;
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/HelperUtilities.cs
+++ b/sources/Providers/Graphics/D3D12/HelperUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
 
 using TerraFX.Interop;
+using TerraFX.Utilities;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.ExceptionUtilities;
 
@@ -8,6 +9,9 @@ namespace TerraFX.Graphics.Providers.D3D12
 {
     internal static unsafe partial class HelperUtilities
     {
+        public static void ReleaseIfNotNull<TUnknown>(Pointer<TUnknown> unknown)
+            where TUnknown : unmanaged => ReleaseIfNotNull(unknown.Value);
+
         public static void ReleaseIfNotNull<TUnknown>(TUnknown* unknown)
             where TUnknown : unmanaged
         {

--- a/sources/Providers/Graphics/D3D12/HelperUtilities.cs
+++ b/sources/Providers/Graphics/D3D12/HelperUtilities.cs
@@ -1,7 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.	
 
 using TerraFX.Interop;
-using TerraFX.Utilities;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.ExceptionUtilities;
 
@@ -9,15 +8,6 @@ namespace TerraFX.Graphics.Providers.D3D12
 {
     internal static unsafe partial class HelperUtilities
     {
-        public static void ReleaseIfCreated<TUnknown>(ValueLazy<Pointer<TUnknown>> unknown)
-            where TUnknown : unmanaged
-        {
-            if (unknown.IsCreated)
-            {
-                ReleaseIfNotNull<TUnknown>(unknown.Value);
-            }
-        }
-
         public static void ReleaseIfNotNull<TUnknown>(TUnknown* unknown)
             where TUnknown : unmanaged
         {

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsAdapter.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsAdapter.cs
@@ -4,82 +4,93 @@ using System;
 using TerraFX.Interop;
 using TerraFX.Utilities;
 using static TerraFX.Interop.Vulkan;
-using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.InteropUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.Vulkan
 {
-    /// <inheritdoc cref="GraphicsAdapter" />
+    /// <inheritdoc />
     public sealed unsafe class VulkanGraphicsAdapter : GraphicsAdapter
     {
-        private readonly VkPhysicalDevice _physicalDevice;
+        private readonly VkPhysicalDevice _vulkanPhysicalDevice;
 
-        private ValueLazy<VkPhysicalDeviceProperties> _physicalDeviceProperties;
-        private ValueLazy<string> _deviceName;
+        private ValueLazy<VkPhysicalDeviceProperties> _vulkanPhysicalDeviceProperties;
+        private ValueLazy<string> _name;
 
         private State _state;
 
-        internal VulkanGraphicsAdapter(VulkanGraphicsProvider graphicsProvider, VkPhysicalDevice physicalDevice)
+        internal VulkanGraphicsAdapter(VulkanGraphicsProvider graphicsProvider, VkPhysicalDevice vulkanPhysicalDevice)
             : base(graphicsProvider)
         {
-            _physicalDevice = physicalDevice;
+            AssertNotNull(vulkanPhysicalDevice, nameof(vulkanPhysicalDevice));
 
-            _physicalDeviceProperties = new ValueLazy<VkPhysicalDeviceProperties>(GetPhysicalDeviceProperties);
-            _deviceName = new ValueLazy<string>(GetDeviceName);
+            _vulkanPhysicalDevice = vulkanPhysicalDevice;
+
+            _vulkanPhysicalDeviceProperties = new ValueLazy<VkPhysicalDeviceProperties>(GetVulkanPhysicalDeviceProperties);
+            _name = new ValueLazy<string>(GetName);
 
             _ = _state.Transition(to: Initialized);
         }
 
         /// <inheritdoc />
-        public override uint DeviceId => PhysicalDeviceProperties.deviceID;
+        public override uint DeviceId => VulkanPhysicalDeviceProperties.deviceID;
 
         /// <inheritdoc />
-        public override string DeviceName => _deviceName.Value;
+        public override string Name => _name.Value;
 
-        /// <summary>Gets the underlying <see cref="VkPhysicalDevice" />.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
-        public VkPhysicalDevice PhysicalDevice
+        /// <inheritdoc />
+        public override uint VendorId => VulkanPhysicalDeviceProperties.vendorID;
+
+        /// <inheritdoc cref="GraphicsAdapter.GraphicsProvider" />
+        public VulkanGraphicsProvider VulkanGraphicsProvider => (VulkanGraphicsProvider)GraphicsProvider;
+
+        /// <summary>Gets the underlying <see cref="VkPhysicalDevice" /> for the adapter.</summary>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed.</exception>
+        public VkPhysicalDevice VulkanPhysicalDevice
         {
             get
             {
                 _state.ThrowIfDisposedOrDisposing();
-                return _physicalDevice;
+                return _vulkanPhysicalDevice;
             }
         }
 
-        /// <summary>Gets the <see cref="VkPhysicalDeviceProperties" /> for <see cref="PhysicalDevice" />.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has been disposed and the value was not otherwise cached.</exception>
-        public ref readonly VkPhysicalDeviceProperties PhysicalDeviceProperties => ref _physicalDeviceProperties.RefValue;
+        /// <summary>Gets the <see cref="VkPhysicalDeviceProperties" /> for <see cref="VulkanPhysicalDevice" />.</summary>
+        /// <exception cref="ObjectDisposedException">The adapter has been disposed and the value was not otherwise cached.</exception>
+        public ref readonly VkPhysicalDeviceProperties VulkanPhysicalDeviceProperties => ref _vulkanPhysicalDeviceProperties.RefValue;
 
         /// <inheritdoc />
-        public override uint VendorId => PhysicalDeviceProperties.vendorID;
+        public override GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface) => CreateVulkanGraphicsContext(graphicsSurface);
 
-        /// <inheritdoc />
-        public override GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface)
+        /// <inheritdoc cref="CreateGraphicsContext(IGraphicsSurface)" />
+        public VulkanGraphicsContext CreateVulkanGraphicsContext(IGraphicsSurface graphicsSurface)
         {
             _state.ThrowIfDisposedOrDisposing();
-            ThrowIfNull(graphicsSurface, nameof(graphicsSurface));
             return new VulkanGraphicsContext(this, graphicsSurface);
         }
 
         /// <inheritdoc />
-        /// <remarks>While there are no unmanaged resources to cleanup, we still want to mark the instance as disposed if the <see cref="GraphicsProvider" /> was disposed or if the adapter no longer exists.</remarks>
+        /// <remarks>While there are no unmanaged resources to cleanup, we still want to mark the instance as disposed if, for example, <see cref="GraphicsAdapter.GraphicsProvider" /> was disposed.</remarks>
         protected override void Dispose(bool isDisposing)
         {
             _ = _state.BeginDispose();
             _state.EndDispose();
         }
 
-        private VkPhysicalDeviceProperties GetPhysicalDeviceProperties()
+        private string GetName()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return MarshalUtf8ToReadOnlySpan(in VulkanPhysicalDeviceProperties.deviceName[0], 256).AsString() ?? string.Empty;
+        }
+
+        private VkPhysicalDeviceProperties GetVulkanPhysicalDeviceProperties()
         {
             _state.ThrowIfDisposedOrDisposing();
 
             VkPhysicalDeviceProperties physicalDeviceProperties;
-            vkGetPhysicalDeviceProperties(PhysicalDevice, &physicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(VulkanPhysicalDevice, &physicalDeviceProperties);
             return physicalDeviceProperties;
         }
-
-        private string GetDeviceName() => MarshalUtf8ToReadOnlySpan(in PhysicalDeviceProperties.deviceName[0], 256).AsString() ?? string.Empty;
     }
 }

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsAdapter.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsAdapter.cs
@@ -61,13 +61,13 @@ namespace TerraFX.Graphics.Providers.Vulkan
         public ref readonly VkPhysicalDeviceProperties VulkanPhysicalDeviceProperties => ref _vulkanPhysicalDeviceProperties.RefValue;
 
         /// <inheritdoc />
-        public override GraphicsContext CreateGraphicsContext(IGraphicsSurface graphicsSurface) => CreateVulkanGraphicsContext(graphicsSurface);
+        public override GraphicsDevice CreateGraphicsDevice(IGraphicsSurface graphicsSurface) => CreateVulkanGraphicsDevice(graphicsSurface);
 
-        /// <inheritdoc cref="CreateGraphicsContext(IGraphicsSurface)" />
-        public VulkanGraphicsContext CreateVulkanGraphicsContext(IGraphicsSurface graphicsSurface)
+        /// <inheritdoc cref="CreateGraphicsDevice(IGraphicsSurface)" />
+        public VulkanGraphicsDevice CreateVulkanGraphicsDevice(IGraphicsSurface graphicsSurface)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new VulkanGraphicsContext(this, graphicsSurface);
+            return new VulkanGraphicsDevice(this, graphicsSurface);
         }
 
         /// <inheritdoc />

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
@@ -663,7 +663,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                         hwnd = GraphicsSurface.WindowHandle,
                     };
 
-                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(graphicsProvider.VulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
                     break;
                 }
 
@@ -677,7 +677,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                         window = (UIntPtr)(void*)GraphicsSurface.WindowHandle,
                     };
 
-                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(graphicsProvider.Instance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(graphicsProvider.VulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
                     break;
                 }
 
@@ -942,7 +942,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             if (_surface.IsCreated)
             {
                 var graphicsProvider = (VulkanGraphicsProvider)GraphicsAdapter.GraphicsProvider;
-                vkDestroySurfaceKHR(graphicsProvider.Instance, _surface.Value, pAllocator: null);
+                vkDestroySurfaceKHR(graphicsProvider.VulkanInstance, _surface.Value, pAllocator: null);
             }
         }
 

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
@@ -520,7 +520,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 ppEnabledExtensionNames = enabledExtensionNames,
                 pEnabledFeatures = &physicalDeviceFeatures,
             };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDevice), vkCreateDevice(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&device));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDevice), vkCreateDevice(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&device));
 
             return device;
         }
@@ -690,7 +690,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             }
 
             uint supported;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, GraphicsQueueFamilyIndex, surface, &supported));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, GraphicsQueueFamilyIndex, surface, &supported));
 
             if (supported == VK_FALSE)
             {
@@ -704,13 +704,13 @@ namespace TerraFX.Graphics.Providers.Vulkan
             VkSwapchainKHR swapChain;
 
             VkSurfaceCapabilitiesKHR surfaceCapabilities;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, Surface, &surfaceCapabilities));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceCapabilities));
 
             uint presentModeCount;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, Surface, &presentModeCount, pPresentModes: null));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &presentModeCount, pPresentModes: null));
 
             var presentModes = stackalloc VkPresentModeKHR[(int)presentModeCount];
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, Surface, &presentModeCount, presentModes));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &presentModeCount, presentModes));
 
             if (((uint)GraphicsSurface.BufferCount < surfaceCapabilities.minImageCount) ||
                 ((surfaceCapabilities.maxImageCount != 0) && ((uint)GraphicsSurface.BufferCount > surfaceCapabilities.maxImageCount)))
@@ -748,10 +748,10 @@ namespace TerraFX.Graphics.Providers.Vulkan
             }
 
             uint surfaceFormatCount;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, Surface, &surfaceFormatCount, pSurfaceFormats: null));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceFormatCount, pSurfaceFormats: null));
 
             var surfaceFormats = stackalloc VkSurfaceFormatKHR[(int)surfaceFormatCount];
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, Surface, &surfaceFormatCount, surfaceFormats));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceFormatCount, surfaceFormats));
 
             for (var i = 0u; i <surfaceFormatCount; i++)
             {
@@ -979,10 +979,10 @@ namespace TerraFX.Graphics.Providers.Vulkan
             var queueFamilyIndex = uint.MaxValue;
 
             uint queueFamilyPropertyCount;
-            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, &queueFamilyPropertyCount, pQueueFamilyProperties: null);
+            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &queueFamilyPropertyCount, pQueueFamilyProperties: null);
 
             var queueFamilyProperties = stackalloc VkQueueFamilyProperties[(int)queueFamilyPropertyCount];
-            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).PhysicalDevice, &queueFamilyPropertyCount, queueFamilyProperties);
+            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &queueFamilyPropertyCount, queueFamilyProperties);
 
             for (var i = 0u; i < queueFamilyPropertyCount; i++)
             {

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
@@ -1,99 +1,49 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using TerraFX.Interop;
 using TerraFX.Numerics;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
-using static TerraFX.Interop.VkAttachmentLoadOp;
-using static TerraFX.Interop.VkAttachmentStoreOp;
-using static TerraFX.Interop.VkColorSpaceKHR;
-using static TerraFX.Interop.VkCommandBufferLevel;
 using static TerraFX.Interop.VkCommandPoolCreateFlagBits;
 using static TerraFX.Interop.VkComponentSwizzle;
-using static TerraFX.Interop.VkCompositeAlphaFlagBitsKHR;
-using static TerraFX.Interop.VkFormat;
 using static TerraFX.Interop.VkImageAspectFlagBits;
-using static TerraFX.Interop.VkImageLayout;
-using static TerraFX.Interop.VkImageUsageFlagBits;
 using static TerraFX.Interop.VkImageViewType;
-using static TerraFX.Interop.VkPipelineBindPoint;
-using static TerraFX.Interop.VkPipelineStageFlagBits;
-using static TerraFX.Interop.VkPresentModeKHR;
-using static TerraFX.Interop.VkQueueFlagBits;
-using static TerraFX.Interop.VkResult;
-using static TerraFX.Interop.VkSampleCountFlagBits;
-using static TerraFX.Interop.VkSharingMode;
 using static TerraFX.Interop.VkStructureType;
 using static TerraFX.Interop.VkSubpassContents;
-using static TerraFX.Interop.VkSurfaceTransformFlagBitsKHR;
 using static TerraFX.Interop.Vulkan;
 using static TerraFX.Utilities.DisposeUtilities;
-using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.Vulkan
 {
-    /// <summary>Represents a graphics context, which can be used for rendering images.</summary>
+    /// <inheritdoc />
     public sealed unsafe class VulkanGraphicsContext : GraphicsContext
     {
-        private ValueLazy<VkSemaphore> _acquireNextImageSemaphore;
-        private ValueLazy<VkCommandBuffer[]> _commandBuffers;
-        private ValueLazy<VkCommandPool> _commandPool;
-        private ValueLazy<VkDevice> _device;
-        private ValueLazy<VkQueue> _deviceQueue;
-        private ValueLazy<VkFramebuffer[]> _frameBuffers;
-        private ValueLazy<uint> _graphicsQueueFamilyIndex;
-        private ValueLazy<VkSemaphore> _queueSubmitSemaphore;
-        private ValueLazy<VkRenderPass> _renderPass;
-        private ValueLazy<VkSurfaceKHR> _surface;
-        private ValueLazy<VkSwapchainKHR> _swapChain;
-        private ValueLazy<VkImageView[]> _swapChainImageViews;
+        private readonly VulkanGraphicsFence _graphicsFence;
+        private readonly VulkanGraphicsFence _waitForExecuteCompletionGraphicsFence;
 
-        private VulkanGraphicsFence[] _graphicsFences;
-        private uint _frameIndex;
-        private VkFormat _swapChainFormat;
+        private ValueLazy<VkCommandBuffer> _vulkanCommandBuffer;
+        private ValueLazy<VkCommandPool> _vulkanCommandPool;
+        private ValueLazy<VkFramebuffer> _vulkanFramebuffer;
+        private ValueLazy<VkImageView> _vulkanSwapChainImageView;
 
         private State _state;
 
-        internal VulkanGraphicsContext(VulkanGraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
-            : base(graphicsAdapter, graphicsSurface)
+        internal VulkanGraphicsContext(VulkanGraphicsDevice graphicsDevice, int index)
+            : base(graphicsDevice, index)
         {
-            _acquireNextImageSemaphore = new ValueLazy<VkSemaphore>(CreateAcquireNextImageSemaphore);
-            _commandBuffers = new ValueLazy<VkCommandBuffer[]>(CreateCommandBuffers);
-            _commandPool = new ValueLazy<VkCommandPool>(CreateCommandPool);
-            _device = new ValueLazy<VkDevice>(CreateDevice);
-            _deviceQueue = new ValueLazy<VkQueue>(CreateDeviceQueue);
-            _frameBuffers = new ValueLazy<VkFramebuffer[]>(CreateFrameBuffers);
-            _graphicsQueueFamilyIndex = new ValueLazy<uint>(FindGraphicsQueueFamilyIndex);
-            _queueSubmitSemaphore = new ValueLazy<VkSemaphore>(CreateQueueSubmitSemaphore);
-            _renderPass = new ValueLazy<VkRenderPass>(CreateRenderPass);
-            _surface = new ValueLazy<VkSurfaceKHR>(CreateSurface);
-            _swapChain = new ValueLazy<VkSwapchainKHR>(CreateSwapChain);
-            _swapChainImageViews = new ValueLazy<VkImageView[]>(CreateSwapChainImageViews);
+            _graphicsFence = new VulkanGraphicsFence(graphicsDevice);
+            _waitForExecuteCompletionGraphicsFence = new VulkanGraphicsFence(graphicsDevice);
 
-            _graphicsFences = CreateGraphicsFences(this, graphicsSurface);
+            _vulkanCommandBuffer = new ValueLazy<VkCommandBuffer>(CreateVulkanCommandBuffer);
+            _vulkanCommandPool = new ValueLazy<VkCommandPool>(CreateVulkanCommandPool);
+            _vulkanFramebuffer = new ValueLazy<VkFramebuffer>(CreateVulkanFramebuffer);
+            _vulkanSwapChainImageView = new ValueLazy<VkImageView>(CreateVulkanSwapChainImageView);
 
             _ = _state.Transition(to: Initialized);
 
-            // Do event hookups after we are in the initialized state, since an event could
-            // technically fire while the constructor is still running.
-
-            graphicsSurface.SizeChanged += HandleGraphicsSurfaceSizeChanged;
-
-            static VulkanGraphicsFence[] CreateGraphicsFences(VulkanGraphicsContext graphicsContext, IGraphicsSurface graphicsSurface)
-            {
-                var graphicsFences = new VulkanGraphicsFence[graphicsSurface.BufferCount];
-
-                for (var i = 0; i < graphicsFences.Length; i++)
-                {
-                    graphicsFences[i] = new VulkanGraphicsFence(graphicsContext);
-                }
-
-                return graphicsFences;
-            }
+            WaitForExecuteCompletionGraphicsFence.Reset();
         }
 
         /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsContext" /> class.</summary>
@@ -102,196 +52,70 @@ namespace TerraFX.Graphics.Providers.Vulkan
             Dispose(isDisposing: false);
         }
 
-        /// <summary>Gets a <c>vkSemaphore</c> for the <see cref="vkAcquireNextImageKHR(IntPtr, ulong, ulong, ulong, ulong, uint*)" /> method.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public ulong AcquireNextImageSemaphore
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _acquireNextImageSemaphore.Value;
-            }
-        }
+        /// <inheritdoc />
+        public override GraphicsFence GraphicsFence => VulkanGraphicsFence;
 
-        /// <summary>Gets an array of <c>VkCommandBuffer</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkCommandBuffer[] CommandBuffers
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _commandBuffers.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="VkCommandBuffer" /> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public VkCommandBuffer VulkanCommandBuffer => _vulkanCommandBuffer.Value;
 
-        /// <summary>Gets the <c>VkCommandPool</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkCommandPool CommandPool
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _commandPool.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="VkCommandPool" /> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public VkCommandPool VulkanCommandPool => _vulkanCommandPool.Value;
 
-        /// <summary>Gets the <c>VkDevice</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkDevice Device
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _device.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="VkFramebuffer"/> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public VkFramebuffer VulkanFramebuffer => _vulkanFramebuffer.Value;
 
-        /// <summary>Gets the <c>VkQueue</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkQueue DeviceQueue
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _deviceQueue.Value;
-            }
-        }
+        /// <inheritdoc cref="GraphicsContext.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
 
-        /// <summary>Gets an array of <c>VkFramebuffer</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkFramebuffer[] FrameBuffers
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _frameBuffers.Value;
-            }
-        }
+        /// <inheritdoc cref="GraphicsFence" />
+        public VulkanGraphicsFence VulkanGraphicsFence => _graphicsFence;
 
-        /// <summary>Gets the index of the graphics queue family for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public uint GraphicsQueueFamilyIndex
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _graphicsQueueFamilyIndex.Value;
-            }
-        }
+        /// <summary>Gets the <see cref="VkImageView" /> used by the context.</summary>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public VkImageView VulkanSwapChainImageView => _vulkanSwapChainImageView.Value;
 
-        /// <summary>Gets a <c>vkSemaphore</c> for the <see cref="vkQueueSubmit(IntPtr, uint, VkSubmitInfo*, ulong)" /> method.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkSemaphore QueueSubmitSemaphore
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _queueSubmitSemaphore.Value;
-            }
-        }
-
-        /// <summary>Gets the <c>VkRenderPass</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkRenderPass RenderPass
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _renderPass.Value;
-            }
-        }
-
-        /// <summary>Gets the <c>VkSurfaceKHR</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkSurfaceKHR Surface
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _surface.Value;
-            }
-        }
-
-        /// <summary>Gets the <c>VkSwapchainKHR</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkSwapchainKHR SwapChain
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _swapChain.Value;
-            }
-        }
-
-        /// <summary>Gets an array of <c>VkImageView</c> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VkImageView[] SwapChainImageViews
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _swapChainImageViews.Value;
-            }
-        }
-
-        /// <summary>Gets an array of <see cref="GraphicsFence" /> for the instance.</summary>
-        /// <exception cref="ObjectDisposedException">The instance has already been disposed.</exception>
-        public VulkanGraphicsFence[] VulkanGraphicsFences
-        {
-            get
-            {
-                _state.ThrowIfDisposedOrDisposing();
-                return _graphicsFences;
-            }
-        }
+        /// <summary>Gets a graphics fence that is used to wait for the context to finish execution.</summary>
+        public VulkanGraphicsFence WaitForExecuteCompletionGraphicsFence => _waitForExecuteCompletionGraphicsFence;
 
         /// <inheritdoc />
         public override void BeginFrame(ColorRgba backgroundColor)
         {
-            uint frameIndex;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkAcquireNextImageKHR), vkAcquireNextImageKHR(Device, SwapChain, timeout: ulong.MaxValue, AcquireNextImageSemaphore, fence: VK_NULL_HANDLE, &frameIndex));
-            _frameIndex = frameIndex;
-
-            var graphicsFence = VulkanGraphicsFences[frameIndex];
+            var graphicsFence = VulkanGraphicsFence;
 
             graphicsFence.Wait();
             graphicsFence.Reset();
 
             var commandBufferBeginInfo = new VkCommandBufferBeginInfo {
                 sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-                pNext = null,
-                flags = 0,
-                pInheritanceInfo = null,
             };
 
-            var commandBuffer = CommandBuffers[frameIndex];
+            var commandBuffer = VulkanCommandBuffer;
             ThrowExternalExceptionIfNotSuccess(nameof(vkBeginCommandBuffer), vkBeginCommandBuffer(commandBuffer, &commandBufferBeginInfo));
 
-            var clearValue = new VkClearValue {
-                depthStencil = new VkClearDepthStencilValue {
-                    depth = 0.0f,
-                    stencil = 0,
-                },
-            };
+            var clearValue = new VkClearValue();
 
             clearValue.color.float32[0] = backgroundColor.Red;
             clearValue.color.float32[1] = backgroundColor.Green;
             clearValue.color.float32[2] = backgroundColor.Blue;
             clearValue.color.float32[3] = backgroundColor.Alpha;
 
+            var graphicsDevice = VulkanGraphicsDevice;
+            var graphicsSurface = graphicsDevice.GraphicsSurface;
+
+            var graphicsSurfaceWidth = graphicsSurface.Width;
+            var graphicsSurfaceHeight = graphicsSurface.Height;
+
             var renderPassBeginInfo = new VkRenderPassBeginInfo {
                 sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-                pNext = null,
-                renderPass = RenderPass,
-                framebuffer = FrameBuffers[frameIndex],
+                renderPass = graphicsDevice.VulkanRenderPass,
+                framebuffer = VulkanFramebuffer,
                 renderArea = new VkRect2D {
-                    offset = new VkOffset2D {
-                        x = 0,
-                        y = 0,
-                    },
                     extent = new VkExtent2D {
-                        width = (uint)GraphicsSurface.Width,
-                        height = (uint)GraphicsSurface.Height,
+                        width = (uint)graphicsSurface.Width,
+                        height = (uint)graphicsSurface.Height,
                     },
                 },
                 clearValueCount = 1,
@@ -301,23 +125,17 @@ namespace TerraFX.Graphics.Providers.Vulkan
             vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
             var viewport = new VkViewport {
-                x = 0.0f,
-                y = 0.0f,
-                width = GraphicsSurface.Width,
-                height = GraphicsSurface.Height,
+                width = graphicsSurface.Width,
+                height = graphicsSurface.Height,
                 minDepth = 0.0f,
                 maxDepth = 1.0f,
             };
             vkCmdSetViewport(commandBuffer, firstViewport: 0, viewportCount: 1, &viewport);
 
             var scissorRect = new VkRect2D {
-                offset = new VkOffset2D {
-                    x = 0,
-                    y = 0,
-                },
                 extent = new VkExtent2D {
-                    width = (uint)GraphicsSurface.Width,
-                    height = (uint)GraphicsSurface.Height,
+                    width = (uint)graphicsSurface.Width,
+                    height = (uint)graphicsSurface.Height,
                 },
             };
             vkCmdSetScissor(commandBuffer, firstScissor: 0, scissorCount: 1, &scissorRect);
@@ -326,486 +144,22 @@ namespace TerraFX.Graphics.Providers.Vulkan
         /// <inheritdoc />
         public override void EndFrame()
         {
-            var frameIndex = _frameIndex;
-
-            var commandBuffer = CommandBuffers[frameIndex];
+            var commandBuffer = VulkanCommandBuffer;
             vkCmdEndRenderPass(commandBuffer);
 
-            var result = vkEndCommandBuffer(commandBuffer);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkEndCommandBuffer), (int)result);
-            }
-
-            var waitSemaphore = AcquireNextImageSemaphore;
-            var waitDstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-            var signalSemaphore = QueueSubmitSemaphore;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkEndCommandBuffer), vkEndCommandBuffer(commandBuffer));
 
             var submitInfo = new VkSubmitInfo {
                 sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-                pNext = null,
-                waitSemaphoreCount = 1,
-                pWaitSemaphores = &waitSemaphore,
-                pWaitDstStageMask = (uint*)&waitDstStageMask,
                 commandBufferCount = 1,
                 pCommandBuffers = (IntPtr*)&commandBuffer,
-                signalSemaphoreCount = 1,
-                pSignalSemaphores = (ulong*)&signalSemaphore
             };
 
-            result = vkQueueSubmit(DeviceQueue, submitCount: 1, &submitInfo, fence: VK_NULL_HANDLE);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkQueueSubmit), (int)result);
-            }
-        }
-
-        /// <inheritdoc />
-        public override void PresentFrame()
-        {
-            var frameIndex = _frameIndex;
-            var waitSemaphore = QueueSubmitSemaphore;
-            var swapChain = SwapChain;
-            var signalSemaphore = QueueSubmitSemaphore;
-
-            var presentInfo = new VkPresentInfoKHR {
-                sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-                pNext = null,
-                waitSemaphoreCount = 1,
-                pWaitSemaphores = (ulong*)&waitSemaphore,
-                swapchainCount = 1,
-                pSwapchains = (ulong*)&swapChain,
-                pImageIndices = &frameIndex,
-                pResults = null,
-            };
-
-            var result = vkQueuePresentKHR(DeviceQueue, &presentInfo);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkQueuePresentKHR), (int)result);
-            }
-
-            var graphicsFence = VulkanGraphicsFences[frameIndex];
-            result = vkQueueSubmit(DeviceQueue, submitCount: 0, pSubmits: null, graphicsFence.VulkanFence);
-
-            if (result != VK_SUCCESS)
-            {
-                ThrowExternalException(nameof(vkQueueSubmit), (int)result);
-            }
-        }
-
-        private VkSemaphore CreateAcquireNextImageSemaphore()
-        {
-            VkSemaphore acquireNextImageSemaphore;
-
-            var acquireNextImageSemaphoreCreateInfo = new VkSemaphoreCreateInfo {
-                sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-            };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &acquireNextImageSemaphoreCreateInfo, pAllocator: null, (ulong*)&acquireNextImageSemaphore));
-
-            return acquireNextImageSemaphore;
-        }
-
-        private VkCommandBuffer[] CreateCommandBuffers()
-        {
-            var commandBuffers = new VkCommandBuffer[(uint)GraphicsSurface.BufferCount];
-
-            var commandBufferAllocateInfo = new VkCommandBufferAllocateInfo {
-                sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-                pNext = null,
-                commandPool = CommandPool,
-                level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-                commandBufferCount = (uint)GraphicsSurface.BufferCount,
-            };
-
-            fixed (VkCommandBuffer* pCommandBuffers = commandBuffers)
-            {
-                ThrowExternalExceptionIfNotSuccess(nameof(vkAllocateCommandBuffers), vkAllocateCommandBuffers(Device, &commandBufferAllocateInfo, (IntPtr*)pCommandBuffers));
-            }
-
-            return commandBuffers;
-        }
-
-        private VkCommandPool CreateCommandPool()
-        {
-            VkCommandPool commandPool;
-
-            var commandPoolCreateInfo = new VkCommandPoolCreateInfo {
-                sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-                pNext = null,
-                flags = (uint)VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-                queueFamilyIndex = GraphicsQueueFamilyIndex,
-            };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateCommandPool), vkCreateCommandPool(Device, &commandPoolCreateInfo, pAllocator: null, (ulong*)&commandPool));
-
-            return commandPool;
-        }
-
-        private VkDevice CreateDevice()
-        {
-            VkDevice device;
-
-            var queuePriority = 1.0f;
-
-            var deviceQueueCreateInfo = new VkDeviceQueueCreateInfo {
-                sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                queueFamilyIndex = GraphicsQueueFamilyIndex,
-                queueCount = 1,
-                pQueuePriorities = &queuePriority,
-            };
-
-            var enabledExtensionCount = 1u;
-
-            var enabledExtensionNames = stackalloc sbyte*[(int)enabledExtensionCount];
-            enabledExtensionNames[0] = (sbyte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(VK_KHR_SWAPCHAIN_EXTENSION_NAME));
-
-            var physicalDeviceFeatures = new VkPhysicalDeviceFeatures {
-                robustBufferAccess = VK_FALSE,
-                fullDrawIndexUint32 = VK_FALSE,
-                imageCubeArray = VK_FALSE,
-                independentBlend = VK_FALSE,
-                geometryShader = VK_FALSE,
-                tessellationShader = VK_FALSE,
-                sampleRateShading = VK_FALSE,
-                dualSrcBlend = VK_FALSE,
-                logicOp = VK_FALSE,
-                multiDrawIndirect = VK_FALSE,
-                drawIndirectFirstInstance = VK_FALSE,
-                depthClamp = VK_FALSE,
-                depthBiasClamp = VK_FALSE,
-                fillModeNonSolid = VK_FALSE,
-                depthBounds = VK_FALSE,
-                wideLines = VK_FALSE,
-                largePoints = VK_FALSE,
-                alphaToOne = VK_FALSE,
-                multiViewport = VK_FALSE,
-                samplerAnisotropy = VK_FALSE,
-                textureCompressionETC2 = VK_FALSE,
-                textureCompressionASTC_LDR = VK_FALSE,
-                textureCompressionBC = VK_FALSE,
-                occlusionQueryPrecise = VK_FALSE,
-                pipelineStatisticsQuery = VK_FALSE,
-                vertexPipelineStoresAndAtomics = VK_FALSE,
-                fragmentStoresAndAtomics = VK_FALSE,
-                shaderTessellationAndGeometryPointSize = VK_FALSE,
-                shaderImageGatherExtended = VK_FALSE,
-                shaderStorageImageExtendedFormats = VK_FALSE,
-                shaderStorageImageMultisample = VK_FALSE,
-                shaderStorageImageReadWithoutFormat = VK_FALSE,
-                shaderStorageImageWriteWithoutFormat = VK_FALSE,
-                shaderUniformBufferArrayDynamicIndexing = VK_FALSE,
-                shaderSampledImageArrayDynamicIndexing = VK_FALSE,
-                shaderStorageBufferArrayDynamicIndexing = VK_FALSE,
-                shaderStorageImageArrayDynamicIndexing = VK_FALSE,
-                shaderClipDistance = VK_FALSE,
-                shaderCullDistance = VK_FALSE,
-                shaderFloat64 = VK_FALSE,
-                shaderInt64 = VK_FALSE,
-                shaderInt16 = VK_FALSE,
-                shaderResourceResidency = VK_FALSE,
-                shaderResourceMinLod = VK_FALSE,
-                sparseBinding = VK_FALSE,
-                sparseResidencyBuffer = VK_FALSE,
-                sparseResidencyImage2D = VK_FALSE,
-                sparseResidencyImage3D = VK_FALSE,
-                sparseResidency2Samples = VK_FALSE,
-                sparseResidency4Samples = VK_FALSE,
-                sparseResidency8Samples = VK_FALSE,
-                sparseResidency16Samples = VK_FALSE,
-                sparseResidencyAliased = VK_FALSE,
-                variableMultisampleRate = VK_FALSE,
-                inheritedQueries = VK_FALSE,
-            };
-
-            var deviceCreateInfo = new VkDeviceCreateInfo {
-                sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                queueCreateInfoCount = 1,
-                pQueueCreateInfos = &deviceQueueCreateInfo,
-                enabledLayerCount = 0,
-                ppEnabledLayerNames = null,
-                enabledExtensionCount = 1,
-                ppEnabledExtensionNames = enabledExtensionNames,
-                pEnabledFeatures = &physicalDeviceFeatures,
-            };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDevice), vkCreateDevice(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&device));
-
-            return device;
-        }
-
-        private VkQueue CreateDeviceQueue()
-        {
-            VkQueue deviceQueue;
-            vkGetDeviceQueue(Device, GraphicsQueueFamilyIndex, queueIndex: 0, (IntPtr*)&deviceQueue);
-            return deviceQueue;
-        }
-
-        private VkFramebuffer[] CreateFrameBuffers()
-        {
-            var frameBuffers = new VkFramebuffer[(uint)GraphicsSurface.BufferCount];
-            var attachments = stackalloc ulong[1];
-
-            var frameBufferCreateInfo = new VkFramebufferCreateInfo {
-                sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                renderPass = RenderPass,
-                attachmentCount = 1,
-                pAttachments = attachments,
-                width = (uint)GraphicsSurface.Width,
-                height = (uint)GraphicsSurface.Height,
-                layers = 1,
-            };
-
-            for (var i = 0; i < frameBuffers.Length; i++)
-            {
-                attachments[0] = SwapChainImageViews[i];
-
-                VkFramebuffer frameBuffer;
-                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateFramebuffer), vkCreateFramebuffer(Device, &frameBufferCreateInfo, pAllocator: null, (ulong*)&frameBuffer));
-                frameBuffers[i] = frameBuffer;
-            }
-
-            return frameBuffers;
-        }
-
-        private VkSemaphore CreateQueueSubmitSemaphore()
-        {
-            VkSemaphore queueSubmitSemaphore;
-
-            var queueSubmitSemaphoreCreateInfo = new VkSemaphoreCreateInfo {
-                sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-            };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSemaphore), vkCreateSemaphore(Device, &queueSubmitSemaphoreCreateInfo, pAllocator: null, (ulong*)&queueSubmitSemaphore));
-
-            return queueSubmitSemaphore;
-        }
-
-        private VkRenderPass CreateRenderPass()
-        {
-            VkRenderPass renderPass;
-
-            var attachment = new VkAttachmentDescription {
-                flags = 0,
-                format = _swapChainFormat,
-                samples = VK_SAMPLE_COUNT_1_BIT,
-                loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
-                storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-                stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-                finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-            };
-
-            var colorAttachment = new VkAttachmentReference {
-                attachment = 0,
-                layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-            };
-
-            var subpass = new VkSubpassDescription {
-                flags = 0,
-                pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
-                inputAttachmentCount = 0,
-                pInputAttachments = null,
-                colorAttachmentCount = 1,
-                pColorAttachments = &colorAttachment,
-                pResolveAttachments = null,
-                pDepthStencilAttachment = null,
-                preserveAttachmentCount = VK_FALSE,
-                pPreserveAttachments = null,
-            };
-
-            var renderPassCreateInfo = new VkRenderPassCreateInfo {
-                sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                attachmentCount = 1,
-                pAttachments = &attachment,
-                subpassCount = 1,
-                pSubpasses = &subpass,
-                dependencyCount = 0,
-                pDependencies = null,
-            };
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateRenderPass), vkCreateRenderPass(Device, &renderPassCreateInfo, pAllocator: null, (ulong*)&renderPass));
-
-            return renderPass;
-        }
-
-        private VkSurfaceKHR CreateSurface()
-        {
-            VkSurfaceKHR surface;
-
-            var graphicsProvider = (VulkanGraphicsProvider)GraphicsAdapter.GraphicsProvider;
-
-            switch (GraphicsSurface.Kind)
-            {
-                case GraphicsSurfaceKind.Win32:
-                {
-                    var surfaceCreateInfo = new VkWin32SurfaceCreateInfoKHR {
-                        sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
-                        pNext = null,
-                        flags = 0,
-                        hinstance = GraphicsSurface.DisplayHandle,
-                        hwnd = GraphicsSurface.WindowHandle,
-                    };
-
-                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(graphicsProvider.VulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
-                    break;
-                }
-
-                case GraphicsSurfaceKind.Xlib:
-                {
-                    var surfaceCreateInfo = new VkXlibSurfaceCreateInfoKHR {
-                        sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,
-                        pNext = null,
-                        flags = 0,
-                        dpy = (UIntPtr)(void*)GraphicsSurface.DisplayHandle,
-                        window = (UIntPtr)(void*)GraphicsSurface.WindowHandle,
-                    };
-
-                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(graphicsProvider.VulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&surface));
-                    break;
-                }
-
-                default:
-                {
-                    ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
-                    surface = VK_NULL_HANDLE;
-                    break;
-                }
-            }
-
-            uint supported;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, GraphicsQueueFamilyIndex, surface, &supported));
-
-            if (supported == VK_FALSE)
-            {
-                ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
-            }
-            return surface;
-        }
-
-        private VkSwapchainKHR CreateSwapChain()
-        {
-            VkSwapchainKHR swapChain;
-
-            VkSurfaceCapabilitiesKHR surfaceCapabilities;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceCapabilities));
-
-            uint presentModeCount;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &presentModeCount, pPresentModes: null));
-
-            var presentModes = stackalloc VkPresentModeKHR[(int)presentModeCount];
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &presentModeCount, presentModes));
-
-            if (((uint)GraphicsSurface.BufferCount < surfaceCapabilities.minImageCount) ||
-                ((surfaceCapabilities.maxImageCount != 0) && ((uint)GraphicsSurface.BufferCount > surfaceCapabilities.maxImageCount)))
-            {
-                ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
-            }
-
-            var swapChainCreateInfo = new VkSwapchainCreateInfoKHR {
-                sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
-                pNext = null,
-                flags = 0,
-                surface = Surface,
-                minImageCount = (uint)GraphicsSurface.BufferCount,
-                imageFormat = VK_FORMAT_UNDEFINED,
-                imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
-                imageExtent = new VkExtent2D {
-                    width = (uint)GraphicsSurface.Width,
-                    height = (uint)GraphicsSurface.Height,
-                },
-                imageArrayLayers = 1,
-                imageUsage = (uint)(VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT),
-                imageSharingMode = VK_SHARING_MODE_EXCLUSIVE,
-                queueFamilyIndexCount = 0,
-                pQueueFamilyIndices = null,
-                preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-                compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
-                presentMode = VK_PRESENT_MODE_FIFO_KHR,
-                clipped = VK_TRUE,
-                oldSwapchain = VK_NULL_HANDLE,
-            };
-
-            if ((surfaceCapabilities.supportedTransforms & (uint)VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) == 0)
-            {
-                swapChainCreateInfo.preTransform = surfaceCapabilities.currentTransform;
-            }
-
-            uint surfaceFormatCount;
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceFormatCount, pSurfaceFormats: null));
-
-            var surfaceFormats = stackalloc VkSurfaceFormatKHR[(int)surfaceFormatCount];
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, Surface, &surfaceFormatCount, surfaceFormats));
-
-            for (var i = 0u; i <surfaceFormatCount; i++)
-            {
-                if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_SRGB)
-                {
-                    swapChainCreateInfo.imageFormat = surfaceFormats[i].format;
-                    swapChainCreateInfo.imageColorSpace = surfaceFormats[i].colorSpace;
-                    break;
-                }
-            }
-            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSwapchainKHR), vkCreateSwapchainKHR(Device, &swapChainCreateInfo, pAllocator: null, (ulong*)&swapChain));
-
-            _swapChainFormat = swapChainCreateInfo.imageFormat;
-            return swapChain;
-        }
-
-        private VkImageView[] CreateSwapChainImageViews()
-        {
-            var swapChainImageCount = (uint)GraphicsSurface.BufferCount;
-            var swapChainImages = stackalloc VkImage[(int)swapChainImageCount];
-
-            ThrowExternalExceptionIfNotSuccess(nameof(vkGetSwapchainImagesKHR), vkGetSwapchainImagesKHR(Device, SwapChain, &swapChainImageCount, (ulong*)swapChainImages));
-
-            var swapChainImageViews = new VkImageView[swapChainImageCount];
-
-            var swapChainImageViewCreateInfo = new VkImageViewCreateInfo {
-                sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-                pNext = null,
-                flags = 0,
-                image = VK_NULL_HANDLE,
-                viewType = VK_IMAGE_VIEW_TYPE_2D,
-                format = _swapChainFormat,
-                components = new VkComponentMapping {
-                    r = VK_COMPONENT_SWIZZLE_R,
-                    g = VK_COMPONENT_SWIZZLE_G,
-                    b = VK_COMPONENT_SWIZZLE_B,
-                    a = VK_COMPONENT_SWIZZLE_A,
-                },
-                subresourceRange = new VkImageSubresourceRange {
-                    aspectMask = (uint)VK_IMAGE_ASPECT_COLOR_BIT,
-                    baseMipLevel = 0,
-                    levelCount = 1,
-                    baseArrayLayer = 0,
-                    layerCount = 1,
-                },
-            };
-
-            for (var i = 0; i < swapChainImageViews.Length; i++)
-            {
-                swapChainImageViewCreateInfo.image = swapChainImages[i];
-
-                VkImageView swapChainImageView;
-                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateImageView), vkCreateImageView(Device, &swapChainImageViewCreateInfo, pAllocator: null, (ulong*)&swapChainImageView));
-
-                swapChainImageViews[i] = swapChainImageView;
-            }
-
-            return swapChainImageViews;
+            var executeGraphicsFence = WaitForExecuteCompletionGraphicsFence;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkQueueSubmit), vkQueueSubmit(VulkanGraphicsDevice.VulkanCommandQueue, submitCount: 1, &submitInfo, executeGraphicsFence.VulkanFence));
+
+            executeGraphicsFence.Wait();
+            executeGraphicsFence.Reset();
         }
 
         /// <inheritdoc />
@@ -815,220 +169,160 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             if (priorState < Disposing)
             {
-                WaitForIdle();
-                DisposeQueueSubmitSemaphore();
-                DisposeAcquireNextImageSemaphore();
-                DisposeIfNotNull(_graphicsFences);
-                DisposeCommandBuffers();
-                DisposeCommandPool();
-                DisposeFrameBuffers();
-                DisposeSwapChainImageViews();
-                DisposeRenderPass();
-                DisposeSwapChain();
-                DisposeSurface();
-                DisposeDevice();
+                _vulkanCommandBuffer.Dispose(DisposeVulkanCommandBuffer);
+                _vulkanCommandPool.Dispose(DisposeVulkanCommandPool);
+                _vulkanFramebuffer.Dispose(DisposeVulkanFramebuffer);
+                _vulkanSwapChainImageView.Dispose(DisposeVulkanSwapChainImageView);
+
+                DisposeIfNotNull(_waitForExecuteCompletionGraphicsFence);
+                DisposeIfNotNull(_graphicsFence);
             }
 
             _state.EndDispose();
         }
 
-        private void DisposeAcquireNextImageSemaphore()
+        internal void OnGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> eventArgs)
         {
-            _state.AssertDisposing();
-
-            if (_acquireNextImageSemaphore.IsCreated)
+            if (_vulkanFramebuffer.IsCreated)
             {
-                vkDestroySemaphore(_device.Value, _acquireNextImageSemaphore.Value, pAllocator: null);
-            }
-        }
+                var vulkanFramebuffer = _vulkanFramebuffer.Value;
 
-        private void DisposeCommandBuffers()
-        {
-            _state.AssertDisposing();
-
-            if (_commandBuffers.IsCreated)
-            {
-                fixed (VkCommandBuffer* commandBuffers = _commandBuffers.Value)
+                if (vulkanFramebuffer != VK_NULL_HANDLE)
                 {
-                    vkFreeCommandBuffers(_device.Value, _commandPool.Value, (uint)GraphicsSurface.BufferCount, (IntPtr*)commandBuffers);
-                }
-            }
-        }
-
-        private void DisposeCommandPool()
-        {
-            _state.AssertDisposing();
-
-            if (_commandPool.IsCreated)
-            {
-                vkDestroyCommandPool(_device.Value, _commandPool.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeDevice()
-        {
-            _state.AssertDisposing();
-
-            if (_device.IsCreated)
-            {
-                vkDestroyDevice(_device.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeFrameBuffers()
-        {
-            _state.AssertDisposing();
-
-            if (_frameBuffers.IsCreated)
-            {
-                var frameBuffers = _frameBuffers.Value;
-
-                foreach (var frameBuffer in frameBuffers)
-                {
-                    if (frameBuffer != VK_NULL_HANDLE)
-                    {
-                        vkDestroyFramebuffer(_device.Value, frameBuffer, pAllocator: null);
-                    }
-                }
-            }
-        }
-
-        private void DisposeQueueSubmitSemaphore()
-        {
-            _state.AssertDisposing();
-
-            if (_queueSubmitSemaphore.IsCreated)
-            {
-                vkDestroySemaphore(_device.Value, _queueSubmitSemaphore.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeRenderPass()
-        {
-            _state.AssertDisposing();
-
-            if (_renderPass.IsCreated)
-            {
-                vkDestroyRenderPass(_device.Value, _renderPass.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeSurface()
-        {
-            _state.AssertDisposing();
-
-            if (_surface.IsCreated)
-            {
-                var graphicsProvider = (VulkanGraphicsProvider)GraphicsAdapter.GraphicsProvider;
-                vkDestroySurfaceKHR(graphicsProvider.VulkanInstance, _surface.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeSwapChain()
-        {
-            _state.AssertDisposing();
-
-            if (_swapChain.IsCreated)
-            {
-                vkDestroySwapchainKHR(_device.Value, _swapChain.Value, pAllocator: null);
-            }
-        }
-
-        private void DisposeSwapChainImageViews()
-        {
-            _state.AssertDisposing();
-
-            if (_swapChainImageViews.IsCreated)
-            {
-                var swapChainImageViews = _swapChainImageViews.Value;
-
-                foreach (var swapChainImageView in swapChainImageViews)
-                {
-                    if (swapChainImageView != VK_NULL_HANDLE)
-                    {
-                        vkDestroyImageView(_device.Value, swapChainImageView, pAllocator: null);
-                    }
-                }
-            }
-        }
-
-        private uint FindGraphicsQueueFamilyIndex()
-        {
-            var queueFamilyIndex = uint.MaxValue;
-
-            uint queueFamilyPropertyCount;
-            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &queueFamilyPropertyCount, pQueueFamilyProperties: null);
-
-            var queueFamilyProperties = stackalloc VkQueueFamilyProperties[(int)queueFamilyPropertyCount];
-            vkGetPhysicalDeviceQueueFamilyProperties(((VulkanGraphicsAdapter)GraphicsAdapter).VulkanPhysicalDevice, &queueFamilyPropertyCount, queueFamilyProperties);
-
-            for (var i = 0u; i < queueFamilyPropertyCount; i++)
-            {
-                if ((queueFamilyProperties[i].queueFlags & (uint)VK_QUEUE_GRAPHICS_BIT) != 0)
-                {
-                    queueFamilyIndex = i;
-                    break;
-                }
-            }
-
-            if (queueFamilyIndex == uint.MaxValue)
-            {
-                ThrowInvalidOperationException(nameof(queueFamilyIndex), queueFamilyIndex);
-            }
-            return queueFamilyIndex;
-        }
-
-        private void HandleGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> e)
-        {
-            WaitForIdle();
-
-            if (_frameBuffers.IsCreated)
-            {
-                var frameBuffers = _frameBuffers.Value;
-
-                foreach (var frameBuffer in frameBuffers)
-                {
-                    if (frameBuffer != VK_NULL_HANDLE)
-                    {
-                        vkDestroyFramebuffer(_device.Value, frameBuffer, pAllocator: null);
-                    }
+                    vkDestroyFramebuffer(VulkanGraphicsDevice.VulkanDevice, vulkanFramebuffer, pAllocator: null);
                 }
 
-                _frameBuffers.Reset(CreateFrameBuffers);
+                _vulkanFramebuffer.Reset(CreateVulkanFramebuffer);
             }
 
-            if (_swapChainImageViews.IsCreated)
+            if (_vulkanSwapChainImageView.IsCreated)
             {
-                var swapChainImageViews = _swapChainImageViews.Value;
+                var vulkanSwapChainImageView = _vulkanSwapChainImageView.Value;
 
-                foreach (var swapChainImageView in swapChainImageViews)
+                if (vulkanSwapChainImageView != VK_NULL_HANDLE)
                 {
-                    if (swapChainImageView != VK_NULL_HANDLE)
-                    {
-                        vkDestroyImageView(_device.Value, swapChainImageView, pAllocator: null);
-                    }
+                    vkDestroyImageView(VulkanGraphicsDevice.VulkanDevice, vulkanSwapChainImageView, pAllocator: null);
                 }
 
-                _swapChainImageViews.Reset(CreateSwapChainImageViews);
-            }
-
-            if (_swapChain.IsCreated)
-            {
-                vkDestroySwapchainKHR(_device.Value, _swapChain.Value, pAllocator: null);
-                _swapChain.Reset(CreateSwapChain);
+                _vulkanSwapChainImageView.Reset(CreateVulkanSwapChainImageView);
             }
         }
 
-        private void WaitForIdle()
+        private VkCommandBuffer CreateVulkanCommandBuffer()
         {
-            if (_device.IsCreated)
-            {
-                var result = vkDeviceWaitIdle(_device.Value);
+            VkCommandBuffer vulkanCommandBuffer;
 
-                if (result != VK_SUCCESS)
-                {
-                    ThrowExternalException(nameof(vkDeviceWaitIdle), (int)result);
-                }
+            var commandBufferAllocateInfo = new VkCommandBufferAllocateInfo {
+                sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+                commandPool = VulkanCommandPool,
+                commandBufferCount = 1,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAllocateCommandBuffers), vkAllocateCommandBuffers(VulkanGraphicsDevice.VulkanDevice, &commandBufferAllocateInfo, (IntPtr*)&vulkanCommandBuffer));
+
+            return vulkanCommandBuffer;
+        }
+
+        private VkCommandPool CreateVulkanCommandPool()
+        {
+            VkCommandPool vulkanCommandPool;
+
+            var commandPoolCreateInfo = new VkCommandPoolCreateInfo {
+                sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+                flags = (uint)VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+                queueFamilyIndex = VulkanGraphicsDevice.VulkanCommandQueueFamilyIndex,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateCommandPool), vkCreateCommandPool(VulkanGraphicsDevice.VulkanDevice, &commandPoolCreateInfo, pAllocator: null, (ulong*)&vulkanCommandPool));
+
+            return vulkanCommandPool;
+        }
+
+        private VkFramebuffer CreateVulkanFramebuffer()
+        {
+            VkFramebuffer vulkanFramebuffer;
+
+            var graphicsDevice = VulkanGraphicsDevice;
+            var graphicsSurface = graphicsDevice.GraphicsSurface;
+            var swapChainImageView = VulkanSwapChainImageView;
+
+            var frameBufferCreateInfo = new VkFramebufferCreateInfo {
+                sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+                renderPass = graphicsDevice.VulkanRenderPass,
+                attachmentCount = 1,
+                pAttachments = (ulong*)&swapChainImageView,
+                width = (uint)graphicsSurface.Width,
+                height = (uint)graphicsSurface.Height,
+                layers = 1,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateFramebuffer), vkCreateFramebuffer(graphicsDevice.VulkanDevice, &frameBufferCreateInfo, pAllocator: null, (ulong*)&vulkanFramebuffer));
+
+            return vulkanFramebuffer;
+        }
+
+        private VkImageView CreateVulkanSwapChainImageView()
+        {
+            VkImageView swapChainImageView;
+
+            var graphicsDevice = VulkanGraphicsDevice;
+
+            var swapChainImageViewCreateInfo = new VkImageViewCreateInfo {
+                sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+                image = graphicsDevice.VulkanSwapchainImages[Index],
+                viewType = VK_IMAGE_VIEW_TYPE_2D,
+                format = graphicsDevice.VulkanSwapchainFormat,
+                components = new VkComponentMapping {
+                    r = VK_COMPONENT_SWIZZLE_R,
+                    g = VK_COMPONENT_SWIZZLE_G,
+                    b = VK_COMPONENT_SWIZZLE_B,
+                    a = VK_COMPONENT_SWIZZLE_A,
+                },
+                subresourceRange = new VkImageSubresourceRange {
+                    aspectMask = (uint)VK_IMAGE_ASPECT_COLOR_BIT,
+                    levelCount = 1,
+                    layerCount = 1,
+                },
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateImageView), vkCreateImageView(graphicsDevice.VulkanDevice, &swapChainImageViewCreateInfo, pAllocator: null, (ulong*)&swapChainImageView));
+
+            return swapChainImageView;
+        }
+
+        private void DisposeVulkanCommandBuffer(VkCommandBuffer vulkanCommandBuffer)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanCommandBuffer != null)
+            {
+                vkFreeCommandBuffers(VulkanGraphicsDevice.VulkanDevice, VulkanCommandPool, 1, (IntPtr*)&vulkanCommandBuffer);
+            }
+        }
+
+        private void DisposeVulkanCommandPool(VkCommandPool vulkanCommandPool)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanCommandPool != VK_NULL_HANDLE)
+            {
+                vkDestroyCommandPool(VulkanGraphicsDevice.VulkanDevice, vulkanCommandPool, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanFramebuffer(VkFramebuffer vulkanFramebuffer)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanFramebuffer != VK_NULL_HANDLE)
+            {
+                vkDestroyFramebuffer(VulkanGraphicsDevice.VulkanDevice, vulkanFramebuffer, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanSwapChainImageView(VkImageView vulkanSwapchainImageView)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanSwapchainImageView != VK_NULL_HANDLE)
+            {
+                vkDestroyImageView(VulkanGraphicsDevice.VulkanDevice, vulkanSwapchainImageView, pAllocator: null);
             }
         }
     }

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -1,0 +1,506 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Numerics;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkAttachmentLoadOp;
+using static TerraFX.Interop.VkAttachmentStoreOp;
+using static TerraFX.Interop.VkColorSpaceKHR;
+using static TerraFX.Interop.VkCommandBufferLevel;
+using static TerraFX.Interop.VkCommandPoolCreateFlagBits;
+using static TerraFX.Interop.VkComponentSwizzle;
+using static TerraFX.Interop.VkCompositeAlphaFlagBitsKHR;
+using static TerraFX.Interop.VkFormat;
+using static TerraFX.Interop.VkImageAspectFlagBits;
+using static TerraFX.Interop.VkImageLayout;
+using static TerraFX.Interop.VkImageUsageFlagBits;
+using static TerraFX.Interop.VkImageViewType;
+using static TerraFX.Interop.VkPipelineBindPoint;
+using static TerraFX.Interop.VkPipelineStageFlagBits;
+using static TerraFX.Interop.VkPresentModeKHR;
+using static TerraFX.Interop.VkQueueFlagBits;
+using static TerraFX.Interop.VkResult;
+using static TerraFX.Interop.VkSampleCountFlagBits;
+using static TerraFX.Interop.VkSharingMode;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.VkSubpassContents;
+using static TerraFX.Interop.VkSurfaceTransformFlagBitsKHR;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsDevice : GraphicsDevice
+    {
+        private readonly VulkanGraphicsFence _presentCompletionGraphicsFence;
+
+        private ValueLazy<VkQueue> _vulkanCommandQueue;
+        private ValueLazy<uint> _vulkanCommandQueueFamilyIndex;
+        private ValueLazy<VkDevice> _vulkanDevice;
+        private ValueLazy<VkRenderPass> _vulkanRenderPass;
+        private ValueLazy<VkSurfaceKHR> _vulkanSurface;
+        private ValueLazy<VkSwapchainKHR> _vulkanSwapchain;
+        private ValueLazy<VkImage[]> _vulkanSwapchainImages;
+
+        private VulkanGraphicsContext[] _graphicsContexts;
+        private int _graphicsContextIndex;
+        private VkFormat _vulkanSwapchainFormat;
+
+        private State _state;
+
+        internal VulkanGraphicsDevice(VulkanGraphicsAdapter graphicsAdapter, IGraphicsSurface graphicsSurface)
+            : base(graphicsAdapter, graphicsSurface)
+        {
+            _presentCompletionGraphicsFence = new VulkanGraphicsFence(this);
+
+            _vulkanCommandQueue = new ValueLazy<VkQueue>(GetVulkanCommandQueue);
+            _vulkanCommandQueueFamilyIndex = new ValueLazy<uint>(GetVulkanCommandQueueFamilyIndex);
+            _vulkanDevice = new ValueLazy<VkDevice>(CreateVulkanDevice);
+            _vulkanRenderPass = new ValueLazy<VkRenderPass>(CreateVulkanRenderPass);
+            _vulkanSurface = new ValueLazy<VkSurfaceKHR>(CreateVulkanSurface);
+            _vulkanSwapchain = new ValueLazy<VkSwapchainKHR>(CreateVulkanSwapchain);
+            _vulkanSwapchainImages = new ValueLazy<VkImage[]>(GetVulkanSwapchainImages);
+
+            _graphicsContexts = CreateGraphicsContexts(this, graphicsSurface);
+
+            _ = _state.Transition(to: Initialized);
+
+            PresentCompletionGraphicsFence.Reset();
+            graphicsSurface.SizeChanged += OnGraphicsSurfaceSizeChanged;
+
+            static VulkanGraphicsContext[] CreateGraphicsContexts(VulkanGraphicsDevice graphicsDevice, IGraphicsSurface graphicsSurface)
+            {
+                var graphicsContexts = new VulkanGraphicsContext[graphicsSurface.BufferCount];
+
+                for (var index = 0; index < graphicsContexts.Length; index++)
+                {
+                    graphicsContexts[index] = new VulkanGraphicsContext(graphicsDevice, index);
+                }
+
+                return graphicsContexts;
+            }
+        }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<GraphicsContext> GraphicsContexts => _graphicsContexts;
+
+        /// <inheritdoc />
+        public override int GraphicsContextIndex => _graphicsContextIndex;
+
+        /// <summary>Gets a graphics fence that is used to wait for <see cref="PresentFrame" /> to complete.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VulkanGraphicsFence PresentCompletionGraphicsFence => _presentCompletionGraphicsFence;
+
+        /// <summary>Gets the <see cref="VkQueue" /> used by the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VkQueue VulkanCommandQueue => _vulkanCommandQueue.Value;
+
+        /// <summary>Gets the index of the queue family for <see cref="VulkanCommandQueue" />.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public uint VulkanCommandQueueFamilyIndex => _vulkanCommandQueueFamilyIndex.Value;
+
+        /// <summary>Gets the underlying <see cref="VkDevice"/> for the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VkDevice VulkanDevice => _vulkanDevice.Value;
+
+        /// <inheritdoc cref="GraphicsDevice.GraphicsAdapter" />
+        public VulkanGraphicsAdapter VulkanGraphicsAdapter => (VulkanGraphicsAdapter)GraphicsAdapter;
+
+        /// <inheritdoc cref="GraphicsContexts" />
+        public ReadOnlySpan<VulkanGraphicsContext> VulkanGraphicsContexts => _graphicsContexts;
+
+        /// <summary>Gets the <see cref="VkRenderPass" /> used by the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VkRenderPass VulkanRenderPass => _vulkanRenderPass.Value;
+
+        /// <summary>Gets the <see cref="VkSurfaceKHR" /> used by the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VkSurfaceKHR VulkanSurface => _vulkanSurface.Value;
+
+        /// <summary>Gets the <see cref="VkSwapchainKHR" /> used by the device.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public VkSwapchainKHR VulkanSwapchain => _vulkanSwapchain.Value;
+
+        /// <summary>Gets the <see cref="VkFormat" /> used by <see cref="VulkanSwapchain" />.</summary>
+        public VkFormat VulkanSwapchainFormat => _vulkanSwapchainFormat;
+
+        /// <summary>Gets a readonly span of the <see cref="VkImage" /> used by <see cref="VulkanSwapchain" />.</summary>
+        public ReadOnlySpan<VkImage> VulkanSwapchainImages => _vulkanSwapchainImages.Value;
+
+        /// <inheritdoc />
+        public override void PresentFrame()
+        {
+            var graphicsContextIndex = GraphicsContextIndex;
+            var vulkanSwapchain = VulkanSwapchain;
+
+            var presentInfo = new VkPresentInfoKHR {
+                sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+                swapchainCount = 1,
+                pSwapchains = (ulong*)&vulkanSwapchain,
+                pImageIndices = (uint*)&graphicsContextIndex,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkQueuePresentKHR), vkQueuePresentKHR(VulkanCommandQueue, &presentInfo));
+
+            var graphicsFence = VulkanGraphicsContexts[graphicsContextIndex].VulkanGraphicsFence;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkQueueSubmit), vkQueueSubmit(VulkanCommandQueue, submitCount: 0, pSubmits: null, graphicsFence.VulkanFence));
+
+            var presentCompletionGraphicsFence = PresentCompletionGraphicsFence;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAcquireNextImageKHR), vkAcquireNextImageKHR(VulkanDevice, vulkanSwapchain, timeout: ulong.MaxValue, semaphore: VK_NULL_HANDLE, presentCompletionGraphicsFence.VulkanFence, (uint*)&graphicsContextIndex));
+            
+            presentCompletionGraphicsFence.Wait();
+            presentCompletionGraphicsFence.Reset();
+
+            _graphicsContextIndex = graphicsContextIndex;
+        }
+
+        /// <inheritdoc />
+        public override void WaitForIdle()
+        {
+            if (_vulkanDevice.IsCreated)
+            {
+                var result = vkDeviceWaitIdle(_vulkanDevice.Value);
+
+                if (result != VK_SUCCESS)
+                {
+                    ThrowExternalException(nameof(vkDeviceWaitIdle), (int)result);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                WaitForIdle();
+                DisposeIfNotNull(_graphicsContexts);
+
+                _vulkanRenderPass.Dispose(DisposeVulkanRenderPass);
+                _vulkanSwapchain.Dispose(DisposeVulkanSwapchain);
+                _vulkanSurface.Dispose(DisposeVulkanSurface);
+
+                DisposeIfNotNull(_presentCompletionGraphicsFence);
+
+                _vulkanDevice.Dispose(DisposeVulkanDevice);
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkDevice CreateVulkanDevice()
+        {
+            VkDevice vulkanDevice;
+
+            var queuePriority = 1.0f;
+
+            var deviceQueueCreateInfo = new VkDeviceQueueCreateInfo {
+                sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+                queueFamilyIndex = VulkanCommandQueueFamilyIndex,
+                queueCount = 1,
+                pQueuePriorities = &queuePriority,
+            };
+
+            const int enabledExtensionNamesCount = 1;
+
+            var enabledExtensionNames = stackalloc sbyte*[enabledExtensionNamesCount] {
+                VK_KHR_SWAPCHAIN_EXTENSION_NAME.AsPointer(),
+            };
+
+            var physicalDeviceFeatures = new VkPhysicalDeviceFeatures();
+
+            var deviceCreateInfo = new VkDeviceCreateInfo {
+                sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+                queueCreateInfoCount = 1,
+                pQueueCreateInfos = &deviceQueueCreateInfo,
+                enabledExtensionCount = enabledExtensionNamesCount,
+                ppEnabledExtensionNames = enabledExtensionNames,
+                pEnabledFeatures = &physicalDeviceFeatures,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDevice), vkCreateDevice(VulkanGraphicsAdapter.VulkanPhysicalDevice, &deviceCreateInfo, pAllocator: null, (IntPtr*)&vulkanDevice));
+
+            return vulkanDevice;
+        }
+
+        private VkRenderPass CreateVulkanRenderPass()
+        {
+            VkRenderPass vulkanRenderPass;
+
+            // The swap chain needs to be created first to ensure we know the format
+            _ = VulkanSwapchain;
+
+            var attachmentDescription = new VkAttachmentDescription {
+                format = _vulkanSwapchainFormat,
+                samples = VK_SAMPLE_COUNT_1_BIT,
+                loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+                stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+            };
+
+            var colorAttachmentReference = new VkAttachmentReference {
+                layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            };
+
+            var subpass = new VkSubpassDescription {
+                pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+                colorAttachmentCount = 1,
+                pColorAttachments = &colorAttachmentReference,
+            };
+
+            var renderPassCreateInfo = new VkRenderPassCreateInfo {
+                sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+                attachmentCount = 1,
+                pAttachments = &attachmentDescription,
+                subpassCount = 1,
+                pSubpasses = &subpass,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateRenderPass), vkCreateRenderPass(VulkanDevice, &renderPassCreateInfo, pAllocator: null, (ulong*)&vulkanRenderPass));
+
+            return vulkanRenderPass;
+        }
+
+        private VkSurfaceKHR CreateVulkanSurface()
+        {
+            VkSurfaceKHR vulkanSurface;
+
+            var graphicsAdapter = VulkanGraphicsAdapter;
+            var vulkanInstance = graphicsAdapter.VulkanGraphicsProvider.VulkanInstance;
+
+            switch (GraphicsSurface.Kind)
+            {
+                case GraphicsSurfaceKind.Win32:
+                {
+                    var surfaceCreateInfo = new VkWin32SurfaceCreateInfoKHR {
+                        sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+                        hinstance = GraphicsSurface.DisplayHandle,
+                        hwnd = GraphicsSurface.WindowHandle,
+                    };
+
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateWin32SurfaceKHR), vkCreateWin32SurfaceKHR(vulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&vulkanSurface));
+                    break;
+                }
+
+                case GraphicsSurfaceKind.Xlib:
+                {
+                    var surfaceCreateInfo = new VkXlibSurfaceCreateInfoKHR {
+                        sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,
+                        dpy = (UIntPtr)(void*)GraphicsSurface.DisplayHandle,
+                        window = (UIntPtr)(void*)GraphicsSurface.WindowHandle,
+                    };
+
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateXlibSurfaceKHR), vkCreateXlibSurfaceKHR(vulkanInstance, &surfaceCreateInfo, pAllocator: null, (ulong*)&vulkanSurface));
+                    break;
+                }
+
+                default:
+                {
+                    ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
+                    vulkanSurface = VK_NULL_HANDLE;
+                    break;
+                }
+            }
+
+            uint supported;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceSupportKHR), vkGetPhysicalDeviceSurfaceSupportKHR(graphicsAdapter.VulkanPhysicalDevice, VulkanCommandQueueFamilyIndex, vulkanSurface, &supported));
+
+            if (supported == VK_FALSE)
+            {
+                ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
+            }
+            return vulkanSurface;
+        }
+
+        private VkSwapchainKHR CreateVulkanSwapchain()
+        {
+            VkSwapchainKHR vulkanSwapchain;
+
+            var vulkanPhysicalDevice = VulkanGraphicsAdapter.VulkanPhysicalDevice;
+            var vulkanSurface = VulkanSurface;
+
+            VkSurfaceCapabilitiesKHR surfaceCapabilities;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceCapabilitiesKHR), vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vulkanPhysicalDevice, vulkanSurface, &surfaceCapabilities));
+
+            uint presentModeCount;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanPhysicalDevice, vulkanSurface, &presentModeCount, pPresentModes: null));
+
+            var presentModes = stackalloc VkPresentModeKHR[(int)presentModeCount];
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfacePresentModesKHR), vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanPhysicalDevice, vulkanSurface, &presentModeCount, presentModes));
+
+            var graphicsSurface = GraphicsSurface;
+            var graphicsSurfaceBufferCount = unchecked((uint)graphicsSurface.BufferCount);
+
+            if ((graphicsSurfaceBufferCount < surfaceCapabilities.minImageCount) || ((surfaceCapabilities.maxImageCount != 0) && (graphicsSurfaceBufferCount > surfaceCapabilities.maxImageCount)))
+            {
+                ThrowArgumentOutOfRangeException(nameof(GraphicsSurface), GraphicsSurface);
+            }
+
+            var swapChainCreateInfo = new VkSwapchainCreateInfoKHR {
+                sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+                surface = vulkanSurface,
+                minImageCount = graphicsSurfaceBufferCount,
+                imageExtent = new VkExtent2D {
+                    width = (uint)graphicsSurface.Width,
+                    height = (uint)graphicsSurface.Height,
+                },
+                imageArrayLayers = 1,
+                imageUsage = (uint)(VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT),
+                preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+                compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+                presentMode = VK_PRESENT_MODE_FIFO_KHR,
+                clipped = VK_TRUE,
+            };
+
+            if ((surfaceCapabilities.supportedTransforms & (uint)VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) == 0)
+            {
+                swapChainCreateInfo.preTransform = surfaceCapabilities.currentTransform;
+            }
+
+            uint surfaceFormatCount;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanPhysicalDevice, VulkanSurface, &surfaceFormatCount, pSurfaceFormats: null));
+
+            var surfaceFormats = stackalloc VkSurfaceFormatKHR[(int)surfaceFormatCount];
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetPhysicalDeviceSurfaceFormatsKHR), vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanPhysicalDevice, VulkanSurface, &surfaceFormatCount, surfaceFormats));
+
+            for (uint i = 0; i < surfaceFormatCount; i++)
+            {
+                if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_SRGB)
+                {
+                    swapChainCreateInfo.imageFormat = surfaceFormats[i].format;
+                    swapChainCreateInfo.imageColorSpace = surfaceFormats[i].colorSpace;
+                    break;
+                }
+            }
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateSwapchainKHR), vkCreateSwapchainKHR(VulkanDevice, &swapChainCreateInfo, pAllocator: null, (ulong*)&vulkanSwapchain));
+
+            _vulkanSwapchainFormat = swapChainCreateInfo.imageFormat;
+            return vulkanSwapchain;
+        }
+
+        private void DisposeVulkanDevice(VkDevice vulkanDevice)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanDevice != null)
+            {
+                vkDestroyDevice(vulkanDevice, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanRenderPass(VkRenderPass vulkanRenderPass)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanRenderPass != VK_NULL_HANDLE)
+            {
+                vkDestroyRenderPass(VulkanDevice, vulkanRenderPass, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanSurface(VkSurfaceKHR vulkanSurface)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanSurface != VK_NULL_HANDLE)
+            {
+                vkDestroySurfaceKHR(VulkanGraphicsAdapter.VulkanGraphicsProvider.VulkanInstance, vulkanSurface, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanSwapchain(VkSwapchainKHR vulkanSwapchain)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanSwapchain != VK_NULL_HANDLE)
+            {
+                vkDestroySwapchainKHR(VulkanDevice, vulkanSwapchain, pAllocator: null);
+            }
+        }
+
+        private VkQueue GetVulkanCommandQueue()
+        {
+            VkQueue vulkanCommandQueue;
+            vkGetDeviceQueue(VulkanDevice, VulkanCommandQueueFamilyIndex, queueIndex: 0, (IntPtr*)&vulkanCommandQueue);
+            return vulkanCommandQueue;
+        }
+
+        private uint GetVulkanCommandQueueFamilyIndex()
+        {
+            var vulkanCommandQueueFamilyIndex = uint.MaxValue;
+
+            var vulkanPhysicalDevice = VulkanGraphicsAdapter.VulkanPhysicalDevice;
+
+            uint queueFamilyPropertyCount;
+            vkGetPhysicalDeviceQueueFamilyProperties(vulkanPhysicalDevice, &queueFamilyPropertyCount, pQueueFamilyProperties: null);
+
+            var queueFamilyProperties = stackalloc VkQueueFamilyProperties[(int)queueFamilyPropertyCount];
+            vkGetPhysicalDeviceQueueFamilyProperties(vulkanPhysicalDevice, &queueFamilyPropertyCount, queueFamilyProperties);
+
+            for (uint i = 0; i < queueFamilyPropertyCount; i++)
+            {
+                if ((queueFamilyProperties[i].queueFlags & (uint)VK_QUEUE_GRAPHICS_BIT) != 0)
+                {
+                    vulkanCommandQueueFamilyIndex = i;
+                    break;
+                }
+            }
+
+            if (vulkanCommandQueueFamilyIndex == uint.MaxValue)
+            {
+                ThrowInvalidOperationException(nameof(vulkanCommandQueueFamilyIndex), vulkanCommandQueueFamilyIndex);
+            }
+            return vulkanCommandQueueFamilyIndex;
+        }
+
+        private VkImage[] GetVulkanSwapchainImages()
+        {
+            var vulkanDevice = VulkanDevice;
+            var vulkanSwapchain = VulkanSwapchain;
+
+            uint swapchainImageCount;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkGetSwapchainImagesKHR), vkGetSwapchainImagesKHR(vulkanDevice, vulkanSwapchain, &swapchainImageCount, pSwapchainImages: null));
+
+            var vulkanSwapchainImages = new VkImage[swapchainImageCount];
+
+            fixed (VkImage* pVulkanSwapchainImages = vulkanSwapchainImages)
+            {
+                ThrowExternalExceptionIfNotSuccess(nameof(vkGetSwapchainImagesKHR), vkGetSwapchainImagesKHR(vulkanDevice, vulkanSwapchain, &swapchainImageCount, (ulong*)pVulkanSwapchainImages));
+            }
+
+            var presentCompletionGraphicsFence = PresentCompletionGraphicsFence;
+
+            int graphicsContextIndex;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAcquireNextImageKHR), vkAcquireNextImageKHR(VulkanDevice, vulkanSwapchain, timeout: ulong.MaxValue, semaphore: VK_NULL_HANDLE, presentCompletionGraphicsFence.VulkanFence, (uint*)&graphicsContextIndex));
+            _graphicsContextIndex = graphicsContextIndex;
+
+            presentCompletionGraphicsFence.Wait();
+            presentCompletionGraphicsFence.Reset();
+
+            return vulkanSwapchainImages;
+        }
+
+        private void OnGraphicsSurfaceSizeChanged(object? sender, PropertyChangedEventArgs<Vector2> eventArgs)
+        {
+            WaitForIdle();
+
+            foreach (var graphicsContext in VulkanGraphicsContexts)
+            {
+                graphicsContext.OnGraphicsSurfaceSizeChanged(sender, eventArgs);
+            }
+
+            if (_vulkanSwapchain.IsCreated)
+            {
+                vkDestroySwapchainKHR(_vulkanDevice.Value, _vulkanSwapchain.Value, pAllocator: null);
+                _vulkanSwapchain.Reset(CreateVulkanSwapchain);
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsFence.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsFence.cs
@@ -1,0 +1,144 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Threading;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkFenceCreateFlagBits;
+using static TerraFX.Interop.VkResult;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsFence : GraphicsFence
+    {
+        private ValueLazy<VkFence> _vulkanFence;
+
+        private State _state;
+
+        internal VulkanGraphicsFence(GraphicsContext graphicsContext)
+            : base(graphicsContext)
+        {
+            _vulkanFence = new ValueLazy<VkFence>(CreateVulkanFence);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsFence" /> class.</summary>
+        ~VulkanGraphicsFence()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <summary>Gets the underlying <see cref="VkFence" /> for the fence.</summary>
+        /// <exception cref="ObjectDisposedException">The fence has been disposed.</exception>
+        public VkFence VulkanFence => _vulkanFence.Value;
+
+        /// <inheritdoc cref="GraphicsFence.GraphicsContext" />
+        public VulkanGraphicsContext VulkanGraphicsContext => (VulkanGraphicsContext)GraphicsContext;
+
+        /// <inheritdoc />
+        public override bool IsSignalled => vkGetFenceStatus(VulkanGraphicsContext.Device, VulkanFence) == VK_SUCCESS;
+
+        /// <inheritdoc />
+        public override void Reset()
+        {
+            var vulkanFence = VulkanFence;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkResetFences), vkResetFences(VulkanGraphicsContext.Device, fenceCount: 1, (ulong*)&vulkanFence));
+        }
+
+        /// <inheritdoc />
+        public override bool TryWait(int millisecondsTimeout = -1)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            if (millisecondsTimeout < Timeout.Infinite)
+            {
+                ThrowArgumentOutOfRangeException(nameof(millisecondsTimeout), millisecondsTimeout);
+            }
+            return TryWait(unchecked((ulong)millisecondsTimeout));
+        }
+
+        /// <inheritdoc />
+        public override bool TryWait(TimeSpan timeout)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            var millisecondsTimeout = (long)timeout.TotalMilliseconds;
+
+            if (millisecondsTimeout < Timeout.Infinite)
+            {
+                ThrowArgumentOutOfRangeException(nameof(timeout), timeout);
+            }
+
+            return TryWait(unchecked((ulong)millisecondsTimeout));
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _vulkanFence.Dispose(DisposeVulkanFence);
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkFence CreateVulkanFence()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            var fenceCreateInfo = new VkFenceCreateInfo {
+                sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                pNext = null,
+                flags = (uint)VK_FENCE_CREATE_SIGNALED_BIT,
+            };
+
+            VkFence vulkanFence;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateFence), vkCreateFence(VulkanGraphicsContext.Device, &fenceCreateInfo, pAllocator: null, (ulong*)&vulkanFence));
+            return vulkanFence;
+        }
+
+        private void DisposeVulkanFence(VkFence vulkanFence)
+        {
+            _state.AssertDisposing();
+
+            if (vulkanFence != VK_NULL_HANDLE)
+            {
+                vkDestroyFence(VulkanGraphicsContext.Device, vulkanFence, pAllocator: null);
+            }
+        }
+
+        private bool TryWait(ulong millisecondsTimeout)
+        {
+            _state.AssertNotDisposedOrDisposing();
+
+            var fenceSignalled = IsSignalled;
+
+            if (!fenceSignalled)
+            {
+                var vulkanFence = VulkanFence;
+                var result = vkWaitForFences(VulkanGraphicsContext.Device, fenceCount: 1, (ulong*)&vulkanFence, waitAll: VK_TRUE, millisecondsTimeout);
+
+                if (result == VK_SUCCESS)
+                {
+                    fenceSignalled = true;
+                }
+                else if (result != VK_TIMEOUT)
+                {
+                    ThrowExternalException(nameof(vkWaitForFences), (int)result);
+                }
+            }
+
+            return fenceSignalled;
+        }
+    }
+}

--- a/sources/Utilities/AssertionUtilities.cs
+++ b/sources/Utilities/AssertionUtilities.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace TerraFX.Utilities
 {
     /// <summary>Provides a set of methods for asserting conditions.</summary>
-    public static class AssertionUtilities
+    public static unsafe class AssertionUtilities
     {
         /// <summary>Asserts that a condition is <c>true</c>.</summary>
         /// <param name="condition">The condition to assert.</param>
@@ -92,5 +92,11 @@ namespace TerraFX.Utilities
         [Conditional("DEBUG")]
         public static void AssertNotNull<T>([NotNull] T? value, string paramName)
             where T : class => Assert(value != null, Resources.ArgumentNullExceptionMessage, paramName);
+
+        /// <summary>Asserts that <paramref name="value" /> is not <c>null</c>.</summary>
+        /// <param name="value">The value to assert is not <c>null</c>.</param>
+        /// <param name="paramName">The name of the parameter being asserted.</param>
+        [Conditional("DEBUG")]
+        public static void AssertNotNull(void* value, string paramName) => Assert(value != null, Resources.ArgumentNullExceptionMessage, paramName);
     }
 }

--- a/sources/Utilities/DisposeUtilities.cs
+++ b/sources/Utilities/DisposeUtilities.cs
@@ -1,39 +1,13 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using static TerraFX.Utilities.AssertionUtilities;
 
 namespace TerraFX.Utilities
 {
     /// <summary>Provides a set of methods for disposing values.</summary>
     public static class DisposeUtilities
     {
-        /// <summary>Disposes of a <see cref="ValueLazy{T}" /> if <see cref="ValueLazy{T}.IsCreated" /> returns <c>true</c>.</summary>
-        /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The lazy <typeparamref name="T" /> to dispose.</param>
-        public static void DisposeIfCreated<T>(ValueLazy<T> value)
-            where T : IDisposable
-        {
-            if (value.IsCreated)
-            {
-                DisposeIfNotNull(value.Value);
-            }
-        }
-
-        /// <summary>Disposes of each element in a <see cref="ValueLazy{T}" /> if <see cref="ValueLazy{T}.IsCreated" /> returns <c>true</c>.</summary>
-        /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
-        /// <param name="values">The lazy <see cref="IEnumerable{T}" /> containing the values to dispose.</param>
-        public static void DisposeIfCreated<T>(ValueLazy<ImmutableArray<T>> values)
-            where T : IDisposable
-        {
-            if (values.IsCreated)
-            {
-                DisposeIfNotNull(values.Value);
-            }
-        }
-
         /// <summary>Disposes of a given <typeparamref name="T" /> if it is not <c>null</c>.</summary>
         /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
         /// <param name="value">The <typeparamref name="T" /> to dispose.</param>
@@ -46,15 +20,13 @@ namespace TerraFX.Utilities
             }
         }
 
-        /// <summary>Disposes of a each element in an <see cref="IEnumerable{T}" /> if that element is not <c>null</c>.</summary>
+        /// <summary>Disposes of a each element in an <see cref="ImmutableArray{T}" /> if that element is not <c>null</c>.</summary>
         /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
-        /// <param name="values">The <see cref="IEnumerable{T}" /> containing the values to dispose.</param>
-        public static void DisposeIfNotNull<T>(IEnumerable<T> values)
+        /// <param name="values">The <see cref="ImmutableArray{T}" /> containing the values to dispose.</param>
+        public static void DisposeIfNotDefault<T>(ImmutableArray<T> values)
             where T : IDisposable
         {
-            AssertNotNull(values, nameof(values));
-
-            if (values != null)
+            if (!values.IsDefault)
             {
                 foreach (var value in values)
                 {

--- a/sources/Utilities/DisposeUtilities.cs
+++ b/sources/Utilities/DisposeUtilities.cs
@@ -20,6 +20,21 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Disposes of a each element in a <typeparamref name="T" /> array if that element is not <c>null</c>.</summary>
+        /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
+        /// <param name="values">The <typeparamref name="T" /> array to dispose.</param>
+        public static void DisposeIfNotNull<T>(T[] values)
+            where T : IDisposable
+        {
+            if (values != null)
+            {
+                foreach (var value in values)
+                {
+                    DisposeIfNotNull(value);
+                }
+            }
+        }
+
         /// <summary>Disposes of a each element in an <see cref="ImmutableArray{T}" /> if that element is not <c>null</c>.</summary>
         /// <typeparam name="T">The type of elements in <paramref name="values" />.</typeparam>
         /// <param name="values">The <see cref="ImmutableArray{T}" /> containing the values to dispose.</param>

--- a/sources/Utilities/ExceptionUtilities.cs
+++ b/sources/Utilities/ExceptionUtilities.cs
@@ -162,6 +162,17 @@ namespace TerraFX.Utilities
             throw new ObjectDisposedException(objectName, message);
         }
 
+        /// <summary>Throws an instance of the <see cref="TimeoutException" /> class.</summary>
+        /// <param name="timeout">The timeout that was reached.</param>
+        /// <exception cref="TimeoutException">The timeout of <paramref name="timeout" /> was reached before the operation could be completed.</exception>
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowTimeoutException(TimeSpan timeout)
+        {
+            var message = string.Format(Resources.TimeoutExceptionMessage, timeout);
+            throw new TimeoutException(message);
+        }
+
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowArgumentNullException(string paramName)

--- a/sources/Utilities/ExceptionUtilities.cs
+++ b/sources/Utilities/ExceptionUtilities.cs
@@ -72,6 +72,19 @@ namespace TerraFX.Utilities
             throw new ExternalException(message, hresult);
         }
 
+        /// <summary>Throws a <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is <c>negative</c>.</summary>
+        /// <param name="value">The value to be checked if <c>negative</c>.</param>
+        /// <param name="paramName">The name of the parameter being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is <c>negative</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNegative(int value, string paramName)
+        {
+            if (value < 0)
+            {
+                ThrowArgumentOutOfRangeException(paramName, value);
+            }
+        }
+
         /// <summary>Throws a <see cref="ArgumentNullException" /> if <paramref name="value" /> is <c>null</c>.</summary>
         /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
         /// <param name="value">The value to be checked for <c>null</c>.</param>

--- a/sources/Utilities/Resources.cs
+++ b/sources/Utilities/Resources.cs
@@ -53,6 +53,9 @@ namespace TerraFX.Utilities
         /// <summary>Gets a localized <see cref="string" /> similar to <c>{0} is disposed</c>.</summary>
         public static string ObjectDisposedExceptionMessage => ResourceManager.GetString(nameof(ObjectDisposedExceptionMessage), Culture)!;
 
+        /// <summary>Gets a localized <see cref="string" /> similar to <c>The timeout of {0}  was reached before the operation could be completed</c>.</summary>
+        public static string TimeoutExceptionMessage => ResourceManager.GetString(nameof(ObjectDisposedExceptionMessage), Culture)!;
+
         /// <summary>Gets a localized <see cref="string" /> similar to <c>Invalid sample format</c>.</summary>
         public static string InvalidSampleFormatMessage => ResourceManager.GetString(nameof(InvalidSampleFormatMessage), Culture)!;
 

--- a/sources/Utilities/Resources.resx
+++ b/sources/Utilities/Resources.resx
@@ -144,6 +144,9 @@
   <data name="ObjectDisposedExceptionMessage" xml:space="preserve">
     <value>{0} is disposed</value>
   </data>
+  <data name="TimeoutExceptionMessage" xml:space="preserve">
+    <value>The timeout of {0} was reached before the operation could be completed</value>
+  </data>
   <data name="InvalidSampleFormatMessage" xml:space="preserve">
     <value>Invalid sample format</value>
   </data>

--- a/sources/Utilities/ValueLazy`1.cs
+++ b/sources/Utilities/ValueLazy`1.cs
@@ -5,14 +5,15 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
 
 namespace TerraFX.Utilities
 {
     /// <summary>Provides support for lazily initializing values.</summary>
     /// <typeparam name="T">The type of the value being lazily initialized.</typeparam>
-    public struct ValueLazy<T>
+    public struct ValueLazy<T> : IDisposable
     {
-        private const int Initialized = 1;
         private const int Creating = 2;
         private const int Created = 3;
 
@@ -25,7 +26,7 @@ namespace TerraFX.Utilities
         /// <exception cref="ArgumentNullException"><paramref name="factory" /> is <c>null</c>.</exception>
         public ValueLazy(Func<T> factory)
         {
-            this = default;
+            SkipInit(out this);
             Reset(factory);
         }
 
@@ -34,33 +35,77 @@ namespace TerraFX.Utilities
 
         /// <summary>Gets a reference to the underyling value for the instance.</summary>
         /// <remarks>This property is unsafe as it returns a reference to a struct field.</remarks>
+        /// <exception cref="ObjectDisposedException">The lazy value has been disposed.</exception>
         public ref T RefValue
         {
             get
             {
+                _state.AssertNotDisposedOrDisposing();
+
                 if (!IsCreated)
                 {
                     CreateValue();
                 }
+
                 return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref _value, 1));
             }
         }
 
         /// <summary>Gets the value for the instance.</summary>
-        public T Value => RefValue;
+        /// <exception cref="ObjectDisposedException">The lazy value has been disposed.</exception>
+        public T Value
+        {
+            get
+            {
+                _state.AssertNotDisposedOrDisposing();
+
+                if (!IsCreated)
+                {
+                    CreateValue();
+                }
+
+                return _value;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _ = _state.BeginDispose();
+            _state.EndDispose();
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="action">The action to call, if the value was created, which performs the appropriate disposal.</param>
+        public void Dispose(Action<T> action)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState == Created)
+            {
+                action(_value);
+            }
+
+            _state.EndDispose();
+        }
 
         /// <summary>Resets the instance so the value can be recreated.</summary>
         /// <param name="factory">The factory method to call when initializing the value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="factory" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The lazy value has been disposed.</exception>
         public void Reset(Func<T> factory)
         {
+            _state.ThrowIfDisposedOrDisposing();
             ThrowIfNull(factory, nameof(factory));
+
             _factory = factory;
             _ = _state.Transition(to: Initialized);
         }
 
         private void CreateValue()
         {
+            _state.ThrowIfDisposedOrDisposing();
+
             var spinWait = new SpinWait();
 
             while (!IsCreated)


### PR DESCRIPTION
This splits GraphicsContext into 3 parts:
* GraphicsDevice, which manages the overall state
* GraphicsFence, which manages fence state
* GraphicsContext, which has one instance per backbuffer and manages per frame state