### PR TITLE
Adding support for rendering indexed primitives

### DIFF
--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -1,0 +1,140 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using TerraFX.ApplicationModel;
+using TerraFX.Graphics;
+using TerraFX.Numerics;
+using TerraFX.UI;
+using TerraFX.Utilities;
+
+namespace TerraFX.Samples.Graphics
+{
+    public sealed class HelloQuad : Sample
+    {
+        private GraphicsDevice _graphicsDevice = null!;
+        private GraphicsPrimitive _quadPrimitive = null!;
+        private Window _window = null!;
+        private TimeSpan _elapsedTime;
+
+        public HelloQuad(string name, params Assembly[] compositionAssemblies)
+            : base(name, compositionAssemblies)
+        {
+        }
+
+        public override void Cleanup()
+        {
+            _quadPrimitive?.Dispose();
+            _graphicsDevice?.Dispose();
+            _window?.Dispose();
+
+            base.Cleanup();
+        }
+
+        public override void Initialize(Application application)
+        {
+            ExceptionUtilities.ThrowIfNull(application, nameof(application));
+
+            var windowProvider = application.GetService<WindowProvider>();
+            _window = windowProvider.CreateWindow();
+            _window.Show();
+
+            var graphicsProvider = application.GetService<GraphicsProvider>();
+            var graphicsAdapter = graphicsProvider.GraphicsAdapters.First();
+
+            _graphicsDevice = graphicsAdapter.CreateGraphicsDevice(_window, graphicsContextCount: 2);
+            _quadPrimitive = CreateQuadPrimitive();
+            
+            base.Initialize(application);
+        }
+
+        protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
+        {
+            ExceptionUtilities.ThrowIfNull(sender, nameof(sender));
+
+            _elapsedTime += eventArgs.Delta;
+
+            if (_elapsedTime.TotalSeconds >= 2.5)
+            {
+                var application = (Application)sender;
+                application.RequestExit();
+            }
+
+            if (_window.IsVisible)
+            {
+                var graphicsDevice = _graphicsDevice;
+                var graphicsContext = graphicsDevice.GraphicsContexts[graphicsDevice.GraphicsContextIndex];
+
+                var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
+                graphicsContext.BeginFrame(backgroundColor);
+
+                graphicsContext.Draw(_quadPrimitive);
+
+                graphicsContext.EndFrame();
+                graphicsDevice.PresentFrame();
+            }
+        }
+
+        private unsafe GraphicsPrimitive CreateQuadPrimitive()
+        {
+            var graphicsDevice = _graphicsDevice;
+            var graphicsSurface = graphicsDevice.GraphicsSurface;
+
+            var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "VSMain", "PSMain");
+
+            var vertexBuffer = CreateVertexBuffer(graphicsDevice, aspectRatio: graphicsSurface.Width / graphicsSurface.Height);
+            var indexBuffer = CreateIndexBuffer(graphicsDevice);
+
+            return graphicsDevice.CreateGraphicsPrimitive(graphicsPipeline, vertexBuffer, indexBuffer);
+
+            static GraphicsBuffer CreateVertexBuffer(GraphicsDevice graphicsDevice, float aspectRatio)
+            {
+                var vertexBuffer = graphicsDevice.CreateGraphicsBuffer(GraphicsBufferKind.Vertex, (ulong)(sizeof(IdentityVertex) * 4), (ulong)sizeof(IdentityVertex));
+
+                ReadOnlySpan<IdentityVertex> vertices = stackalloc IdentityVertex[4] {
+                    new IdentityVertex {
+                        Position = new Vector3(0.25f, 0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
+                    },
+                    new IdentityVertex {
+                        Position = new Vector3(0.25f, -0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(0.0f, 1.0f, 0.0f, 1.0f),
+                    },
+                    new IdentityVertex {
+                        Position = new Vector3(-0.25f, -0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(0.0f, 0.0f, 1.0f, 1.0f),
+                    },
+                    new IdentityVertex {
+                        Position = new Vector3(-0.25f, 0.25f * aspectRatio, 0.0f),
+                        Color = new Vector4(0.0f, 1.0f, 0.0f, 1.0f),
+                    },
+                };
+
+                vertexBuffer.Write(MemoryMarshal.AsBytes(vertices));
+                return vertexBuffer;
+            }
+
+            static GraphicsBuffer CreateIndexBuffer(GraphicsDevice graphicsDevice)
+            {
+                var indexBuffer = graphicsDevice.CreateGraphicsBuffer(GraphicsBufferKind.Index, sizeof(ushort) * 6, sizeof(ushort));
+
+                ReadOnlySpan<ushort> indices = stackalloc ushort[6] {
+                    0, 1, 2,
+                    0, 2, 3,
+                };
+
+                indexBuffer.Write(MemoryMarshal.AsBytes(indices));
+                return indexBuffer;
+            }
+
+            GraphicsPipeline CreateGraphicsPipeline(GraphicsDevice graphicsDevice, string shaderName, string vertexShaderEntryPoint, string pixelShaderEntryPoint)
+            {
+                var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, "Identity", "main");
+                var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, "Identity", "main");
+                return graphicsDevice.CreateGraphicsPipeline(vertexShader, pixelShader);
+            }
+        }
+    }
+}

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -29,6 +29,9 @@ namespace TerraFX.Samples
             new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
             new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
 
+            new HelloQuad("D3D12.HelloQuad", s_graphicsProviderD3D12),
+            new HelloQuad("Vulkan.HelloQuad", s_graphicsProviderVulkan),
+
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),
 

--- a/sources/Graphics/GraphicsBuffer.cs
+++ b/sources/Graphics/GraphicsBuffer.cs
@@ -19,9 +19,15 @@ namespace TerraFX.Graphics
         /// <param name="size">The size, in bytes, of the buffer.</param>
         /// <param name="stride">The size, in bytes, of the buffer elements.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="kind" /> is <see cref="GraphicsBufferKind.Index" /> and <paramref name="stride" /> is not <c>2</c> or <c>4</c>.</exception>
         protected GraphicsBuffer(GraphicsDevice graphicsDevice, GraphicsBufferKind kind, ulong size, ulong stride)
         {
             ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+
+            if ((kind == GraphicsBufferKind.Index) && (stride != 2) && (stride != 4))
+            {
+                ThrowArgumentOutOfRangeException(nameof(stride), stride);
+            }
 
             _size = size;
             _stride = stride;

--- a/sources/Graphics/GraphicsBufferKind.cs
+++ b/sources/Graphics/GraphicsBufferKind.cs
@@ -10,5 +10,8 @@ namespace TerraFX.Graphics
 
         /// <summary>Defines a vertex buffer.</summary>
         Vertex,
+
+        /// <summary>Defines an index buffer.</summary>
+        Index,
     }
 }

--- a/sources/Graphics/GraphicsDevice.cs
+++ b/sources/Graphics/GraphicsDevice.cs
@@ -60,12 +60,14 @@ namespace TerraFX.Graphics
         /// <summary>Creates a new graphics primitive for the device.</summary>
         /// <param name="graphicsPipeline">The graphics pipeline used for rendering the graphics primitive.</param>
         /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the graphics primitive.</param>
+        /// <param name="indexBuffer">The graphics buffer which holds the indices for the graphics primitive or <c>null</c> if none exists.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for this device.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for this device.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBuffer" /> was not created for this device.</exception>
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
-        public abstract GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer);
+        public abstract GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null);
 
         /// <summary>Creates a new graphics shader for the device.</summary>
         /// <param name="kind">The kind of graphics shader to create.</param>

--- a/sources/Graphics/GraphicsPrimitive.cs
+++ b/sources/Graphics/GraphicsPrimitive.cs
@@ -11,17 +11,20 @@ namespace TerraFX.Graphics
         private readonly GraphicsDevice _graphicsDevice;
         private readonly GraphicsPipeline _graphicsPipeline;
         private readonly GraphicsBuffer _vertexBuffer;
+        private readonly GraphicsBuffer? _indexBuffer;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsPrimitive" /> class.</summary>
         /// <param name="graphicsDevice">The graphics device for which the primitive was created.</param>
         /// <param name="graphicsPipeline">The graphics pipeline used for rendering the primitive.</param>
         /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the primitive.</param>
+        /// <param name="indexBuffer">The graphics buffer which holds the indices for the primitive or <c>null</c> if none exists.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for <paramref name="graphicsDevice" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for <paramref name="graphicsDevice" />.</exception>
-        protected GraphicsPrimitive(GraphicsDevice graphicsDevice, GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer)
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBuffer" /> was not created for <paramref name="graphicsDevice" />.</exception>
+        protected GraphicsPrimitive(GraphicsDevice graphicsDevice, GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer)
         {
             ThrowIfNull(graphicsPipeline, nameof(graphicsPipeline));
             ThrowIfNull(vertexBuffer, nameof(vertexBuffer));
@@ -36,9 +39,16 @@ namespace TerraFX.Graphics
                 ThrowArgumentOutOfRangeException(nameof(vertexBuffer), vertexBuffer);
             }
 
+            if ((indexBuffer != null) && (indexBuffer.GraphicsDevice != graphicsDevice))
+            {
+                ThrowArgumentOutOfRangeException(nameof(indexBuffer), indexBuffer);
+            }
+
             _graphicsDevice = graphicsDevice;
             _graphicsPipeline = graphicsPipeline;
+
             _vertexBuffer = vertexBuffer;
+            _indexBuffer = indexBuffer;
         }
 
         /// <summary>Gets the graphics device for which the pipeline was created.</summary>
@@ -46,6 +56,9 @@ namespace TerraFX.Graphics
 
         /// <summary>Gets the graphics pipeline used for rendering the primitive.</summary>
         public GraphicsPipeline GraphicsPipeline => _graphicsPipeline;
+
+        /// <summary>Gets the graphics buffer which holds the indices for the primitive or <c>null</c> if none exists.</summary>
+        public GraphicsBuffer? IndexBuffer => _indexBuffer;
 
         /// <summary>Gets the graphics buffer which holds the vertices for the primitive.</summary>
         public GraphicsBuffer VertexBuffer => _vertexBuffer;

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -11,7 +11,9 @@ using static TerraFX.Interop.D3D12_COMMAND_LIST_TYPE;
 using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_TYPE;
 using static TerraFX.Interop.D3D12_RESOURCE_STATES;
 using static TerraFX.Interop.D3D12_RTV_DIMENSION;
+using static TerraFX.Interop.DXGI_FORMAT;
 using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.DisposeUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.State;
@@ -131,17 +133,42 @@ namespace TerraFX.Graphics.Providers.D3D12
             var graphicsPipeline = graphicsPrimitive.D3D12GraphicsPipeline;
             var vertexBuffer = graphicsPrimitive.D3D12VertexBuffer;
 
+            graphicsCommandList->SetGraphicsRootSignature(graphicsPipeline.D3D12RootSignature);
+            graphicsCommandList->SetPipelineState(graphicsPipeline.D3D12PipelineState);
+
             var vertexBufferView = new D3D12_VERTEX_BUFFER_VIEW {
                 BufferLocation = vertexBuffer.D3D12Resource->GetGPUVirtualAddress(),
                 StrideInBytes = (uint)vertexBuffer.Stride,
                 SizeInBytes = (uint)vertexBuffer.Size,
             };
-
-            graphicsCommandList->SetGraphicsRootSignature(graphicsPipeline.D3D12RootSignature);
-            graphicsCommandList->SetPipelineState(graphicsPipeline.D3D12PipelineState);
-
             graphicsCommandList->IASetVertexBuffers(StartSlot: 0, NumViews: 1, &vertexBufferView);
-            graphicsCommandList->DrawInstanced(VertexCountPerInstance: (uint)(vertexBuffer.Size / vertexBuffer.Stride), InstanceCount: 1, StartVertexLocation: 0, StartInstanceLocation: 0);
+
+            var indexBuffer = graphicsPrimitive.D3D12IndexBuffer;
+
+            if (indexBuffer != null)
+            {
+                var indexBufferStride = indexBuffer.Stride;
+                var indexFormat = DXGI_FORMAT_R16_UINT;
+
+                if (indexBufferStride != 2)
+                {
+                    Assert(indexBufferStride == 4, "Index Buffer has an unsupported stride.");
+                    indexFormat = DXGI_FORMAT_R32_UINT;
+                }
+
+                var indexBufferView = new D3D12_INDEX_BUFFER_VIEW {
+                    BufferLocation = indexBuffer.D3D12Resource->GetGPUVirtualAddress(),
+                    SizeInBytes = (uint)indexBuffer.Size,
+                    Format = indexFormat,
+                };
+                graphicsCommandList->IASetIndexBuffer(&indexBufferView);
+
+                graphicsCommandList->DrawIndexedInstanced(IndexCountPerInstance: (uint)(indexBuffer.Size / indexBufferStride), InstanceCount: 1, StartIndexLocation: 0, BaseVertexLocation: 0, StartInstanceLocation: 0);
+            }
+            else
+            {
+                graphicsCommandList->DrawInstanced(VertexCountPerInstance: (uint)(vertexBuffer.Size / vertexBuffer.Stride), InstanceCount: 1, StartVertexLocation: 0, StartInstanceLocation: 0);
+            }
         }
 
         /// <inheritdoc />

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -11,7 +11,6 @@ using static TerraFX.Interop.D3D12_COMMAND_LIST_TYPE;
 using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_TYPE;
 using static TerraFX.Interop.D3D12_RESOURCE_STATES;
 using static TerraFX.Interop.D3D12_RTV_DIMENSION;
-using static TerraFX.Interop.DXGI_FORMAT;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.DisposeUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
@@ -245,7 +244,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             var d3d12Device = graphicsDevice.D3D12Device;
 
             var renderTargetViewDesc = new D3D12_RENDER_TARGET_VIEW_DESC {
-                Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+                Format = graphicsDevice.DxgiSwapChainFormat,
                 ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D,
                 Anonymous = new D3D12_RENDER_TARGET_VIEW_DESC._Anonymous_e__Union {
                     Texture2D = new D3D12_TEX2D_RTV(),

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -118,11 +118,11 @@ namespace TerraFX.Graphics.Providers.D3D12
             return new D3D12GraphicsPipeline(this, vertexShader, pixelShader);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer)" />
-        public D3D12GraphicsPrimitive CreateD3D12GraphicsPrimitive(D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer)
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
+        public D3D12GraphicsPrimitive CreateD3D12GraphicsPrimitive(D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new D3D12GraphicsPrimitive(this, graphicsPipeline, vertexBuffer);
+            return new D3D12GraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer);
         }
 
         /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
@@ -139,7 +139,7 @@ namespace TerraFX.Graphics.Providers.D3D12
         public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsShader?)vertexShader, (D3D12GraphicsShader?)pixelShader);
 
         /// <inheritdoc />
-        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer);
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer, (D3D12GraphicsBuffer?)indexBuffer);
 
         /// <inheritdoc />
         public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateD3D12GraphicsShader(kind, bytecode, entryPointName);

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -29,6 +29,7 @@ namespace TerraFX.Graphics.Providers.D3D12
 
         private D3D12GraphicsContext[] _graphicsContexts;
         private int _graphicsContextIndex;
+        private DXGI_FORMAT _dxgiSwapChainFormat;
 
         private State _state;
 
@@ -89,6 +90,9 @@ namespace TerraFX.Graphics.Providers.D3D12
         /// <summary>Gets the <see cref="IDXGISwapChain3" /> for the device.</summary>
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
         public IDXGISwapChain3* DxgiSwapChain => _dxgiSwapChain.Value;
+
+        /// <summary>Gets the <see cref="DXGI_FORMAT" /> used by <see cref="DxgiSwapChain" />.</summary>
+        public DXGI_FORMAT DxgiSwapChainFormat => _dxgiSwapChainFormat;
 
         /// <inheritdoc />
         public override ReadOnlySpan<GraphicsContext> GraphicsContexts => _graphicsContexts;
@@ -270,6 +274,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             // Fullscreen transitions are not currently supported
             ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(graphicsSurfaceHandle, DXGI_MWA_NO_ALT_ENTER));
 
+            _dxgiSwapChainFormat = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
             return dxgiSwapChain;
         }
 

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
@@ -95,7 +95,7 @@ namespace TerraFX.Graphics.Providers.D3D12
                 SampleDesc = new DXGI_SAMPLE_DESC(count: 1, quality: 0),
             };
             graphicsPipelineStateDesc.DepthStencilState.DepthEnable = FALSE;
-            graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+            graphicsPipelineStateDesc.RTVFormats[0] = D3D12GraphicsDevice.DxgiSwapChainFormat;
 
             var vertexShader = D3D12VertexShader;
 

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
@@ -11,8 +11,8 @@ namespace TerraFX.Graphics.Providers.D3D12
     {
         private State _state;
 
-        internal D3D12GraphicsPrimitive(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer)
-            : base(graphicsDevice, graphicsPipeline, vertexBuffer)
+        internal D3D12GraphicsPrimitive(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer)
         {
             _ = _state.Transition(to: Initialized);
         }
@@ -29,6 +29,9 @@ namespace TerraFX.Graphics.Providers.D3D12
         /// <inheritdoc cref="GraphicsPrimitive.GraphicsPipeline" />
         public D3D12GraphicsPipeline D3D12GraphicsPipeline => (D3D12GraphicsPipeline)GraphicsPipeline;
 
+        /// <inheritdoc cref="GraphicsPrimitive.IndexBuffer" />
+        public D3D12GraphicsBuffer? D3D12IndexBuffer => (D3D12GraphicsBuffer?)IndexBuffer;
+
         /// <inheritdoc cref="GraphicsPrimitive.VertexBuffer" />
         public D3D12GraphicsBuffer D3D12VertexBuffer => (D3D12GraphicsBuffer)VertexBuffer;
 
@@ -41,6 +44,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             {
                 DisposeIfNotNull(GraphicsPipeline);
                 DisposeIfNotNull(VertexBuffer);
+                DisposeIfNotNull(IndexBuffer);
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -137,11 +137,11 @@ namespace TerraFX.Graphics.Providers.Vulkan
             return new VulkanGraphicsPipeline(this, vertexShader, pixelShader);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer)" />
-        public VulkanGraphicsPrimitive CreateVulkanGraphicsPrimitive(VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer)
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
+        public VulkanGraphicsPrimitive CreateVulkanGraphicsPrimitive(VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new VulkanGraphicsPrimitive(this, graphicsPipeline, vertexBuffer);
+            return new VulkanGraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer);
         }
 
         /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
@@ -158,7 +158,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
         public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsShader?)vertexShader, (VulkanGraphicsShader?)pixelShader);
 
         /// <inheritdoc />
-        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer);
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer, (VulkanGraphicsBuffer?)indexBuffer);
 
         /// <inheritdoc />
         public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateVulkanGraphicsShader(kind, bytecode, entryPointName);

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -1,33 +1,22 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using TerraFX.Interop;
 using TerraFX.Numerics;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
 using static TerraFX.Interop.VkAttachmentLoadOp;
 using static TerraFX.Interop.VkAttachmentStoreOp;
-using static TerraFX.Interop.VkColorSpaceKHR;
-using static TerraFX.Interop.VkCommandBufferLevel;
-using static TerraFX.Interop.VkCommandPoolCreateFlagBits;
-using static TerraFX.Interop.VkComponentSwizzle;
 using static TerraFX.Interop.VkCompositeAlphaFlagBitsKHR;
 using static TerraFX.Interop.VkFormat;
-using static TerraFX.Interop.VkImageAspectFlagBits;
 using static TerraFX.Interop.VkImageLayout;
 using static TerraFX.Interop.VkImageUsageFlagBits;
-using static TerraFX.Interop.VkImageViewType;
 using static TerraFX.Interop.VkPipelineBindPoint;
-using static TerraFX.Interop.VkPipelineStageFlagBits;
 using static TerraFX.Interop.VkPresentModeKHR;
 using static TerraFX.Interop.VkQueueFlagBits;
 using static TerraFX.Interop.VkResult;
 using static TerraFX.Interop.VkSampleCountFlagBits;
-using static TerraFX.Interop.VkSharingMode;
 using static TerraFX.Interop.VkStructureType;
-using static TerraFX.Interop.VkSubpassContents;
 using static TerraFX.Interop.VkSurfaceTransformFlagBitsKHR;
 using static TerraFX.Interop.Vulkan;
 using static TerraFX.Utilities.DisposeUtilities;

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
@@ -11,8 +11,8 @@ namespace TerraFX.Graphics.Providers.Vulkan
     {
         private State _state;
 
-        internal VulkanGraphicsPrimitive(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer)
-            : base(graphicsDevice, graphicsPipeline, vertexBuffer)
+        internal VulkanGraphicsPrimitive(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer)
         {
             _ = _state.Transition(to: Initialized);
         }
@@ -29,6 +29,9 @@ namespace TerraFX.Graphics.Providers.Vulkan
         /// <inheritdoc cref="GraphicsPrimitive.GraphicsPipeline" />
         public VulkanGraphicsPipeline VulkanGraphicsPipeline => (VulkanGraphicsPipeline)GraphicsPipeline;
 
+        /// <inheritdoc cref="GraphicsPrimitive.IndexBuffer" />
+        public VulkanGraphicsBuffer? VulkanIndexBuffer => (VulkanGraphicsBuffer?)IndexBuffer;
+
         /// <inheritdoc cref="GraphicsPrimitive.VertexBuffer" />
         public VulkanGraphicsBuffer VulkanVertexBuffer => (VulkanGraphicsBuffer)VertexBuffer;
 
@@ -41,6 +44,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             {
                 DisposeIfNotNull(GraphicsPipeline);
                 DisposeIfNotNull(VertexBuffer);
+                DisposeIfNotNull(IndexBuffer);
             }
 
             _state.EndDispose();

--- a/tests/Utilities/InteropUtilities.cs
+++ b/tests/Utilities/InteropUtilities.cs
@@ -1,8 +1,5 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using NUnit.Framework;
 
 namespace TerraFX.Utilities.UnitTests


### PR DESCRIPTION
This adds support for rendering indexed primitives and adds a corresponding `HelloQuad` sample.

![image](https://user-images.githubusercontent.com/10487869/71117271-affcb880-218a-11ea-8635-dbf3c867b28a.png)
