### PR TITLE
Adding the capability to create and draw graphics primitives

### DIFF
--- a/samples/TerraFX/Graphics/HelloTriangle.cs
+++ b/samples/TerraFX/Graphics/HelloTriangle.cs
@@ -1,0 +1,121 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using TerraFX.ApplicationModel;
+using TerraFX.Graphics;
+using TerraFX.Numerics;
+using TerraFX.UI;
+using TerraFX.Utilities;
+
+namespace TerraFX.Samples.Graphics
+{
+    public sealed class HelloTriangle : Sample
+    {
+        private GraphicsDevice _graphicsDevice = null!;
+        private GraphicsPrimitive _trianglePrimitive = null!;
+        private Window _window = null!;
+        private TimeSpan _elapsedTime;
+
+        public HelloTriangle(string name, params Assembly[] compositionAssemblies)
+            : base(name, compositionAssemblies)
+        {
+        }
+
+        public override void Cleanup()
+        {
+            _trianglePrimitive?.Dispose();
+            _graphicsDevice?.Dispose();
+            _window?.Dispose();
+
+            base.Cleanup();
+        }
+
+        public override void Initialize(Application application)
+        {
+            ExceptionUtilities.ThrowIfNull(application, nameof(application));
+
+            var windowProvider = application.GetService<WindowProvider>();
+            _window = windowProvider.CreateWindow();
+            _window.Show();
+
+            var graphicsProvider = application.GetService<GraphicsProvider>();
+            var graphicsAdapter = graphicsProvider.GraphicsAdapters.First();
+
+            _graphicsDevice = graphicsAdapter.CreateGraphicsDevice(_window, graphicsContextCount: 2);
+            _trianglePrimitive = CreateTrianglePrimitive();
+            
+            base.Initialize(application);
+        }
+
+        protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
+        {
+            ExceptionUtilities.ThrowIfNull(sender, nameof(sender));
+
+            _elapsedTime += eventArgs.Delta;
+
+            if (_elapsedTime.TotalSeconds >= 2.5)
+            {
+                var application = (Application)sender;
+                application.RequestExit();
+            }
+
+            if (_window.IsVisible)
+            {
+                var graphicsDevice = _graphicsDevice;
+                var graphicsContext = graphicsDevice.GraphicsContexts[graphicsDevice.GraphicsContextIndex];
+
+                var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
+                graphicsContext.BeginFrame(backgroundColor);
+
+                graphicsContext.Draw(_trianglePrimitive);
+
+                graphicsContext.EndFrame();
+                graphicsDevice.PresentFrame();
+            }
+        }
+
+        private unsafe GraphicsPrimitive CreateTrianglePrimitive()
+        {
+            var graphicsDevice = _graphicsDevice;
+            var graphicsSurface = graphicsDevice.GraphicsSurface;
+
+            var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "VSMain", "PSMain");
+            var vertexBuffer = CreateVertexBuffer(graphicsDevice, aspectRatio: graphicsSurface.Width / graphicsSurface.Height);
+
+            return graphicsDevice.CreateGraphicsPrimitive(graphicsPipeline, vertexBuffer);
+
+            static GraphicsBuffer CreateVertexBuffer(GraphicsDevice graphicsDevice, float aspectRatio)
+            {
+                var vertexBuffer = graphicsDevice.CreateGraphicsBuffer(GraphicsBufferKind.Vertex, (ulong)(sizeof(IdentityVertex) * 3), (ulong)sizeof(IdentityVertex));
+
+                ReadOnlySpan<IdentityVertex> vertices = stackalloc IdentityVertex[3] {
+                    new IdentityVertex {
+                        Position = new Vector3(0.0f, 0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(1.0f, 0.0f, 0.0f, 1.0f)
+                    },
+                    new IdentityVertex {
+                        Position = new Vector3(0.25f, -0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(0.0f, 1.0f, 0.0f, 1.0f)
+                    },
+                    new IdentityVertex {
+                        Position = new Vector3(-0.25f, -0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(0.0f, 0.0f, 1.0f, 1.0f)
+                    },
+                };
+
+                vertexBuffer.Write(MemoryMarshal.AsBytes(vertices));
+                return vertexBuffer;
+            }
+
+            GraphicsPipeline CreateGraphicsPipeline(GraphicsDevice graphicsDevice, string shaderName, string vertexShaderEntryPoint, string pixelShaderEntryPoint)
+            {
+                var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, "Identity", "main");
+                var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, "Identity", "main");
+                return graphicsDevice.CreateGraphicsPipeline(vertexShader, pixelShader);
+            }
+        }
+    }
+}

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -14,17 +14,20 @@ namespace TerraFX.Samples
 {
     public static unsafe class Program
     {
-        private static readonly Assembly s_audioProviderPulseAudio = Assembly.LoadFrom("TerraFX.Audio.Providers.PulseAudio.dll");
+        internal static readonly Assembly s_audioProviderPulseAudio = Assembly.LoadFrom("TerraFX.Audio.Providers.PulseAudio.dll");
 
-        private static readonly Assembly s_graphicsProviderD3D12 = Assembly.LoadFrom("TerraFX.Graphics.Providers.D3D12.dll");
-        private static readonly Assembly s_graphicsProviderVulkan = Assembly.LoadFrom("TerraFX.Graphics.Providers.Vulkan.dll");
+        internal static readonly Assembly s_graphicsProviderD3D12 = Assembly.LoadFrom("TerraFX.Graphics.Providers.D3D12.dll");
+        internal static readonly Assembly s_graphicsProviderVulkan = Assembly.LoadFrom("TerraFX.Graphics.Providers.Vulkan.dll");
 
         private static readonly Sample[] s_samples = {
             new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_graphicsProviderD3D12),
             new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_graphicsProviderVulkan),
-
+            
             new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
             new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
+
+            new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
+            new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
 
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),

--- a/samples/TerraFX/Shared/Sample.cs
+++ b/samples/TerraFX/Shared/Sample.cs
@@ -1,22 +1,35 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using TerraFX.ApplicationModel;
+using TerraFX.Graphics;
+using TerraFX.Interop;
+using static TerraFX.Interop.D3DCompiler;
+using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples
 {
     public abstract class Sample
     {
-        private static readonly Assembly s_uiProviderWin32 = Assembly.LoadFrom("TerraFX.UI.Providers.Win32.dll");
-        private static readonly Assembly s_uiProviderXlib = Assembly.LoadFrom("TerraFX.UI.Providers.Xlib.dll");
+        internal static readonly Assembly s_uiProviderWin32 = Assembly.LoadFrom("TerraFX.UI.Providers.Win32.dll");
+        internal static readonly Assembly s_uiProviderXlib = Assembly.LoadFrom("TerraFX.UI.Providers.Xlib.dll");
 
+        private readonly string _assemblyPath;
         private readonly string _name;
         private readonly Assembly[] _compositionAssemblies;
 
         protected Sample(string name, Assembly[] compositionAssemblies)
         {
+            var entryAssembly = Assembly.GetEntryAssembly()!;
+            _assemblyPath = Path.GetDirectoryName(entryAssembly.Location)!;
+
             _name = name;
 
             _compositionAssemblies = new Assembly[compositionAssemblies.Length + 1];
@@ -24,6 +37,12 @@ namespace TerraFX.Samples
 
             Array.Copy(compositionAssemblies, 0, _compositionAssemblies, 1, compositionAssemblies.Length);
         }
+
+        // ps_5_0
+        private static ReadOnlySpan<sbyte> D3D12CompileTarget_ps_5_0 => new sbyte[] { 0x70, 0x73, 0x5F, 0x35, 0x5F, 0x30, 0x00 };
+
+        // vs_5_0
+        private static ReadOnlySpan<sbyte> D3D12CompileTarget_vs_5_0 => new sbyte[] { 0x76, 0x73, 0x5F, 0x35, 0x5F, 0x30, 0x00 };
 
         public Assembly[] CompositionAssemblies => _compositionAssemblies;
 
@@ -36,5 +55,132 @@ namespace TerraFX.Samples
         public virtual void Initialize(Application application) => application.Idle += OnIdle;
 
         protected abstract void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs);
+
+        protected unsafe GraphicsShader CompileShader(GraphicsDevice graphicsDevice, GraphicsShaderKind kind, string shaderName, string entryPointName)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _compositionAssemblies.Contains(Program.s_graphicsProviderD3D12))
+            {
+                var assetName = $"{shaderName}{kind}.hlsl";
+
+                fixed (char* assetPath = GetAssetFullPath("Shaders", assetName))
+                fixed (sbyte* entryPoint = MarshalStringToUtf8(entryPointName))
+                {
+                    var compileFlags = 0u;
+
+#if DEBUG
+                    // Enable better shader debugging with the graphics debugging tools.
+                    compileFlags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+#endif
+                    ID3DBlob* d3dShaderBlob = null;
+
+                    try
+                    {
+                        var result = D3DCompileFromFile((ushort*)assetPath, pDefines: null, (ID3DInclude*)D3D_COMPILE_STANDARD_FILE_INCLUDE, entryPoint, GetD3D12CompileTarget(kind).AsPointer(), compileFlags, Flags2: 0, &d3dShaderBlob, ppErrorMsgs: null);
+
+                        if (FAILED(result))
+                        {
+                            ThrowExternalException(nameof(D3DCompileFromFile), result);
+                        }
+
+                        var shaderBytecode = new ReadOnlySpan<byte>(d3dShaderBlob->GetBufferPointer(), (int)d3dShaderBlob->GetBufferSize());
+                        return graphicsDevice.CreateGraphicsShader(kind, shaderBytecode, entryPointName);
+                    }
+                    finally
+                    {
+                        if (d3dShaderBlob != null)
+                        {
+                            d3dShaderBlob->Release();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var assetName = $"{shaderName}{kind}.glsl";
+                var assetPath = GetAssetFullPath("Shaders", assetName);
+                var assetOutput = Path.ChangeExtension(assetPath, "spirv");
+
+                var additionalArgs = string.Empty;
+
+#if DEBUG
+                // Enable better shader debugging with the graphics debugging tools.
+                additionalArgs += $" -g -O0";
+#endif
+
+                var glslcProcessStartInfo = new ProcessStartInfo {
+                    Arguments = $"-fshader-stage={GetVulkanShaderStage(kind)} -o \"{assetOutput}\" -std=450core --target-env=vulkan1.0 --target-spv=spv1.0 -x glsl{additionalArgs} {assetPath}",
+                    FileName = "glslc.exe",
+                    WorkingDirectory = Path.GetDirectoryName(assetPath),
+                };
+                Process.Start(glslcProcessStartInfo).WaitForExit();
+
+                using var fileReader = File.OpenRead(assetOutput);
+
+                var bytecode = new byte[fileReader.Length];
+                _ = fileReader.Read(bytecode);
+
+                return graphicsDevice.CreateGraphicsShader(kind, bytecode, entryPointName);
+            }
+
+            static ReadOnlySpan<sbyte> GetD3D12CompileTarget(GraphicsShaderKind graphicsShaderKind)
+            {
+                ReadOnlySpan<sbyte> d3d12CompileTarget;
+
+                switch (graphicsShaderKind)
+                {
+                    case GraphicsShaderKind.Vertex:
+                    {
+                        d3d12CompileTarget = D3D12CompileTarget_vs_5_0;
+                        break;
+                    }
+
+                    case GraphicsShaderKind.Pixel:
+                    {
+                        d3d12CompileTarget = D3D12CompileTarget_ps_5_0;
+                        break;
+                    }
+
+                    default:
+                    {
+                        ThrowArgumentOutOfRangeException(nameof(graphicsShaderKind), graphicsShaderKind);
+                        d3d12CompileTarget = default;
+                        break;
+                    }
+                }
+
+                return d3d12CompileTarget;
+            }
+
+            static string GetVulkanShaderStage(GraphicsShaderKind graphicsShaderKind)
+            {
+                string vulkanShaderStage;
+
+                switch (graphicsShaderKind)
+                {
+                    case GraphicsShaderKind.Vertex:
+                    {
+                        vulkanShaderStage = "vertex";
+                        break;
+                    }
+
+                    case GraphicsShaderKind.Pixel:
+                    {
+                        vulkanShaderStage = "fragment";
+                        break;
+                    }
+
+                    default:
+                    {
+                        ThrowArgumentOutOfRangeException(nameof(graphicsShaderKind), graphicsShaderKind);
+                        vulkanShaderStage = string.Empty;
+                        break;
+                    }
+                }
+
+                return vulkanShaderStage;
+            }
+        }
+
+        private string GetAssetFullPath(string assetCategory, string assetName) => Path.Combine(_assemblyPath, "Assets", assetCategory, assetName);
     }
 }

--- a/samples/TerraFX/Vertices/IdentityVertex.cs
+++ b/samples/TerraFX/Vertices/IdentityVertex.cs
@@ -1,0 +1,12 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using TerraFX.Numerics;
+
+namespace TerraFX.Samples.Graphics
+{
+    public struct IdentityVertex
+    {
+        public Vector3 Position;
+        public Vector4 Color;
+    }
+}

--- a/sources/Graphics/Assets/Shaders/IdentityPixel.glsl
+++ b/sources/Graphics/Assets/Shaders/IdentityPixel.glsl
@@ -1,0 +1,11 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#version 450 core
+
+layout(location = 0) in vec4 input_color;
+layout(location = 0) out vec4 output_color;
+
+void main()
+{
+    output_color = input_color;
+}

--- a/sources/Graphics/Assets/Shaders/IdentityPixel.hlsl
+++ b/sources/Graphics/Assets/Shaders/IdentityPixel.hlsl
@@ -1,0 +1,8 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#include "IdentityTypes.hlsl"
+
+float4 main(PSInput input) : SV_Target
+{
+    return input.color;
+}

--- a/sources/Graphics/Assets/Shaders/IdentityTypes.hlsl
+++ b/sources/Graphics/Assets/Shaders/IdentityTypes.hlsl
@@ -1,0 +1,13 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+struct VSInput
+{
+    float3 position : POSITION;
+    float4 color : COLOR;
+};
+
+struct PSInput
+{
+    float4 position : SV_Position;
+    float4 color : COLOR;
+};

--- a/sources/Graphics/Assets/Shaders/IdentityVertex.glsl
+++ b/sources/Graphics/Assets/Shaders/IdentityVertex.glsl
@@ -1,0 +1,19 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#version 450 core
+
+layout(location = 0) in vec3 input_position;
+layout(location = 1) in vec4 input_color;
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+layout(location = 0) out vec4 output_color;
+
+void main()
+{
+    gl_Position = vec4(input_position, 1.0);
+    output_color = input_color;
+}

--- a/sources/Graphics/Assets/Shaders/IdentityVertex.hlsl
+++ b/sources/Graphics/Assets/Shaders/IdentityVertex.hlsl
@@ -1,0 +1,13 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#include "IdentityTypes.hlsl"
+
+PSInput main(VSInput input)
+{
+    PSInput output;
+
+    output.position = float4(input.position, 1.0f);
+    output.color = input.color;
+
+    return output;
+}

--- a/sources/Graphics/GraphicsBuffer.cs
+++ b/sources/Graphics/GraphicsBuffer.cs
@@ -1,0 +1,59 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics buffer which can hold data for a graphics device.</summary>
+    public abstract class GraphicsBuffer : IDisposable
+    {
+        private readonly ulong _size;
+        private readonly ulong _stride;
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly GraphicsBufferKind _kind;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsBuffer" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the buffer was created.</param>
+        /// <param name="kind">The buffer kind.</param>
+        /// <param name="size">The size, in bytes, of the buffer.</param>
+        /// <param name="stride">The size, in bytes, of the buffer elements.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        protected GraphicsBuffer(GraphicsDevice graphicsDevice, GraphicsBufferKind kind, ulong size, ulong stride)
+        {
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+
+            _size = size;
+            _stride = stride;
+            _graphicsDevice = graphicsDevice;
+            _kind = kind;
+        }
+
+        /// <summary>Gets the graphics device for which the buffer was created.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        /// <summary>Gets the kind of buffer.</summary>
+        public GraphicsBufferKind Kind => _kind;
+
+        /// <summary>Gets the size, in bytes, of the buffer.</summary>
+        public ulong Size => _size;
+
+        /// <summary>Gets the size, in bytes, of the buffer elements.</summary>
+        public ulong Stride => _stride;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>Writes a set of bytes into the buffer.</summary>
+        /// <param name="bytes">The bytes which to write.</param>
+        public abstract void Write(ReadOnlySpan<byte> bytes);
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsBufferKind.cs
+++ b/sources/Graphics/GraphicsBufferKind.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Graphics
+{
+    /// <summary>Defines a graphics buffer kind.</summary>
+    public enum GraphicsBufferKind
+    {
+        /// <summary>Defines an unknown graphics buffer kind.</summary>
+        Unknown,
+
+        /// <summary>Defines a vertex buffer.</summary>
+        Vertex,
+    }
+}

--- a/sources/Graphics/GraphicsContext.cs
+++ b/sources/Graphics/GraphicsContext.cs
@@ -25,7 +25,7 @@ namespace TerraFX.Graphics
             _index = index;
         }
 
-        /// <summary>Gets the <see cref="GraphicsDevice" /> for the instance.</summary>
+        /// <summary>Gets the <see cref="GraphicsDevice" /> for the context.</summary>
         public GraphicsDevice GraphicsDevice => _graphicsDevice;
 
         /// <summary>Gets the graphics fence used by the context for synchronization.</summary>
@@ -46,6 +46,12 @@ namespace TerraFX.Graphics
             Dispose(isDisposing: true);
             GC.SuppressFinalize(this);
         }
+
+        /// <summary>Draws a graphics primitive to the render surface.</summary>
+        /// <param name="graphicsPrimitive">The graphics primitive to draw.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsPrimitive" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+        public abstract void Draw(GraphicsPrimitive graphicsPrimitive);
 
         /// <summary>Ends the frame currently be rendered.</summary>
         /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>

--- a/sources/Graphics/GraphicsDevice.cs
+++ b/sources/Graphics/GraphicsDevice.cs
@@ -34,8 +34,48 @@ namespace TerraFX.Graphics
         /// <summary>Gets an index which can be used to lookup the current graphics context.</summary>
         public abstract int GraphicsContextIndex { get; }
 
-        /// <summary>Gets the <see cref="IGraphicsSurface" /> for the instance.</summary>
+        /// <summary>Gets the graphics surface on which the device can render.</summary>
         public IGraphicsSurface GraphicsSurface => _graphicsSurface;
+
+        /// <summary>Creates a new graphics buffer for the device.</summary>
+        /// <param name="kind">The kind of graphics buffer to create.</param>
+        /// <param name="size">The size, in bytes, of the graphics buffer.</param>
+        /// <param name="stride">The size, in bytes, of the graphics buffer elements.</param>
+        /// <returns>A new graphics buffer created for the device.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="kind" /> is unsupported.</exception>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride);
+
+        /// <summary>Creates a new graphics pipeline for the device.</summary>
+        /// <param name="vertexShader">The vertex shader for the graphics pipeline or <c>null</c> if none exists.</param>
+        /// <param name="pixelShader">The pixel shader for the graphics pipeline or <c>null</c> if none exists.</param>
+        /// <returns>A new graphics pipeline created for the device.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for this device.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> was not created for this device.</exception>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null);
+
+        /// <summary>Creates a new graphics primitive for the device.</summary>
+        /// <param name="graphicsPipeline">The graphics pipeline used for rendering the graphics primitive.</param>
+        /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the graphics primitive.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for this device.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for this device.</exception>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer);
+
+        /// <summary>Creates a new graphics shader for the device.</summary>
+        /// <param name="kind">The kind of graphics shader to create.</param>
+        /// <param name="bytecode">The underlying bytecode for the graphics shader.</param>
+        /// <param name="entryPointName">The name of the entry point for the graphics shader.</param>
+        /// <returns>A new graphics shader created for the device.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="entryPointName" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="kind" /> is unsupported.</exception>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName);
 
         /// <inheritdoc />
         public void Dispose()

--- a/sources/Graphics/GraphicsPipeline.cs
+++ b/sources/Graphics/GraphicsPipeline.cs
@@ -1,0 +1,69 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics pipeline which defines how a graphics primitive should be rendered.</summary>
+    public abstract class GraphicsPipeline : IDisposable
+    {
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly GraphicsShader? _vertexShader;
+        private readonly GraphicsShader? _pixelShader;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsPipeline" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the pipeline was created.</param>
+        /// <param name="vertexShader">The vertex shader for the pipeline or <c>null</c> if none  exists.</param>
+        /// <param name="pixelShader">The pixel shader for the pipeline or <c>null</c> if none exists.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for <paramref name="graphicsDevice" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" />was not created for <paramref name="graphicsDevice" />.</exception>
+        protected GraphicsPipeline(GraphicsDevice graphicsDevice, GraphicsShader? vertexShader, GraphicsShader? pixelShader)
+        {
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+
+            if ((vertexShader != null) && ((vertexShader.Kind != GraphicsShaderKind.Vertex) || (vertexShader.GraphicsDevice != graphicsDevice)))
+            {
+                ThrowArgumentOutOfRangeException(nameof(vertexShader), vertexShader);
+            }
+
+            if ((pixelShader != null) && ((pixelShader.Kind != GraphicsShaderKind.Pixel) || (pixelShader.GraphicsDevice != graphicsDevice)))
+            {
+                ThrowArgumentOutOfRangeException(nameof(pixelShader), pixelShader);;
+            }
+
+            _graphicsDevice = graphicsDevice;
+            _vertexShader = vertexShader;
+            _pixelShader = pixelShader;
+        }
+
+        /// <summary>Gets the graphics device for which the pipeline was created.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        /// <summary>Gets <c>true</c> if the pipeline has a pixel shader; otherwise, <c>false</c>.</summary>
+        public bool HasPixelShader => _pixelShader != null;
+
+        /// <summary>Gets <c>true</c> if the pipeline has a vertex shader; otherwise, <c>false</c>.</summary>
+        public bool HasVertexShader => _vertexShader != null;
+
+        /// <summary>Gets the pixel shader for the pipeline or <c>null</c> if none exists.</summary>
+        public GraphicsShader? PixelShader => _pixelShader;
+
+        /// <summary>Gets the vertex shader for the pipeline or <c>null</c> if none exists.</summary>
+        public GraphicsShader? VertexShader => _vertexShader;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsPrimitive.cs
+++ b/sources/Graphics/GraphicsPrimitive.cs
@@ -1,0 +1,64 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics primitive which represents the most basic renderable object.</summary>
+    public abstract class GraphicsPrimitive : IDisposable
+    {
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly GraphicsPipeline _graphicsPipeline;
+        private readonly GraphicsBuffer _vertexBuffer;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsPrimitive" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the primitive was created.</param>
+        /// <param name="graphicsPipeline">The graphics pipeline used for rendering the primitive.</param>
+        /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the primitive.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for <paramref name="graphicsDevice" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for <paramref name="graphicsDevice" />.</exception>
+        protected GraphicsPrimitive(GraphicsDevice graphicsDevice, GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer)
+        {
+            ThrowIfNull(graphicsPipeline, nameof(graphicsPipeline));
+            ThrowIfNull(vertexBuffer, nameof(vertexBuffer));
+
+            if (graphicsPipeline.GraphicsDevice != graphicsDevice)
+            {
+                ThrowArgumentOutOfRangeException(nameof(graphicsPipeline), graphicsPipeline);
+            }
+
+            if (vertexBuffer.GraphicsDevice != graphicsDevice)
+            {
+                ThrowArgumentOutOfRangeException(nameof(vertexBuffer), vertexBuffer);
+            }
+
+            _graphicsDevice = graphicsDevice;
+            _graphicsPipeline = graphicsPipeline;
+            _vertexBuffer = vertexBuffer;
+        }
+
+        /// <summary>Gets the graphics device for which the pipeline was created.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        /// <summary>Gets the graphics pipeline used for rendering the primitive.</summary>
+        public GraphicsPipeline GraphicsPipeline => _graphicsPipeline;
+
+        /// <summary>Gets the graphics buffer which holds the vertices for the primitive.</summary>
+        public GraphicsBuffer VertexBuffer => _vertexBuffer;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsShader.cs
+++ b/sources/Graphics/GraphicsShader.cs
@@ -1,0 +1,54 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics shader which performs a transformation for a graphics device.</summary>
+    public abstract class GraphicsShader : IDisposable
+    {
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly string _entryPointName;
+        private readonly GraphicsShaderKind _kind;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsShader" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the shader was created.</param>
+        /// <param name="kind">The shader kind.</param>
+        /// <param name="entryPointName">The name of the entry point for the shader.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="entryPointName" /> is <c>null</c>.</exception>
+        protected GraphicsShader(GraphicsDevice graphicsDevice, GraphicsShaderKind kind, string entryPointName)
+        {
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+            ThrowIfNull(entryPointName, nameof(entryPointName));
+
+            _graphicsDevice = graphicsDevice;
+            _entryPointName = entryPointName;
+            _kind = kind;
+        }
+
+        /// <summary>Gets the underlying bytecode for the shader.</summary>
+        public abstract ReadOnlySpan<byte> Bytecode { get; }
+
+        /// <summary>Gets the name of the entry point for the shader.</summary>
+        public string EntryPointName => _entryPointName;
+
+        /// <summary>Gets the graphics device for which the shader was created.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        /// <summary>Gets the kind of shader.</summary>
+        public GraphicsShaderKind Kind => _kind;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsShaderKind.cs
+++ b/sources/Graphics/GraphicsShaderKind.cs
@@ -1,0 +1,17 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Graphics
+{
+    /// <summary>Defines a graphics shader kind.</summary>
+    public enum GraphicsShaderKind
+    {
+        /// <summary>Defines an unknown graphics shader kind.</summary>
+        Unknown,
+
+        /// <summary>Defines a vertex shader which can transform vertices for a graphics device.</summary>
+        Vertex,
+
+        /// <summary>Defines a pixel shader which can transform pixels for a graphics device.</summary>
+        Pixel,
+    }
+}

--- a/sources/Graphics/TerraFX.Graphics.csproj
+++ b/sources/Graphics/TerraFX.Graphics.csproj
@@ -1,10 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="Assets\Shaders\IdentityTypes.hlsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\IdentityPixel.glsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\IdentityPixel.hlsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\IdentityVertex.glsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\IdentityVertex.hlsl" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Core\TerraFX.csproj" />

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsBuffer.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsBuffer.cs
@@ -1,0 +1,94 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D12;
+using static TerraFX.Interop.D3D12_HEAP_FLAGS;
+using static TerraFX.Interop.D3D12_HEAP_TYPE;
+using static TerraFX.Interop.D3D12_RESOURCE_STATES;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsBuffer : GraphicsBuffer
+    {
+        private ValueLazy<Pointer<ID3D12Resource>> _d3d12Resource;
+
+        private State _state;
+
+        internal D3D12GraphicsBuffer(D3D12GraphicsDevice graphicsDevice, GraphicsBufferKind kind, ulong size, ulong stride)
+            : base(graphicsDevice, kind, size, stride)
+        {
+            _d3d12Resource = new ValueLazy<Pointer<ID3D12Resource>>(CreateD3D12Resource);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <inheritdoc cref="GraphicsBuffer.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="ID3D12Resource" /> where the buffer exists.</summary>
+        /// <exception cref="ExternalException">The call to <see cref="ID3D12Device.CreateCommittedResource(D3D12_HEAP_PROPERTIES*, D3D12_HEAP_FLAGS, D3D12_RESOURCE_DESC*, D3D12_RESOURCE_STATES, D3D12_CLEAR_VALUE*, Guid*, void**)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+        public ID3D12Resource* D3D12Resource => _d3d12Resource.Value;
+
+        /// <inheritdoc />
+        /// <exception cref="ExternalException">The call to <see cref="ID3D12Resource.Map(uint, D3D12_RANGE*, void**)" /> failed.</exception>
+        public override void Write(ReadOnlySpan<byte> bytes)
+        {
+            var d3d12Resource = D3D12Resource;
+            var bytesWritten = bytes.Length;
+
+            var readRange = new D3D12_RANGE();
+            var writtenRange = new D3D12_RANGE(UIntPtr.Zero, (UIntPtr)bytesWritten);
+
+            void* pDestination;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Resource.Map), d3d12Resource->Map(Subresource: 0, &readRange, &pDestination));
+
+            var destination = new Span<byte>(pDestination, bytesWritten);
+            bytes.CopyTo(destination);
+
+            d3d12Resource->Unmap(Subresource: 0, &writtenRange);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _d3d12Resource.Dispose(ReleaseIfNotNull);
+            }
+
+            _state.EndDispose();
+        }
+
+        private Pointer<ID3D12Resource> CreateD3D12Resource()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3D12Resource* d3d12Resource;
+
+            var heapProperties = new D3D12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+            var bufferDesc = D3D12_RESOURCE_DESC.Buffer(width: Size);
+            
+            var iid = IID_ID3D12Resource;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateCommittedResource), D3D12GraphicsDevice.D3D12Device->CreateCommittedResource(
+                &heapProperties,
+                D3D12_HEAP_FLAG_NONE,
+                &bufferDesc,
+                D3D12_RESOURCE_STATE_GENERIC_READ,
+                pOptimizedClearValue: null,
+                &iid,
+                (void**)&d3d12Resource
+            ));
+
+            return d3d12Resource;
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -100,6 +100,46 @@ namespace TerraFX.Graphics.Providers.D3D12
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
         public D3D12GraphicsFence WaitForIdleGraphicsFence => _idleGraphicsFence;
 
+        /// <inheritdoc cref="CreateGraphicsBuffer(GraphicsBufferKind, ulong, ulong)" />
+        public D3D12GraphicsBuffer CreateD3D12GraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new D3D12GraphicsBuffer(this, kind, size, stride);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader, GraphicsShader)" />
+        public D3D12GraphicsPipeline CreateD3D12GraphicsPipeline(D3D12GraphicsShader? vertexShader = null, D3D12GraphicsShader? pixelShader = null)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new D3D12GraphicsPipeline(this, vertexShader, pixelShader);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer)" />
+        public D3D12GraphicsPrimitive CreateD3D12GraphicsPrimitive(D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new D3D12GraphicsPrimitive(this, graphicsPipeline, vertexBuffer);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
+        public D3D12GraphicsShader CreateD3D12GraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new D3D12GraphicsShader(this, kind, bytecode, entryPointName);
+        }
+
+        /// <inheritdoc />
+        public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateD3D12GraphicsBuffer(kind, size, stride);
+
+        /// <inheritdoc />
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsShader?)vertexShader, (D3D12GraphicsShader?)pixelShader);
+
+        /// <inheritdoc />
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer);
+
+        /// <inheritdoc />
+        public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateD3D12GraphicsShader(kind, bytecode, entryPointName);
+
         /// <inheritdoc />
         public override void PresentFrame()
         {

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
@@ -1,0 +1,167 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D_ROOT_SIGNATURE_VERSION;
+using static TerraFX.Interop.D3D12;
+using static TerraFX.Interop.D3D12_PRIMITIVE_TOPOLOGY_TYPE;
+using static TerraFX.Interop.D3D12_ROOT_SIGNATURE_FLAGS;
+using static TerraFX.Interop.DXGI_FORMAT;
+using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsPipeline : GraphicsPipeline
+    {
+        private ValueLazy<Pointer<ID3D12PipelineState>> _d3d12PipelineState;
+        private ValueLazy<Pointer<ID3D12RootSignature>> _d3d12RootSignature;
+
+        private State _state;
+
+        internal D3D12GraphicsPipeline(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsShader? vertexShader, D3D12GraphicsShader? pixelShader)
+            : base(graphicsDevice, vertexShader, pixelShader)
+        {
+            _d3d12PipelineState = new ValueLazy<Pointer<ID3D12PipelineState>>(CreateD3D12GraphicsPipelineState);
+            _d3d12RootSignature = new ValueLazy<Pointer<ID3D12RootSignature>>(CreateD3D12RootSignature);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsPipeline" /> class.</summary>
+        ~D3D12GraphicsPipeline()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        // COLOR
+        private static ReadOnlySpan<sbyte> COLOR_SEMANTIC_NAME => new sbyte[] { 0x43, 0x4F, 0x4C, 0x4F, 0x52, 0x00 };
+
+        // POSITION
+        private static ReadOnlySpan<sbyte> POSITION_SEMANTIC_NAME => new sbyte[] { 0x50, 0x4F, 0x53, 0x49, 0x54, 0x49, 0x4F, 0x4E, 0x00 };
+
+        /// <inheritdoc cref="GraphicsPipeline.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="ID3D12PipelineState" /> for the pipeline.</summary>
+        public ID3D12PipelineState* D3D12PipelineState => _d3d12PipelineState.Value;
+
+        /// <inheritdoc cref="GraphicsPipeline.PixelShader" />
+        public D3D12GraphicsShader? D3D12PixelShader => (D3D12GraphicsShader?)PixelShader;
+
+        /// <summary>Gets the underlying <see cref="ID3D12RootSignature" /> for the pipeline.</summary>
+        public ID3D12RootSignature* D3D12RootSignature => _d3d12RootSignature.Value;
+
+        /// <inheritdoc cref="GraphicsPipeline.VertexShader" />
+        public D3D12GraphicsShader? D3D12VertexShader => (D3D12GraphicsShader?)VertexShader;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _d3d12PipelineState.Dispose(ReleaseIfNotNull);
+                _d3d12RootSignature.Dispose(ReleaseIfNotNull);
+
+                DisposeIfNotNull(PixelShader);
+                DisposeIfNotNull(VertexShader);
+            }
+
+            _state.EndDispose();
+        }
+
+        private Pointer<ID3D12PipelineState> CreateD3D12GraphicsPipelineState()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3D12PipelineState* d3d12GraphicsPipelineState;
+
+            var inputElementDescs = Array.Empty<D3D12_INPUT_ELEMENT_DESC>();
+
+            var graphicsPipelineStateDesc = new D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+                pRootSignature = D3D12RootSignature,
+                RasterizerState = D3D12_RASTERIZER_DESC.DEFAULT,
+                BlendState = D3D12_BLEND_DESC.DEFAULT,
+                DepthStencilState = D3D12_DEPTH_STENCIL_DESC.DEFAULT,
+                SampleMask = uint.MaxValue,
+                PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+                NumRenderTargets = 1,
+                SampleDesc = new DXGI_SAMPLE_DESC(count: 1, quality: 0),
+            };
+            graphicsPipelineStateDesc.DepthStencilState.DepthEnable = FALSE;
+            graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+
+            var vertexShader = D3D12VertexShader;
+
+            if (vertexShader != null)
+            {
+                inputElementDescs = new D3D12_INPUT_ELEMENT_DESC[2] {
+                    new D3D12_INPUT_ELEMENT_DESC {
+                        SemanticName = POSITION_SEMANTIC_NAME.AsPointer(),
+                        Format = DXGI_FORMAT_R32G32B32_FLOAT,
+                    },
+                    new D3D12_INPUT_ELEMENT_DESC {
+                        SemanticName = COLOR_SEMANTIC_NAME.AsPointer(),
+                        Format = DXGI_FORMAT_R32G32B32A32_FLOAT,
+                        AlignedByteOffset = sizeof(float) * 3,
+                    }
+                };
+
+                graphicsPipelineStateDesc.VS = vertexShader.D3D12ShaderBytecode;
+            }
+
+            var pixelShader = D3D12PixelShader;
+
+            if (pixelShader != null)
+            {
+                graphicsPipelineStateDesc.PS = pixelShader.D3D12ShaderBytecode;
+            }
+
+            fixed (D3D12_INPUT_ELEMENT_DESC* pInputElementDescs = inputElementDescs)
+            {
+                graphicsPipelineStateDesc.InputLayout = new D3D12_INPUT_LAYOUT_DESC {
+                    pInputElementDescs = pInputElementDescs,
+                    NumElements = unchecked((uint)inputElementDescs.Length),
+                };
+
+                var iid = IID_ID3D12PipelineState;
+                ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateGraphicsPipelineState), D3D12GraphicsDevice.D3D12Device->CreateGraphicsPipelineState(&graphicsPipelineStateDesc, &iid, (void**)&d3d12GraphicsPipelineState));
+            }
+            return d3d12GraphicsPipelineState;
+        }
+
+        private Pointer<ID3D12RootSignature> CreateD3D12RootSignature()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3DBlob* rootSignatureBlob = null;
+            ID3DBlob* rootSignatureErrorBlob = null;
+
+            try
+            {
+                ID3D12RootSignature* d3d12RootSignature;
+
+                var rootSignatureDesc = new D3D12_ROOT_SIGNATURE_DESC {
+                    Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+                };
+                ThrowExternalExceptionIfFailed(nameof(D3D12SerializeRootSignature), D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &rootSignatureBlob, &rootSignatureErrorBlob));
+
+                var iid = IID_ID3D12RootSignature;
+                ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateRootSignature), D3D12GraphicsDevice.D3D12Device->CreateRootSignature(0, rootSignatureBlob->GetBufferPointer(), rootSignatureBlob->GetBufferSize(), &iid, (void**)&d3d12RootSignature));
+
+                return d3d12RootSignature;
+            }
+            finally
+            {
+                ReleaseIfNotNull(rootSignatureErrorBlob);
+                ReleaseIfNotNull(rootSignatureBlob);
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
@@ -1,0 +1,49 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using TerraFX.Utilities;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsPrimitive : GraphicsPrimitive
+    {
+        private State _state;
+
+        internal D3D12GraphicsPrimitive(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer)
+        {
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsPrimitive" /> class.</summary>
+        ~D3D12GraphicsPrimitive()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <inheritdoc cref="GraphicsPrimitive.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
+
+        /// <inheritdoc cref="GraphicsPrimitive.GraphicsPipeline" />
+        public D3D12GraphicsPipeline D3D12GraphicsPipeline => (D3D12GraphicsPipeline)GraphicsPipeline;
+
+        /// <inheritdoc cref="GraphicsPrimitive.VertexBuffer" />
+        public D3D12GraphicsBuffer D3D12VertexBuffer => (D3D12GraphicsBuffer)VertexBuffer;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                DisposeIfNotNull(GraphicsPipeline);
+                DisposeIfNotNull(VertexBuffer);
+            }
+
+            _state.EndDispose();
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsShader.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsShader.cs
@@ -1,0 +1,70 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsShader : GraphicsShader
+    {
+        private readonly D3D12_SHADER_BYTECODE _d3d12ShaderBytecode;
+
+        private State _state;
+
+        internal D3D12GraphicsShader(D3D12GraphicsDevice graphicsDevice, GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName)
+            : base(graphicsDevice, kind, entryPointName)
+        {
+            var bytecodeLength = bytecode.Length;
+
+            _d3d12ShaderBytecode.pShaderBytecode = Allocate(bytecodeLength);
+            _d3d12ShaderBytecode.BytecodeLength = (UIntPtr)bytecodeLength;
+
+            var destination = new Span<byte>(_d3d12ShaderBytecode.pShaderBytecode, bytecodeLength);
+            bytecode.CopyTo(destination);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsShader" /> class.</summary>
+        ~D3D12GraphicsShader()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> Bytecode => new ReadOnlySpan<byte>(_d3d12ShaderBytecode.pShaderBytecode, (int)_d3d12ShaderBytecode.BytecodeLength);
+
+        /// <inheritdoc cref="GraphicsShader.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="D3D12_SHADER_BYTECODE" /> for the shader.</summary>
+        public ref readonly D3D12_SHADER_BYTECODE D3D12ShaderBytecode => ref _d3d12ShaderBytecode;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                DisposeD3D12ShaderBytecode();
+            }
+
+            _state.EndDispose();
+        }
+
+        private void DisposeD3D12ShaderBytecode()
+        {
+            var shaderBytecode = _d3d12ShaderBytecode.pShaderBytecode;
+
+            if (shaderBytecode != null)
+            {
+                Free(shaderBytecode);
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
@@ -1,0 +1,172 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkBufferUsageFlagBits;
+using static TerraFX.Interop.VkMemoryPropertyFlagBits;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsBuffer : GraphicsBuffer
+    {
+        private ValueLazy<VkBuffer> _vulkanBuffer;
+        private ValueLazy<VkDeviceMemory> _vulkanDeviceMemory;
+
+        private State _state;
+
+        internal VulkanGraphicsBuffer(VulkanGraphicsDevice graphicsDevice, GraphicsBufferKind kind, ulong size, ulong stride)
+            : base(graphicsDevice, kind, size, stride)
+        {
+            _vulkanBuffer = new ValueLazy<VkBuffer>(CreateVulkanBuffer);
+            _vulkanDeviceMemory = new ValueLazy<VkDeviceMemory>(CreateVulkanDeviceMemory);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsBuffer" /> class.</summary>
+        ~VulkanGraphicsBuffer()
+        {
+            Dispose(isDisposing: true);
+        }
+
+        /// <summary>Gets the underlying <see cref="VkBuffer" /> for the buffer.</summary>
+        /// <exception cref="ExternalException">The call to <see cref="vkCreateBuffer(IntPtr, VkBufferCreateInfo*, VkAllocationCallbacks*, ulong*)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+        public VkBuffer VulkanBuffer => _vulkanBuffer.Value;
+
+        /// <summary>Gets the underlying <see cref="VkDeviceMemory" /> for the buffer.</summary>
+        /// <exception cref="ExternalException">The call to <see cref="vkAllocateMemory(IntPtr, VkMemoryAllocateInfo*, VkAllocationCallbacks*, ulong*)" /> failed.</exception>
+        /// <exception cref="ExternalException">The call to <see cref="vkBindBufferMemory(IntPtr, ulong, ulong, ulong)" /> failed.</exception>
+        /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+        public VkDeviceMemory VulkanDeviceMemory => _vulkanDeviceMemory.Value;
+
+        /// <inheritdoc cref="GraphicsBuffer.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
+
+        /// <inheritdoc />
+        /// <exception cref="ExternalException">The call to <see cref="vkMapMemory(IntPtr, ulong, ulong, ulong, uint, void**)" /> failed.</exception>
+        /// <exception cref="ExternalException">The call to <see cref="vkFlushMappedMemoryRanges(IntPtr, uint, VkMappedMemoryRange*)" /> failed.</exception>
+        public override void Write(ReadOnlySpan<byte> bytes)
+        {
+            var vulkanDevice = VulkanGraphicsDevice.VulkanDevice;
+            var vulkanDeviceMemory = VulkanDeviceMemory;
+            var bytesWritten = bytes.Length;
+
+            void* pDestination;
+            ThrowExternalExceptionIfNotSuccess(nameof(vkMapMemory), vkMapMemory(vulkanDevice, vulkanDeviceMemory, offset: 0, size: unchecked((ulong)bytesWritten), flags: 0, &pDestination));
+
+            var destination = new Span<byte>(pDestination, bytesWritten);
+            bytes.CopyTo(destination);
+
+            var mappedMemoryRange = new VkMappedMemoryRange {
+                sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+                memory = vulkanDeviceMemory,
+                offset = 0,
+                size = VK_WHOLE_SIZE,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkFlushMappedMemoryRanges), vkFlushMappedMemoryRanges(vulkanDevice, 1, &mappedMemoryRange));
+
+            vkUnmapMemory(vulkanDevice, vulkanDeviceMemory);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _vulkanDeviceMemory.Dispose(DisposeVulkanDeviceMemory);
+                _vulkanBuffer.Dispose(DisposeVulkanBuffer);
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkBuffer CreateVulkanBuffer()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            VkBuffer vulkanBuffer;
+
+            var bufferCreateInfo = new VkBufferCreateInfo {
+                sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+                size = Size,
+                usage = (uint)VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreateBuffer), vkCreateBuffer(VulkanGraphicsDevice.VulkanDevice, &bufferCreateInfo, pAllocator: null, (ulong*)&vulkanBuffer));
+
+            return vulkanBuffer;
+        }
+
+        private VkDeviceMemory CreateVulkanDeviceMemory()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            VkDeviceMemory vulkanDeviceMemory;
+
+            var memoryAllocateInfo = new VkMemoryAllocateInfo {
+                sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+                allocationSize = Size,
+                memoryTypeIndex = GetMemoryTypeIndex(VulkanGraphicsDevice.VulkanGraphicsAdapter.VulkanPhysicalDevice),
+            };
+            var vulkanDevice = VulkanGraphicsDevice.VulkanDevice;
+
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAllocateMemory), vkAllocateMemory(vulkanDevice, &memoryAllocateInfo, pAllocator: null, (ulong*)&vulkanDeviceMemory));
+            ThrowExternalExceptionIfNotSuccess(nameof(vkBindBufferMemory), vkBindBufferMemory(vulkanDevice, VulkanBuffer, vulkanDeviceMemory, memoryOffset: 0));
+
+            return vulkanDeviceMemory;
+
+
+            static uint GetMemoryTypeIndex(VkPhysicalDevice vulkanPhysicalDevice)
+            {
+                uint memoryTypeIndex = uint.MaxValue;
+
+                VkPhysicalDeviceMemoryProperties physicalDeviceMemoryProperties;
+                vkGetPhysicalDeviceMemoryProperties(vulkanPhysicalDevice, &physicalDeviceMemoryProperties);
+
+                var memoryTypesCount = physicalDeviceMemoryProperties.memoryTypeCount;
+                var memoryTypes = physicalDeviceMemoryProperties.memoryTypes;
+
+                for (uint index = 0; index < memoryTypesCount; index++)
+                {
+                    if ((memoryTypes[unchecked((int)index)].propertyFlags & (uint)VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
+                    {
+                        memoryTypeIndex = index;
+                        break;
+                    }
+                }
+
+                if (memoryTypeIndex == uint.MaxValue)
+                {
+                    ThrowInvalidOperationException(nameof(memoryTypeIndex), memoryTypeIndex);
+                }
+                return memoryTypeIndex;
+            }
+        }
+
+        private void DisposeVulkanBuffer(VkBuffer vulkanBuffer)
+        {
+            if (vulkanBuffer != VK_NULL_HANDLE)
+            {
+                vkDestroyBuffer(VulkanGraphicsDevice.VulkanDevice, vulkanBuffer, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanDeviceMemory(VkDeviceMemory vulkanDeviceMemory)
+        {
+            if (vulkanDeviceMemory != VK_NULL_HANDLE)
+            {
+                vkFreeMemory(VulkanGraphicsDevice.VulkanDevice, vulkanDeviceMemory, pAllocator: null);
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -134,6 +134,46 @@ namespace TerraFX.Graphics.Providers.Vulkan
         /// <summary>Gets a readonly span of the <see cref="VkImage" /> used by <see cref="VulkanSwapchain" />.</summary>
         public ReadOnlySpan<VkImage> VulkanSwapchainImages => _vulkanSwapchainImages.Value;
 
+        /// <inheritdoc cref="CreateGraphicsBuffer(GraphicsBufferKind, ulong, ulong)" />
+        public VulkanGraphicsBuffer CreateVulkanGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new VulkanGraphicsBuffer(this, kind, size, stride);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader, GraphicsShader)" />
+        public VulkanGraphicsPipeline CreateVulkanGraphicsPipeline(VulkanGraphicsShader? vertexShader = null, VulkanGraphicsShader? pixelShader = null)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new VulkanGraphicsPipeline(this, vertexShader, pixelShader);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer)" />
+        public VulkanGraphicsPrimitive CreateVulkanGraphicsPrimitive(VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new VulkanGraphicsPrimitive(this, graphicsPipeline, vertexBuffer);
+        }
+
+        /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
+        public VulkanGraphicsShader CreateVulkanGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new VulkanGraphicsShader(this, kind, bytecode, entryPointName);
+        }
+
+        /// <inheritdoc />
+        public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateVulkanGraphicsBuffer(kind, size, stride);
+
+        /// <inheritdoc />
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsShader?)vertexShader, (VulkanGraphicsShader?)pixelShader);
+
+        /// <inheritdoc />
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer);
+
+        /// <inheritdoc />
+        public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateVulkanGraphicsShader(kind, bytecode, entryPointName);
+
         /// <inheritdoc />
         public override void PresentFrame()
         {

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
@@ -1,0 +1,286 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkCompareOp;
+using static TerraFX.Interop.VkFrontFace;
+using static TerraFX.Interop.VkFormat;
+using static TerraFX.Interop.VkPrimitiveTopology;
+using static TerraFX.Interop.VkSampleCountFlagBits;
+using static TerraFX.Interop.VkShaderStageFlagBits;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.VkVertexInputRate;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsPipeline : GraphicsPipeline
+    {
+        private ValueLazy<VkPipeline> _vulkanPipeline;
+        private ValueLazy<VkPipelineLayout> _vulkanPipelineLayout;
+
+        private State _state;
+
+        internal VulkanGraphicsPipeline(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsShader? vertexShader, VulkanGraphicsShader? pixelShader)
+            : base(graphicsDevice, vertexShader, pixelShader)
+        {
+            _vulkanPipeline = new ValueLazy<VkPipeline>(CreateVulkanGraphicsPipeline);
+            _vulkanPipelineLayout = new ValueLazy<VkPipelineLayout>(CreateVulkanPipelineLayout);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsPipeline" /> class.</summary>
+        ~VulkanGraphicsPipeline()
+        {
+            Dispose(isDisposing: true);
+        }
+
+        /// <inheritdoc cref="GraphicsPipeline.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="VkPipeline" /> for the pipeline.</summary>
+        public VkPipeline VulkanPipeline => _vulkanPipeline.Value;
+
+        /// <summary>Gets the underlying <see cref="VkPipelineLayout" /> for the pipeline.</summary>
+        public VkPipelineLayout VulkanPipelineLayout => _vulkanPipelineLayout.Value;
+
+        /// <inheritdoc cref="GraphicsPipeline.PixelShader" />
+        public VulkanGraphicsShader? VulkanPixelShader => (VulkanGraphicsShader?)PixelShader;
+
+        /// <inheritdoc cref="GraphicsPipeline.VertexShader" />
+        public VulkanGraphicsShader? VulkanVertexShader => (VulkanGraphicsShader?)VertexShader;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _vulkanPipeline.Dispose(DisposeVulkanPipeline);
+                _vulkanPipelineLayout.Dispose(DisposeVulkanPipelineLayout);
+
+                DisposeIfNotNull(PixelShader);
+                DisposeIfNotNull(VertexShader);
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkPipeline CreateVulkanGraphicsPipeline()
+        {
+            var pipelineShaderStageCreateInfos = stackalloc VkPipelineShaderStageCreateInfo[2];
+            uint pipelineShaderStageCreateInfosCount = 0;
+
+            try
+            {
+                VkPipeline vulkanPipeline;
+
+                var graphicsDevice = VulkanGraphicsDevice;
+                var graphicsSurface = graphicsDevice.GraphicsSurface;
+
+                var vertexInputBindingDescription = new VkVertexInputBindingDescription {
+                    inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
+                };
+
+                var vertexInputAttributeDescriptions = Array.Empty<VkVertexInputAttributeDescription>();
+
+                var pipelineVertexInputStateCreateInfo = new VkPipelineVertexInputStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+                    vertexBindingDescriptionCount = 1,
+                    pVertexBindingDescriptions = &vertexInputBindingDescription,
+                };
+
+                var pipelineInputAssemblyStateCreateInfo = new VkPipelineInputAssemblyStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+                    topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+                };
+
+                var viewport = new VkViewport {
+                    width = graphicsSurface.Width,
+                    height = graphicsSurface.Height,
+                    minDepth = 0.0f,
+                    maxDepth = 1.0f,
+                };
+
+                var scissorRect2D = new VkRect2D {
+                    extent = new VkExtent2D {
+                        width = (uint)viewport.width,
+                        height = (uint)viewport.height,
+                    },
+                };
+
+                var pipelineViewportStateCreateInfo = new VkPipelineViewportStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+                    viewportCount = 1,
+                    pViewports = &viewport,
+                    scissorCount = 1,
+                    pScissors = &scissorRect2D,
+                };
+
+                var pipelineRasterizationStateCreateInfo = new VkPipelineRasterizationStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+                    frontFace = VK_FRONT_FACE_CLOCKWISE,
+                    lineWidth = 1.0f,
+                };
+
+                var pipelineMultisampleStateCreateInfo = new VkPipelineMultisampleStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+                    rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+                };
+
+                var pipelineDepthStencilStateCreateInfo = new VkPipelineDepthStencilStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
+                    depthCompareOp = VK_COMPARE_OP_ALWAYS,
+                    front = new VkStencilOpState {
+                        compareOp = VK_COMPARE_OP_ALWAYS,
+                    },
+                    back = new VkStencilOpState {
+                        compareOp = VK_COMPARE_OP_ALWAYS,
+                    },
+                };
+
+                var pipelineColorBlendAttachmentState = new VkPipelineColorBlendAttachmentState {
+                    colorWriteMask = 0xF,
+                };
+
+                var pipelineColorBlendStateCreateInfo = new VkPipelineColorBlendStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+                    attachmentCount = 1,
+                    pAttachments = &pipelineColorBlendAttachmentState,
+                };
+
+                var graphicsPipelineCreateInfo = new VkGraphicsPipelineCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+                    pViewportState = &pipelineViewportStateCreateInfo,
+                    pRasterizationState = &pipelineRasterizationStateCreateInfo,
+                    pMultisampleState = &pipelineMultisampleStateCreateInfo,
+                    pDepthStencilState = &pipelineDepthStencilStateCreateInfo,
+                    pColorBlendState = &pipelineColorBlendStateCreateInfo,
+                    layout = VulkanPipelineLayout,
+                    renderPass = graphicsDevice.VulkanRenderPass,
+                };
+
+                var vertexShader = VulkanVertexShader;
+
+                if (vertexShader != null)
+                {
+                    var index = pipelineShaderStageCreateInfosCount++;
+
+                    var entryPointName = MarshalStringToUtf8(vertexShader.EntryPointName);
+                    var entryPointNameLength = entryPointName.Length + 1;
+
+                    pipelineShaderStageCreateInfos[index] = new VkPipelineShaderStageCreateInfo {
+                        sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                        stage = VK_SHADER_STAGE_VERTEX_BIT,
+                        module = vertexShader.VulkanShaderModule,
+                        pName = (sbyte*)Allocate(entryPointNameLength),
+                    };
+
+                    var destination = new Span<sbyte>(pipelineShaderStageCreateInfos[index].pName, entryPointNameLength);
+                    entryPointName.CopyTo(destination);
+                    destination[entryPointName.Length] = 0x00;
+
+                    vertexInputBindingDescription.stride = sizeof(float) * 7;
+                    vertexInputAttributeDescriptions = new VkVertexInputAttributeDescription[2] {
+                        new VkVertexInputAttributeDescription {
+                            format = VK_FORMAT_R32G32B32_SFLOAT,
+                        },
+                        new VkVertexInputAttributeDescription {
+                            location = 1,
+                            format = VK_FORMAT_R32G32B32A32_SFLOAT,
+                            offset = sizeof(float) * 3
+                        },
+                    };
+
+                    graphicsPipelineCreateInfo.pVertexInputState = &pipelineVertexInputStateCreateInfo;
+                    graphicsPipelineCreateInfo.pInputAssemblyState = &pipelineInputAssemblyStateCreateInfo;
+                }
+
+                var pixelShader = VulkanPixelShader;
+
+                if (pixelShader != null)
+                {
+                    var index = pipelineShaderStageCreateInfosCount++;
+
+                    var entryPointName = MarshalStringToUtf8(pixelShader.EntryPointName);
+                    var entryPointNameLength = entryPointName.Length + 1;
+
+                    pipelineShaderStageCreateInfos[index] = new VkPipelineShaderStageCreateInfo {
+                        sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                        stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+                        module = pixelShader.VulkanShaderModule,
+                        pName = (sbyte*)Allocate(entryPointNameLength),
+                    };
+
+                    var destination = new Span<sbyte>(pipelineShaderStageCreateInfos[index].pName, entryPointNameLength);
+                    entryPointName.CopyTo(destination);
+                    destination[entryPointName.Length] = 0x00;
+                }
+
+                if (pipelineShaderStageCreateInfosCount != 0)
+                {
+                    graphicsPipelineCreateInfo.stageCount = pipelineShaderStageCreateInfosCount;
+                    graphicsPipelineCreateInfo.pStages = pipelineShaderStageCreateInfos;
+                }
+
+                fixed (VkVertexInputAttributeDescription* pVertexInputAttributeDescriptions = vertexInputAttributeDescriptions)
+                {
+                    pipelineVertexInputStateCreateInfo.vertexAttributeDescriptionCount = unchecked((uint)vertexInputAttributeDescriptions.Length);
+                    pipelineVertexInputStateCreateInfo.pVertexAttributeDescriptions = pVertexInputAttributeDescriptions;
+
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateGraphicsPipelines), vkCreateGraphicsPipelines(graphicsDevice.VulkanDevice, pipelineCache: VK_NULL_HANDLE, 1, &graphicsPipelineCreateInfo, pAllocator: null, (ulong*)&vulkanPipeline));
+                }
+
+                return vulkanPipeline;
+            }
+            finally
+            {
+                for (uint index = 0; index < pipelineShaderStageCreateInfosCount; index++)
+                {
+                    var entryPointName = pipelineShaderStageCreateInfos[index].pName;
+
+                    if (entryPointName != null)
+                    {
+                        Free(entryPointName);
+                    }
+                }
+            }
+        }
+
+        private VkPipelineLayout CreateVulkanPipelineLayout()
+        {
+            VkPipelineLayout vulkanPipelineLayout;
+
+            var pipelineLayoutCreateInfo = new VkPipelineLayoutCreateInfo {
+                sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreatePipelineLayout), vkCreatePipelineLayout(VulkanGraphicsDevice.VulkanDevice, &pipelineLayoutCreateInfo, pAllocator: null, (ulong*)&vulkanPipelineLayout));
+
+            return vulkanPipelineLayout;
+        }
+
+        private void DisposeVulkanPipeline(VkPipeline vulkanPipeline)
+        {
+            if (vulkanPipeline != VK_NULL_HANDLE)
+            {
+                vkDestroyPipeline(VulkanGraphicsDevice.VulkanDevice, vulkanPipeline, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanPipelineLayout(VkPipelineLayout vulkanPipelineLayout)
+        {
+            if (vulkanPipelineLayout != VK_NULL_HANDLE)
+            {
+                vkDestroyPipelineLayout(VulkanGraphicsDevice.VulkanDevice, vulkanPipelineLayout, pAllocator: null);
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
@@ -1,0 +1,49 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using TerraFX.Utilities;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsPrimitive : GraphicsPrimitive
+    {
+        private State _state;
+
+        internal VulkanGraphicsPrimitive(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer)
+        {
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsPrimitive" /> class.</summary>
+        ~VulkanGraphicsPrimitive()
+        {
+            Dispose(isDisposing: true);
+        }
+
+        /// <inheritdoc cref="GraphicsPrimitive.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
+
+        /// <inheritdoc cref="GraphicsPrimitive.GraphicsPipeline" />
+        public VulkanGraphicsPipeline VulkanGraphicsPipeline => (VulkanGraphicsPipeline)GraphicsPipeline;
+
+        /// <inheritdoc cref="GraphicsPrimitive.VertexBuffer" />
+        public VulkanGraphicsBuffer VulkanVertexBuffer => (VulkanGraphicsBuffer)VertexBuffer;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                DisposeIfNotNull(GraphicsPipeline);
+                DisposeIfNotNull(VertexBuffer);
+            }
+
+            _state.EndDispose();
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsShader.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsShader.cs
@@ -1,0 +1,99 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsShader : GraphicsShader
+    {
+        private readonly VkShaderModuleCreateInfo _vulkanShaderModuleCreateInfo;
+
+        private ValueLazy<VkShaderModule> _vulkanShaderModule;
+
+        private State _state;
+
+        internal VulkanGraphicsShader(VulkanGraphicsDevice graphicsDevice, GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName)
+            : base(graphicsDevice, kind, entryPointName)
+        {
+            var bytecodeLength = bytecode.Length;
+
+            _vulkanShaderModuleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+            _vulkanShaderModuleCreateInfo.codeSize = (UIntPtr)bytecodeLength;
+            _vulkanShaderModuleCreateInfo.pCode = (uint*)Allocate(bytecodeLength);
+
+            var destination = new Span<byte>(_vulkanShaderModuleCreateInfo.pCode, bytecodeLength);
+            bytecode.CopyTo(destination);
+
+            _vulkanShaderModule = new ValueLazy<VkShaderModule>(CreateVulkanShaderModule);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsShader" /> class.</summary>
+        ~VulkanGraphicsShader()
+        {
+            Dispose(isDisposing: true);
+        }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> Bytecode => new ReadOnlySpan<byte>(_vulkanShaderModuleCreateInfo.pCode, (int)_vulkanShaderModuleCreateInfo.codeSize);
+
+        /// <inheritdoc cref="GraphicsShader.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="VkShaderModule" /> for the shader.</summary>
+        public VkShaderModule VulkanShaderModule => _vulkanShaderModule.Value;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _vulkanShaderModule.Dispose(DisposeVulkanShaderModule);
+                DisposeVulkanShaderModuleCreateInfo();
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkShaderModule CreateVulkanShaderModule()
+        {
+            VkShaderModule vulkanShaderModule;
+
+            fixed (VkShaderModuleCreateInfo* shaderModuleCreateInfo = &_vulkanShaderModuleCreateInfo)
+            {
+                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateShaderModule), vkCreateShaderModule(VulkanGraphicsDevice.VulkanDevice, shaderModuleCreateInfo, pAllocator: null, (ulong*)&vulkanShaderModule));
+            }
+
+            return vulkanShaderModule;
+        }
+        
+        private void DisposeVulkanShaderModule(VkShaderModule vulkanShaderModule)
+        {
+            if (vulkanShaderModule != VK_NULL_HANDLE)
+            {
+                vkDestroyShaderModule(VulkanGraphicsDevice.VulkanDevice, vulkanShaderModule, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanShaderModuleCreateInfo()
+        {
+            var code = _vulkanShaderModuleCreateInfo.pCode;
+
+            if (code != null)
+            {
+                Free(code);
+            }
+        }
+    }
+}

--- a/sources/Utilities/DisposeUtilities.cs
+++ b/sources/Utilities/DisposeUtilities.cs
@@ -12,7 +12,7 @@ namespace TerraFX.Utilities
         /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
         /// <param name="value">The <typeparamref name="T" /> to dispose.</param>
         public static void DisposeIfNotNull<T>(T value)
-            where T : IDisposable
+            where T : IDisposable?
         {
             if (value != null)
             {

--- a/sources/Utilities/InteropUtilities.cs
+++ b/sources/Utilities/InteropUtilities.cs
@@ -11,6 +11,11 @@ namespace TerraFX.Utilities
     /// <summary>Provides a set of methods for simplifying interop code.</summary>
     public static unsafe class InteropUtilities
     {
+        /// <summary>Allocates a chunk of unmanaged memory.</summary>
+        /// <param name="size">The size, in bytes, of the allocation.</param>
+        /// <returns>An allocated chunk of memory that is <paramref name="size" /> bytes in length.</returns>
+        public static void* Allocate(int size) => (void*)Marshal.AllocHGlobal(size);
+
         /// <summary>Gets the underlying pointer for a <typeparamref name="T" /> reference.</summary>
         /// <typeparam name="T">The type of <paramref name="source" />.</typeparam>
         /// <param name="source">The reference for which to get the underlying pointer.</param>
@@ -107,6 +112,10 @@ namespace TerraFX.Utilities
 
             return result;
         }
+
+        /// <summary>Frees a chunk of unmanaged memory.</summary>
+        /// <param name="memory">The memory to free</param>
+        public static void Free(void* memory) => Marshal.FreeHGlobal((IntPtr)memory);
 
         /// <summary>Marshals a managed delegate to get a function pointer which will invoke it.</summary>
         /// <typeparam name="TDelegate">The type of the managed delegate.</typeparam>


### PR DESCRIPTION
This adds the capability to create and draw graphics primitives:
* A new "HelloTriangle" sample was added
* The `GraphicsBuffer` type supports writing data to the buffer
  * This causes a new resource allocation per buffer. Ideally we would have larger allocations and this would be a view into that
  * This only supports writing data today and always creates an "upload" buffer. Ideally we would create GPU only and CPU read, write, or read/write buffers as appropriate
  * Only vertex buffers are supported right now
* The `GraphicsPipeline` type carries all the pipeline state (namely shaders) for rendering a primitive
  * Only Vertex and Pixel shaders are supported right now, but both are optional
  * You cannot currently customize the vertex input layout
* The `GraphicsPrimitive` type was added and tracks the pipeline used to render it and the vertices it is made of
  * Ideally this would also support optional indexing
* The `GraphicsShader` type was added and tracks the bytecode and entry point for a given shader
  * Only vertex and pixel shaders are supported right now
* The above types are created via `GraphicsDevice.Create*`
* Graphics primitives are are drawn via `GraphicsContext.Draw`