### PR TITLE
Adding a GraphicsPipelineInputElement type

### DIFF
--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -133,7 +133,13 @@ namespace TerraFX.Samples.Graphics
             {
                 var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, "Identity", "main");
                 var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, "Identity", "main");
-                return graphicsDevice.CreateGraphicsPipeline(vertexShader, pixelShader);
+
+                var inputElements = new GraphicsPipelineInputElement[2] {
+                    new GraphicsPipelineInputElement(typeof(Vector3), GraphicsPipelineInputElementKind.Position, size: 12),
+                    new GraphicsPipelineInputElement(typeof(Vector4), GraphicsPipelineInputElementKind.Color, size: 16),
+                };
+
+                return graphicsDevice.CreateGraphicsPipeline(vertexShader, inputElements, pixelShader);
             }
         }
     }

--- a/samples/TerraFX/Graphics/HelloTriangle.cs
+++ b/samples/TerraFX/Graphics/HelloTriangle.cs
@@ -114,7 +114,13 @@ namespace TerraFX.Samples.Graphics
             {
                 var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, "Identity", "main");
                 var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, "Identity", "main");
-                return graphicsDevice.CreateGraphicsPipeline(vertexShader, pixelShader);
+
+                var inputElements = new GraphicsPipelineInputElement[2] {
+                    new GraphicsPipelineInputElement(typeof(Vector3), GraphicsPipelineInputElementKind.Position, size: 12),
+                    new GraphicsPipelineInputElement(typeof(Vector4), GraphicsPipelineInputElementKind.Color, size: 16),
+                };
+
+                return graphicsDevice.CreateGraphicsPipeline(vertexShader, inputElements, pixelShader);
             }
         }
     }

--- a/sources/Graphics/GraphicsDevice.cs
+++ b/sources/Graphics/GraphicsDevice.cs
@@ -48,14 +48,16 @@ namespace TerraFX.Graphics
 
         /// <summary>Creates a new graphics pipeline for the device.</summary>
         /// <param name="vertexShader">The vertex shader for the graphics pipeline or <c>null</c> if none exists.</param>
+        /// <param name="inputElements">The input elements describing the inputs to <paramref name="vertexShader" /> or <c>null</c> if none exist.</param>
         /// <param name="pixelShader">The pixel shader for the graphics pipeline or <c>null</c> if none exists.</param>
         /// <returns>A new graphics pipeline created for the device.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="vertexShader" /> is <c>null</c> and <paramref name="inputElements" /> is not empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for this device.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> was not created for this device.</exception>
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
-        public abstract GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null);
+        public abstract GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null);
 
         /// <summary>Creates a new graphics primitive for the device.</summary>
         /// <param name="graphicsPipeline">The graphics pipeline used for rendering the graphics primitive.</param>

--- a/sources/Graphics/GraphicsPipeline.cs
+++ b/sources/Graphics/GraphicsPipeline.cs
@@ -10,24 +10,32 @@ namespace TerraFX.Graphics
     {
         private readonly GraphicsDevice _graphicsDevice;
         private readonly GraphicsShader? _vertexShader;
+        private readonly GraphicsPipelineInputElement[] _inputElements;
         private readonly GraphicsShader? _pixelShader;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsPipeline" /> class.</summary>
         /// <param name="graphicsDevice">The graphics device for which the pipeline was created.</param>
-        /// <param name="vertexShader">The vertex shader for the pipeline or <c>null</c> if none  exists.</param>
+        /// <param name="vertexShader">The vertex shader for the pipeline or <c>null</c> if none exists.</param>
+        /// <param name="inputElements">The input elements describing the inputs to <paramref name="vertexShader" /> or <c>null</c> if none exist.</param>
         /// <param name="pixelShader">The pixel shader for the pipeline or <c>null</c> if none exists.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="vertexShader" /> is <c>null</c> and <paramref name="inputElements" /> is not empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for <paramref name="graphicsDevice" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" />was not created for <paramref name="graphicsDevice" />.</exception>
-        protected GraphicsPipeline(GraphicsDevice graphicsDevice, GraphicsShader? vertexShader, GraphicsShader? pixelShader)
+        protected GraphicsPipeline(GraphicsDevice graphicsDevice, GraphicsShader? vertexShader, ReadOnlySpan<GraphicsPipelineInputElement> inputElements, GraphicsShader? pixelShader)
         {
             ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
 
             if ((vertexShader != null) && ((vertexShader.Kind != GraphicsShaderKind.Vertex) || (vertexShader.GraphicsDevice != graphicsDevice)))
             {
                 ThrowArgumentOutOfRangeException(nameof(vertexShader), vertexShader);
+            }
+
+            if (!inputElements.IsEmpty)
+            {
+                ThrowIfNull(vertexShader, nameof(vertexShader));
             }
 
             if ((pixelShader != null) && ((pixelShader.Kind != GraphicsShaderKind.Pixel) || (pixelShader.GraphicsDevice != graphicsDevice)))
@@ -37,6 +45,7 @@ namespace TerraFX.Graphics
 
             _graphicsDevice = graphicsDevice;
             _vertexShader = vertexShader;
+            _inputElements = inputElements.ToArray();
             _pixelShader = pixelShader;
         }
 
@@ -48,6 +57,9 @@ namespace TerraFX.Graphics
 
         /// <summary>Gets <c>true</c> if the pipeline has a vertex shader; otherwise, <c>false</c>.</summary>
         public bool HasVertexShader => _vertexShader != null;
+
+        /// <summary>Gets the input elements describing the inputs to <see cref="VertexShader" /> or <c>null</c> if none exist.</summary>
+        public ReadOnlySpan<GraphicsPipelineInputElement> InputElements => _inputElements;
 
         /// <summary>Gets the pixel shader for the pipeline or <c>null</c> if none exists.</summary>
         public GraphicsShader? PixelShader => _pixelShader;

--- a/sources/Graphics/GraphicsPipelineInputElement.cs
+++ b/sources/Graphics/GraphicsPipelineInputElement.cs
@@ -1,0 +1,38 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics pipeline input element which describes an element of an input vertex.</summary>
+    public readonly struct GraphicsPipelineInputElement
+    {
+        private readonly Type _type;
+        private readonly GraphicsPipelineInputElementKind _kind;
+        private readonly uint _size;
+
+        /// <summary>Creates a new instance of the <see cref="GraphicsPipelineInputElement" /> struct.</summary>
+        /// <param name="type">The type of the input element.</param>
+        /// <param name="kind">The kind of the input element.</param>
+        /// <param name="size">The size, in bytes, of the input element.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="type" /> is <c>null</c>.</exception>
+        public GraphicsPipelineInputElement(Type type, GraphicsPipelineInputElementKind kind, uint size)
+        {
+            ThrowIfNull(type, nameof(type));
+
+            _type = type;
+            _kind = kind;
+            _size = size;
+        }
+
+        /// <summary>Gets the kind of the input element.</summary>
+        public GraphicsPipelineInputElementKind Kind => _kind;
+
+        /// <summary>The size, in bytes, of the input element.</summary>
+        public uint Size => _size;
+
+        /// <summary>The type of the input element.</summary>
+        public Type Type => _type;
+    }
+}

--- a/sources/Graphics/GraphicsPipelineInputElementKind.cs
+++ b/sources/Graphics/GraphicsPipelineInputElementKind.cs
@@ -1,0 +1,17 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Graphics
+{
+    /// <summary>Defines the kind of a graphics pipeline input element.</summary>
+    public enum GraphicsPipelineInputElementKind
+    {
+        /// <summary>Defines an unknown graphics pipeline input element kind.</summary>
+        Unknown,
+
+        /// <summary>Defines a graphics pipeline input element for a position.</summary>
+        Position,
+
+        /// <summary>Defines a graphics pipeline input element for a color.</summary>
+        Color,
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -111,11 +111,11 @@ namespace TerraFX.Graphics.Providers.D3D12
             return new D3D12GraphicsBuffer(this, kind, size, stride);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader, GraphicsShader)" />
-        public D3D12GraphicsPipeline CreateD3D12GraphicsPipeline(D3D12GraphicsShader? vertexShader = null, D3D12GraphicsShader? pixelShader = null)
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader?, ReadOnlySpan{GraphicsPipelineInputElement}, GraphicsShader?)" />
+        public D3D12GraphicsPipeline CreateD3D12GraphicsPipeline(D3D12GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, D3D12GraphicsShader? pixelShader = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new D3D12GraphicsPipeline(this, vertexShader, pixelShader);
+            return new D3D12GraphicsPipeline(this, vertexShader, inputElements, pixelShader);
         }
 
         /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
@@ -136,7 +136,7 @@ namespace TerraFX.Graphics.Providers.D3D12
         public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateD3D12GraphicsBuffer(kind, size, stride);
 
         /// <inheritdoc />
-        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsShader?)vertexShader, (D3D12GraphicsShader?)pixelShader);
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsShader?)vertexShader, inputElements, (D3D12GraphicsShader?)pixelShader);
 
         /// <inheritdoc />
         public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer, (D3D12GraphicsBuffer?)indexBuffer);

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
@@ -100,7 +100,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             var bufferCreateInfo = new VkBufferCreateInfo {
                 sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
                 size = Size,
-                usage = (uint)VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                usage = GetVulkanBufferUsageKind(Kind),
             };
             ThrowExternalExceptionIfNotSuccess(nameof(vkCreateBuffer), vkCreateBuffer(VulkanGraphicsDevice.VulkanDevice, &bufferCreateInfo, pAllocator: null, (ulong*)&vulkanBuffer));
 
@@ -151,6 +151,34 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 }
                 return memoryTypeIndex;
             }
+        }
+
+        private uint GetVulkanBufferUsageKind(GraphicsBufferKind kind)
+        {
+            VkBufferUsageFlagBits vulkanBufferUsageKind;
+
+            switch (kind)
+            {
+                case GraphicsBufferKind.Vertex:
+                {
+                    vulkanBufferUsageKind = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+                    break;
+                }
+
+                case GraphicsBufferKind.Index:
+                {
+                    vulkanBufferUsageKind = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+                    break;
+                }
+
+                default:
+                {
+                    vulkanBufferUsageKind = 0;
+                    break;
+                }
+            }
+
+            return (uint)vulkanBufferUsageKind;
         }
 
         private void DisposeVulkanBuffer(VkBuffer vulkanBuffer)

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -130,11 +130,11 @@ namespace TerraFX.Graphics.Providers.Vulkan
             return new VulkanGraphicsBuffer(this, kind, size, stride);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader, GraphicsShader)" />
-        public VulkanGraphicsPipeline CreateVulkanGraphicsPipeline(VulkanGraphicsShader? vertexShader = null, VulkanGraphicsShader? pixelShader = null)
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader?, ReadOnlySpan{GraphicsPipelineInputElement}, GraphicsShader?)" />
+        public VulkanGraphicsPipeline CreateVulkanGraphicsPipeline(VulkanGraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, VulkanGraphicsShader? pixelShader = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new VulkanGraphicsPipeline(this, vertexShader, pixelShader);
+            return new VulkanGraphicsPipeline(this, vertexShader, inputElements, pixelShader);
         }
 
         /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
@@ -155,7 +155,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
         public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateVulkanGraphicsBuffer(kind, size, stride);
 
         /// <inheritdoc />
-        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsShader?)vertexShader, (VulkanGraphicsShader?)pixelShader);
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsShader?)vertexShader, inputElements, (VulkanGraphicsShader?)pixelShader);
 
         /// <inheritdoc />
         public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer, (VulkanGraphicsBuffer?)indexBuffer);


### PR DESCRIPTION
This adds a new `GraphicsPipelineInputElement` type which can be used to describe the layout of the input to the vertex shader. The recognized types are currently fairly limited but will be expanded as other functionality comes online.