### PR TITLE
Adding basic support for constant/uniform buffers

### DIFF
--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -82,7 +82,7 @@ namespace TerraFX.Samples.Graphics
             var graphicsDevice = _graphicsDevice;
             var graphicsSurface = graphicsDevice.GraphicsSurface;
 
-            var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "VSMain", "PSMain");
+            var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "main", "main");
 
             var vertexBuffer = CreateVertexBuffer(graphicsDevice, aspectRatio: graphicsSurface.Width / graphicsSurface.Height);
             var indexBuffer = CreateIndexBuffer(graphicsDevice);
@@ -131,15 +131,25 @@ namespace TerraFX.Samples.Graphics
 
             GraphicsPipeline CreateGraphicsPipeline(GraphicsDevice graphicsDevice, string shaderName, string vertexShaderEntryPoint, string pixelShaderEntryPoint)
             {
-                var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, "Identity", "main");
-                var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, "Identity", "main");
+                var signature = CreateGraphicsPipelineSignature(graphicsDevice);
+                var vertexShader = CompileShader(graphicsDevice, GraphicsShaderKind.Vertex, shaderName, vertexShaderEntryPoint);
+                var pixelShader = CompileShader(graphicsDevice, GraphicsShaderKind.Pixel, shaderName, pixelShaderEntryPoint);
 
-                var inputElements = new GraphicsPipelineInputElement[2] {
-                    new GraphicsPipelineInputElement(typeof(Vector3), GraphicsPipelineInputElementKind.Position, size: 12),
-                    new GraphicsPipelineInputElement(typeof(Vector4), GraphicsPipelineInputElementKind.Color, size: 16),
+                return graphicsDevice.CreateGraphicsPipeline(signature, vertexShader, pixelShader);
+            }
+
+            GraphicsPipelineSignature CreateGraphicsPipelineSignature(GraphicsDevice graphicsDevice)
+            {
+                var inputs = new GraphicsPipelineInput[1] {
+                    new GraphicsPipelineInput(
+                        new GraphicsPipelineInputElement[2] {
+                            new GraphicsPipelineInputElement(typeof(Vector3), GraphicsPipelineInputElementKind.Position, size: 12),
+                            new GraphicsPipelineInputElement(typeof(Vector4), GraphicsPipelineInputElementKind.Color, size: 16),
+                        }
+                    ),
                 };
 
-                return graphicsDevice.CreateGraphicsPipeline(vertexShader, inputElements, pixelShader);
+                return graphicsDevice.CreateGraphicsPipelineSignature(inputs);
             }
         }
     }

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -25,12 +25,15 @@ namespace TerraFX.Samples
             
             new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
             new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
-
+            
             new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
             new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
-
+            
             new HelloQuad("D3D12.HelloQuad", s_graphicsProviderD3D12),
             new HelloQuad("Vulkan.HelloQuad", s_graphicsProviderVulkan),
+
+            new HelloConstantBuffer("D3D12.HelloConstantBuffer", s_graphicsProviderD3D12),
+            new HelloConstantBuffer("Vulkan.HelloConstantBuffer", s_graphicsProviderVulkan),
 
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),

--- a/sources/Graphics/Assets/Shaders/TransformPixel.glsl
+++ b/sources/Graphics/Assets/Shaders/TransformPixel.glsl
@@ -1,0 +1,11 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#version 450 core
+
+layout(location = 0) in vec4 input_color;
+layout(location = 0) out vec4 output_color;
+
+void main()
+{
+    output_color = input_color;
+}

--- a/sources/Graphics/Assets/Shaders/TransformPixel.hlsl
+++ b/sources/Graphics/Assets/Shaders/TransformPixel.hlsl
@@ -1,0 +1,8 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#include "TransformTypes.hlsl"
+
+float4 main(PSInput input) : SV_Target
+{
+    return input.color;
+}

--- a/sources/Graphics/Assets/Shaders/TransformTypes.hlsl
+++ b/sources/Graphics/Assets/Shaders/TransformTypes.hlsl
@@ -1,0 +1,13 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+struct VSInput
+{
+    float3 position : POSITION;
+    float4 color : COLOR;
+};
+
+struct PSInput
+{
+    float4 position : SV_Position;
+    float4 color : COLOR;
+};

--- a/sources/Graphics/Assets/Shaders/TransformVertex.glsl
+++ b/sources/Graphics/Assets/Shaders/TransformVertex.glsl
@@ -1,0 +1,33 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#version 450 core
+
+layout(binding = 0, std140) uniform PerFrameInput
+{
+    layout(column_major) mat4 frameTransform;
+};
+
+layout(binding = 1, std140) uniform PerPrimitiveInput
+{
+    layout(column_major) mat4 primitiveTransform;
+};
+
+layout(location = 0) in vec3 input_position;
+layout(location = 1) in vec4 input_color;
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+layout(location = 0) out vec4 output_color;
+
+void main()
+{
+    gl_Position = vec4(input_position, 1.0);
+
+    gl_Position = gl_Position * primitiveTransform;
+    gl_Position = gl_Position * frameTransform;
+
+    output_color = input_color;
+}

--- a/sources/Graphics/Assets/Shaders/TransformVertex.hlsl
+++ b/sources/Graphics/Assets/Shaders/TransformVertex.hlsl
@@ -1,0 +1,27 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+#include "TransformTypes.hlsl"
+
+cbuffer PerFrameInput : register(b0)
+{
+    matrix frameTransform;
+};
+
+cbuffer PerPrimitiveInput : register(b1)
+{
+    matrix primitiveTransform;
+};
+
+PSInput main(VSInput input)
+{
+    PSInput output;
+
+    output.position = float4(input.position, 1.0f);
+
+    output.position = mul(output.position, primitiveTransform);
+    output.position = mul(output.position, frameTransform);
+
+    output.color = input.color;
+
+    return output;
+}

--- a/sources/Graphics/GraphicsBufferKind.cs
+++ b/sources/Graphics/GraphicsBufferKind.cs
@@ -13,5 +13,8 @@ namespace TerraFX.Graphics
 
         /// <summary>Defines an index buffer.</summary>
         Index,
+
+        /// <summary>Defines a constant buffer.</summary>
+        Constant,
     }
 }

--- a/sources/Graphics/GraphicsDevice.cs
+++ b/sources/Graphics/GraphicsDevice.cs
@@ -47,29 +47,37 @@ namespace TerraFX.Graphics
         public abstract GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride);
 
         /// <summary>Creates a new graphics pipeline for the device.</summary>
+        /// <param name="signature">The signature which details the inputs given and resources available to the graphics pipeline.</param>
         /// <param name="vertexShader">The vertex shader for the graphics pipeline or <c>null</c> if none exists.</param>
-        /// <param name="inputElements">The input elements describing the inputs to <paramref name="vertexShader" /> or <c>null</c> if none exist.</param>
         /// <param name="pixelShader">The pixel shader for the graphics pipeline or <c>null</c> if none exists.</param>
         /// <returns>A new graphics pipeline created for the device.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="vertexShader" /> is <c>null</c> and <paramref name="inputElements" /> is not empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="signature" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for this device.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> was not created for this device.</exception>
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
-        public abstract GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null);
+        public abstract GraphicsPipeline CreateGraphicsPipeline(GraphicsPipelineSignature signature, GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null);
+
+        /// <summary>Creates a new graphics pipeline signature for the device.</summary>
+        /// <param name="inputs">The inputs given to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</param>
+        /// <param name="resources">The resources available to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</param>
+        /// <returns>A new graphics pipeline signature created for the device.</returns>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public abstract GraphicsPipelineSignature CreateGraphicsPipelineSignature(ReadOnlySpan<GraphicsPipelineInput> inputs = default, ReadOnlySpan<GraphicsPipelineResource> resources = default);
 
         /// <summary>Creates a new graphics primitive for the device.</summary>
         /// <param name="graphicsPipeline">The graphics pipeline used for rendering the graphics primitive.</param>
         /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the graphics primitive.</param>
         /// <param name="indexBuffer">The graphics buffer which holds the indices for the graphics primitive or <c>null</c> if none exists.</param>
+        /// <param name="inputBuffers"></param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for this device.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for this device.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBuffer" /> was not created for this device.</exception>
         /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
-        public abstract GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null);
+        public abstract GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null, ReadOnlySpan<GraphicsBuffer> inputBuffers = default);
 
         /// <summary>Creates a new graphics shader for the device.</summary>
         /// <param name="kind">The kind of graphics shader to create.</param>

--- a/sources/Graphics/GraphicsPipeline.cs
+++ b/sources/Graphics/GraphicsPipeline.cs
@@ -9,33 +9,29 @@ namespace TerraFX.Graphics
     public abstract class GraphicsPipeline : IDisposable
     {
         private readonly GraphicsDevice _graphicsDevice;
+        private readonly GraphicsPipelineSignature _signature;
         private readonly GraphicsShader? _vertexShader;
-        private readonly GraphicsPipelineInputElement[] _inputElements;
         private readonly GraphicsShader? _pixelShader;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsPipeline" /> class.</summary>
         /// <param name="graphicsDevice">The graphics device for which the pipeline was created.</param>
+        /// <param name="signature">The signature which details the inputs given and resources available to the pipeline.</param>
         /// <param name="vertexShader">The vertex shader for the pipeline or <c>null</c> if none exists.</param>
-        /// <param name="inputElements">The input elements describing the inputs to <paramref name="vertexShader" /> or <c>null</c> if none exist.</param>
         /// <param name="pixelShader">The pixel shader for the pipeline or <c>null</c> if none exists.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="vertexShader" /> is <c>null</c> and <paramref name="inputElements" /> is not empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="signature" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> is not <see cref="GraphicsShaderKind.Vertex"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexShader" /> was not created for <paramref name="graphicsDevice" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" /> is not <see cref="GraphicsShaderKind.Pixel"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pixelShader" />was not created for <paramref name="graphicsDevice" />.</exception>
-        protected GraphicsPipeline(GraphicsDevice graphicsDevice, GraphicsShader? vertexShader, ReadOnlySpan<GraphicsPipelineInputElement> inputElements, GraphicsShader? pixelShader)
+        protected GraphicsPipeline(GraphicsDevice graphicsDevice, GraphicsPipelineSignature signature, GraphicsShader? vertexShader, GraphicsShader? pixelShader)
         {
             ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+            ThrowIfNull(signature, nameof(signature));
 
             if ((vertexShader != null) && ((vertexShader.Kind != GraphicsShaderKind.Vertex) || (vertexShader.GraphicsDevice != graphicsDevice)))
             {
                 ThrowArgumentOutOfRangeException(nameof(vertexShader), vertexShader);
-            }
-
-            if (!inputElements.IsEmpty)
-            {
-                ThrowIfNull(vertexShader, nameof(vertexShader));
             }
 
             if ((pixelShader != null) && ((pixelShader.Kind != GraphicsShaderKind.Pixel) || (pixelShader.GraphicsDevice != graphicsDevice)))
@@ -44,8 +40,8 @@ namespace TerraFX.Graphics
             }
 
             _graphicsDevice = graphicsDevice;
+            _signature = signature;
             _vertexShader = vertexShader;
-            _inputElements = inputElements.ToArray();
             _pixelShader = pixelShader;
         }
 
@@ -58,11 +54,11 @@ namespace TerraFX.Graphics
         /// <summary>Gets <c>true</c> if the pipeline has a vertex shader; otherwise, <c>false</c>.</summary>
         public bool HasVertexShader => _vertexShader != null;
 
-        /// <summary>Gets the input elements describing the inputs to <see cref="VertexShader" /> or <c>null</c> if none exist.</summary>
-        public ReadOnlySpan<GraphicsPipelineInputElement> InputElements => _inputElements;
-
         /// <summary>Gets the pixel shader for the pipeline or <c>null</c> if none exists.</summary>
         public GraphicsShader? PixelShader => _pixelShader;
+
+        /// <summary>Gets the signature of the pipeline.</summary>
+        public GraphicsPipelineSignature Signature => _signature;
 
         /// <summary>Gets the vertex shader for the pipeline or <c>null</c> if none exists.</summary>
         public GraphicsShader? VertexShader => _vertexShader;

--- a/sources/Graphics/GraphicsPipelineInput.cs
+++ b/sources/Graphics/GraphicsPipelineInput.cs
@@ -1,0 +1,22 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics pipeline input which describes an input to a stage of the graphics pipeline.</summary>
+    public readonly struct GraphicsPipelineInput
+    {
+        private readonly GraphicsPipelineInputElement[] _elements;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsPipelineInput" /> struct.</summary>
+        /// <param name="elements">The elements that make up the pipeline input.</param>
+        public GraphicsPipelineInput(ReadOnlySpan<GraphicsPipelineInputElement> elements)
+        {
+            _elements = elements.ToArray();
+        }
+
+        /// <summary>Gets the elements that make up the pipeline input.</summary>
+        public ReadOnlySpan<GraphicsPipelineInputElement> Elements => _elements;       
+    }
+}

--- a/sources/Graphics/GraphicsPipelineInputElement.cs
+++ b/sources/Graphics/GraphicsPipelineInputElement.cs
@@ -5,17 +5,17 @@ using static TerraFX.Utilities.ExceptionUtilities;
 
 namespace TerraFX.Graphics
 {
-    /// <summary>A graphics pipeline input element which describes an element of an input vertex.</summary>
+    /// <summary>A graphics pipeline input element which describes an element graphics pipeline input.</summary>
     public readonly struct GraphicsPipelineInputElement
     {
         private readonly Type _type;
         private readonly GraphicsPipelineInputElementKind _kind;
         private readonly uint _size;
 
-        /// <summary>Creates a new instance of the <see cref="GraphicsPipelineInputElement" /> struct.</summary>
-        /// <param name="type">The type of the input element.</param>
-        /// <param name="kind">The kind of the input element.</param>
-        /// <param name="size">The size, in bytes, of the input element.</param>
+        /// <summary>Initializes a new instance of the <see cref="GraphicsPipelineInputElement" /> struct.</summary>
+        /// <param name="type">The type of the pipeline input element.</param>
+        /// <param name="kind">The kind of the pipeline input element.</param>
+        /// <param name="size">The size, in bytes, of the pipeline input element.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type" /> is <c>null</c>.</exception>
         public GraphicsPipelineInputElement(Type type, GraphicsPipelineInputElementKind kind, uint size)
         {

--- a/sources/Graphics/GraphicsPipelineResource.cs
+++ b/sources/Graphics/GraphicsPipelineResource.cs
@@ -1,0 +1,26 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics pipeline resource which is a graphics resource available to one or more stages of a graphics pipeline.</summary>
+    public readonly struct GraphicsPipelineResource
+    {
+        private readonly GraphicsPipelineResourceKind _kind;
+        private readonly GraphicsShaderVisibility _shaderVisibility;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsPipelineInput" /> struct.</summary>
+        /// <param name="kind">The kind of the pipeline input.</param>
+        /// <param name="shaderVisibility">The graphics shader kind(s) for which the pipeline resource is visible.</param>
+        public GraphicsPipelineResource(GraphicsPipelineResourceKind kind, GraphicsShaderVisibility shaderVisibility)
+        {
+            _kind = kind;
+            _shaderVisibility = shaderVisibility;
+        }
+
+        /// <summary>Gets the kind of the pipeline resource.</summary>
+        public GraphicsPipelineResourceKind Kind => _kind;
+
+        /// <summary>Gets the graphics shader  kind(s) for which the pipeline resource is visible.</summary>
+        public GraphicsShaderVisibility ShaderVisibility => _shaderVisibility;
+    }
+}

--- a/sources/Graphics/GraphicsPipelineResourceKind.cs
+++ b/sources/Graphics/GraphicsPipelineResourceKind.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Graphics
+{
+    /// <summary>Defines the kind of a graphics pipeline resource.</summary>
+    public enum GraphicsPipelineResourceKind
+    {
+        /// <summary>Defines an unknown graphics pipeline resource kind.</summary>
+        Unknown,
+
+        /// <summary>Defines a constant buffer graphics pipeline resource.</summary>
+        ConstantBuffer,
+    }
+}

--- a/sources/Graphics/GraphicsPipelineSignature.cs
+++ b/sources/Graphics/GraphicsPipelineSignature.cs
@@ -1,0 +1,49 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>A graphics pipeline signature which details the inputs given and resources available to a graphics pipeline.</summary>
+    public abstract class GraphicsPipelineSignature : IDisposable
+    {
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly GraphicsPipelineInput[] _inputs;
+        private readonly GraphicsPipelineResource[] _resources;
+
+        /// <summary>Creates a new instance of the <see cref="GraphicsPipelineSignature" /> class.</summary>
+        /// <param name="graphicsDevice">The graphics device for which the pipeline signature was created.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
+        /// <param name="inputs">The inputs given to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</param>
+        /// <param name="resources">The resources available to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</param>
+        protected GraphicsPipelineSignature(GraphicsDevice graphicsDevice, ReadOnlySpan<GraphicsPipelineInput> inputs, ReadOnlySpan<GraphicsPipelineResource> resources)
+        {
+            ThrowIfNull(graphicsDevice, nameof(graphicsDevice));
+
+            _graphicsDevice = graphicsDevice;
+            _inputs = inputs.ToArray();
+            _resources = resources.ToArray();
+        }
+
+        /// <summary>Gets the graphics device for which the pipeline was created.</summary>
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        /// <summary>Gets the inputs given to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</summary>
+        public ReadOnlySpan<GraphicsPipelineInput> Inputs => _inputs;
+
+        /// <summary>Gets the resources available to the graphics pipeline or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</summary>
+        public ReadOnlySpan<GraphicsPipelineResource> Resources => _resources;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
+    }
+}

--- a/sources/Graphics/GraphicsPrimitive.cs
+++ b/sources/Graphics/GraphicsPrimitive.cs
@@ -12,19 +12,21 @@ namespace TerraFX.Graphics
         private readonly GraphicsPipeline _graphicsPipeline;
         private readonly GraphicsBuffer _vertexBuffer;
         private readonly GraphicsBuffer? _indexBuffer;
+        private readonly GraphicsBuffer[] _constantBuffers;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsPrimitive" /> class.</summary>
         /// <param name="graphicsDevice">The graphics device for which the primitive was created.</param>
         /// <param name="graphicsPipeline">The graphics pipeline used for rendering the primitive.</param>
         /// <param name="vertexBuffer">The graphics buffer which holds the vertices for the primitive.</param>
         /// <param name="indexBuffer">The graphics buffer which holds the indices for the primitive or <c>null</c> if none exists.</param>
+        /// <param name="constantBuffers">The constant buffers which hold the constant data for the primitive or an empty span if none exist.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsPipeline" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="graphicsPipeline" /> was not created for <paramref name="graphicsDevice" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for <paramref name="graphicsDevice" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBuffer" /> was not created for <paramref name="graphicsDevice" />.</exception>
-        protected GraphicsPrimitive(GraphicsDevice graphicsDevice, GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer)
+        protected GraphicsPrimitive(GraphicsDevice graphicsDevice, GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer, ReadOnlySpan<GraphicsBuffer> constantBuffers)
         {
             ThrowIfNull(graphicsPipeline, nameof(graphicsPipeline));
             ThrowIfNull(vertexBuffer, nameof(vertexBuffer));
@@ -49,7 +51,11 @@ namespace TerraFX.Graphics
 
             _vertexBuffer = vertexBuffer;
             _indexBuffer = indexBuffer;
+            _constantBuffers = constantBuffers.ToArray();
         }
+
+        /// <summary>Gets the constant buffers which hold the constant data for the primitive or <see cref="ReadOnlySpan{T}.Empty" /> if none exist.</summary>
+        public ReadOnlySpan<GraphicsBuffer> ConstantBuffers => _constantBuffers;
 
         /// <summary>Gets the graphics device for which the pipeline was created.</summary>
         public GraphicsDevice GraphicsDevice => _graphicsDevice;

--- a/sources/Graphics/GraphicsShaderVisibility.cs
+++ b/sources/Graphics/GraphicsShaderVisibility.cs
@@ -1,0 +1,20 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace TerraFX.Graphics
+{
+    /// <summary>Defines the graphics shader(s) for which a resource is visible.</summary>
+    [Flags]
+    public enum GraphicsShaderVisibility
+    {
+        /// <summary>Defines visibility to all shaders.</summary>
+        All = 0,
+
+        /// <summary>Defines vertex shader visibility.</summary>
+        Vertex = 1,
+
+        /// <summary>Defines pixel shader visibility.</summary>
+        Pixel = 2,
+    }
+}

--- a/sources/Graphics/TerraFX.Graphics.csproj
+++ b/sources/Graphics/TerraFX.Graphics.csproj
@@ -12,6 +12,11 @@
     <None Include="Assets\Shaders\IdentityPixel.hlsl" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Assets\Shaders\IdentityVertex.glsl" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Assets\Shaders\IdentityVertex.hlsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\TransformPixel.glsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\TransformPixel.hlsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\TransformTypes.hlsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\TransformVertex.glsl" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\Shaders\TransformVertex.hlsl" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -133,7 +133,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             var graphicsPipeline = graphicsPrimitive.D3D12GraphicsPipeline;
             var vertexBuffer = graphicsPrimitive.D3D12VertexBuffer;
 
-            graphicsCommandList->SetGraphicsRootSignature(graphicsPipeline.D3D12RootSignature);
+            graphicsCommandList->SetGraphicsRootSignature(graphicsPipeline.D3D12Signature.D3D12RootSignature);
             graphicsCommandList->SetPipelineState(graphicsPipeline.D3D12PipelineState);
 
             var vertexBufferView = new D3D12_VERTEX_BUFFER_VIEW {
@@ -142,6 +142,15 @@ namespace TerraFX.Graphics.Providers.D3D12
                 SizeInBytes = (uint)vertexBuffer.Size,
             };
             graphicsCommandList->IASetVertexBuffers(StartSlot: 0, NumViews: 1, &vertexBufferView);
+
+            var constantBuffers = graphicsPrimitive.ConstantBuffers;
+            var constantBuffersLength = constantBuffers.Length;
+
+            for (var index = 0; index < constantBuffersLength; index++)
+            {
+                var constantBuffer = (D3D12GraphicsBuffer)constantBuffers[index];
+                graphicsCommandList->SetGraphicsRootConstantBufferView(unchecked((uint)index), constantBuffer.D3D12Resource->GetGPUVirtualAddress());
+            }
 
             var indexBuffer = graphicsPrimitive.D3D12IndexBuffer;
 

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -111,18 +111,18 @@ namespace TerraFX.Graphics.Providers.D3D12
             return new D3D12GraphicsBuffer(this, kind, size, stride);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader?, ReadOnlySpan{GraphicsPipelineInputElement}, GraphicsShader?)" />
-        public D3D12GraphicsPipeline CreateD3D12GraphicsPipeline(D3D12GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, D3D12GraphicsShader? pixelShader = null)
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsPipelineSignature, GraphicsShader?, GraphicsShader?)" />
+        public D3D12GraphicsPipeline CreateD3D12GraphicsPipeline(D3D12GraphicsPipelineSignature signature, D3D12GraphicsShader ? vertexShader = null, D3D12GraphicsShader? pixelShader = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new D3D12GraphicsPipeline(this, vertexShader, inputElements, pixelShader);
+            return new D3D12GraphicsPipeline(this, signature, vertexShader, pixelShader);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
-        public D3D12GraphicsPrimitive CreateD3D12GraphicsPrimitive(D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer = null)
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer, ReadOnlySpan{GraphicsBuffer})" />
+        public D3D12GraphicsPrimitive CreateD3D12GraphicsPrimitive(D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer = null, ReadOnlySpan<GraphicsBuffer> inputBuffers = default)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new D3D12GraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer);
+            return new D3D12GraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer, inputBuffers);
         }
 
         /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
@@ -136,10 +136,17 @@ namespace TerraFX.Graphics.Providers.D3D12
         public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateD3D12GraphicsBuffer(kind, size, stride);
 
         /// <inheritdoc />
-        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsShader?)vertexShader, inputElements, (D3D12GraphicsShader?)pixelShader);
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsPipelineSignature signature, GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateD3D12GraphicsPipeline((D3D12GraphicsPipelineSignature)signature, (D3D12GraphicsShader?)vertexShader, (D3D12GraphicsShader?)pixelShader);
 
         /// <inheritdoc />
-        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer, (D3D12GraphicsBuffer?)indexBuffer);
+        public override GraphicsPipelineSignature CreateGraphicsPipelineSignature(ReadOnlySpan<GraphicsPipelineInput> inputs = default, ReadOnlySpan<GraphicsPipelineResource> resources = default)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new D3D12GraphicsPipelineSignature(this, inputs, resources);
+        }
+
+        /// <inheritdoc />
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null, ReadOnlySpan<GraphicsBuffer> inputBuffers = default) => CreateD3D12GraphicsPrimitive((D3D12GraphicsPipeline)graphicsPipeline, (D3D12GraphicsBuffer)vertexBuffer, (D3D12GraphicsBuffer?)indexBuffer, inputBuffers);
 
         /// <inheritdoc />
         public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateD3D12GraphicsShader(kind, bytecode, entryPointName);

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPipelineSignature.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPipelineSignature.cs
@@ -1,0 +1,159 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Numerics;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D_ROOT_SIGNATURE_VERSION;
+using static TerraFX.Interop.D3D12;
+using static TerraFX.Interop.D3D12_PRIMITIVE_TOPOLOGY_TYPE;
+using static TerraFX.Interop.D3D12_ROOT_SIGNATURE_FLAGS;
+using static TerraFX.Interop.D3D12_SHADER_VISIBILITY;
+using static TerraFX.Interop.DXGI_FORMAT;
+using static TerraFX.Interop.Windows;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.State;
+
+namespace TerraFX.Graphics.Providers.D3D12
+{
+    /// <inheritdoc />
+    public sealed unsafe class D3D12GraphicsPipelineSignature : GraphicsPipelineSignature
+    {
+        private ValueLazy<Pointer<ID3D12RootSignature>> _d3d12RootSignature;
+
+        private State _state;
+
+        internal D3D12GraphicsPipelineSignature(D3D12GraphicsDevice graphicsDevice, ReadOnlySpan<GraphicsPipelineInput> inputs, ReadOnlySpan<GraphicsPipelineResource> resources)
+            : base(graphicsDevice, inputs, resources)
+        {
+            _d3d12RootSignature = new ValueLazy<Pointer<ID3D12RootSignature>>(CreateD3D12RootSignature);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsPipelineSignature" /> class.</summary>
+        ~D3D12GraphicsPipelineSignature()
+        {
+            Dispose(isDisposing: false);
+        }
+
+        /// <inheritdoc cref="GraphicsPipeline.GraphicsDevice" />
+        public D3D12GraphicsDevice D3D12GraphicsDevice => (D3D12GraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="ID3D12RootSignature" /> for the pipeline.</summary>
+        public ID3D12RootSignature* D3D12RootSignature => _d3d12RootSignature.Value;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _d3d12RootSignature.Dispose(ReleaseIfNotNull);
+            }
+
+            _state.EndDispose();
+        }
+
+        private Pointer<ID3D12RootSignature> CreateD3D12RootSignature()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            ID3DBlob* rootSignatureBlob = null;
+            ID3DBlob* rootSignatureErrorBlob = null;
+
+            try
+            {
+                ID3D12RootSignature* d3d12RootSignature;
+
+                var rootParameters = Array.Empty<D3D12_ROOT_PARAMETER>();
+
+                var rootSignatureDesc = new D3D12_ROOT_SIGNATURE_DESC {
+                    Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+                };
+
+                var resources = Resources;
+                var resourcesLength = resources.Length;
+
+                var rootParametersIndex = 0;
+                var constantShaderRegister = 0;
+
+                if (resourcesLength != 0)
+                {
+                    rootParameters = new D3D12_ROOT_PARAMETER[resourcesLength];
+
+                    for (var inputIndex = 0; inputIndex < resourcesLength; inputIndex++)
+                    {
+                        var input = resources[inputIndex];
+
+                        switch (input.Kind)
+                        {
+                            case GraphicsPipelineResourceKind.ConstantBuffer:
+                            {
+                                var shaderVisibility = GetD3D12ShaderVisiblity(input.ShaderVisibility);
+                                rootParameters[rootParametersIndex].InitAsConstantBufferView(unchecked((uint)constantShaderRegister), registerSpace: 0, shaderVisibility);
+
+                                constantShaderRegister++;
+                                rootParametersIndex++;
+                                break;
+                            }
+
+                            default:
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                fixed (D3D12_ROOT_PARAMETER* pRootParameters = rootParameters)
+                {
+                    rootSignatureDesc.NumParameters = unchecked((uint)rootParameters.Length);
+                    rootSignatureDesc.pParameters = pRootParameters;
+
+                    ThrowExternalExceptionIfFailed(nameof(D3D12SerializeRootSignature), D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &rootSignatureBlob, &rootSignatureErrorBlob));
+                }
+
+                var iid = IID_ID3D12RootSignature;
+                ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateRootSignature), D3D12GraphicsDevice.D3D12Device->CreateRootSignature(0, rootSignatureBlob->GetBufferPointer(), rootSignatureBlob->GetBufferSize(), &iid, (void**)&d3d12RootSignature));
+
+                return d3d12RootSignature;
+            }
+            finally
+            {
+                ReleaseIfNotNull(rootSignatureErrorBlob);
+                ReleaseIfNotNull(rootSignatureBlob);
+            }
+
+            static D3D12_SHADER_VISIBILITY GetD3D12ShaderVisiblity(GraphicsShaderVisibility shaderVisibility)
+            {
+                D3D12_SHADER_VISIBILITY d3d12ShaderVisibility;
+
+                switch (shaderVisibility)
+                {
+                    case GraphicsShaderVisibility.Vertex:
+                    {
+                        d3d12ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
+                        break;
+                    }
+
+                    case GraphicsShaderVisibility.Pixel:
+                    {
+                        d3d12ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+                        break;
+                    }
+
+                    default:
+                    {
+                        d3d12ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+                        break;
+                    }
+                }
+
+                return d3d12ShaderVisibility;
+            }
+        }
+    }
+}

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
@@ -1,5 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using TerraFX.Utilities;
 using static TerraFX.Utilities.DisposeUtilities;
 using static TerraFX.Utilities.State;
@@ -11,8 +12,8 @@ namespace TerraFX.Graphics.Providers.D3D12
     {
         private State _state;
 
-        internal D3D12GraphicsPrimitive(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer)
-            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer)
+        internal D3D12GraphicsPrimitive(D3D12GraphicsDevice graphicsDevice, D3D12GraphicsPipeline graphicsPipeline, D3D12GraphicsBuffer vertexBuffer, D3D12GraphicsBuffer? indexBuffer, ReadOnlySpan<GraphicsBuffer> constantBuffers)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer, constantBuffers)
         {
             _ = _state.Transition(to: Initialized);
         }
@@ -45,6 +46,11 @@ namespace TerraFX.Graphics.Providers.D3D12
                 DisposeIfNotNull(GraphicsPipeline);
                 DisposeIfNotNull(VertexBuffer);
                 DisposeIfNotNull(IndexBuffer);
+
+                foreach (var inputBuffer in ConstantBuffers)
+                {
+                    DisposeIfNotNull(inputBuffer);
+                }
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
@@ -171,6 +171,12 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     break;
                 }
 
+                case GraphicsBufferKind.Constant:
+                {
+                    vulkanBufferUsageKind = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+                    break;
+                }
+
                 default:
                 {
                     vulkanBufferUsageKind = 0;

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -130,18 +130,18 @@ namespace TerraFX.Graphics.Providers.Vulkan
             return new VulkanGraphicsBuffer(this, kind, size, stride);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsShader?, ReadOnlySpan{GraphicsPipelineInputElement}, GraphicsShader?)" />
-        public VulkanGraphicsPipeline CreateVulkanGraphicsPipeline(VulkanGraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, VulkanGraphicsShader? pixelShader = null)
+        /// <inheritdoc cref="CreateGraphicsPipeline(GraphicsPipelineSignature, GraphicsShader?, GraphicsShader?)" />
+        public VulkanGraphicsPipeline CreateVulkanGraphicsPipeline(VulkanGraphicsPipelineSignature signature, VulkanGraphicsShader? vertexShader = null, VulkanGraphicsShader? pixelShader = null)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new VulkanGraphicsPipeline(this, vertexShader, inputElements, pixelShader);
+            return new VulkanGraphicsPipeline(this, signature, vertexShader, pixelShader);
         }
 
-        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer)" />
-        public VulkanGraphicsPrimitive CreateVulkanGraphicsPrimitive(VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer = null)
+        /// <inheritdoc cref="CreateGraphicsPrimitive(GraphicsPipeline, GraphicsBuffer, GraphicsBuffer, ReadOnlySpan{GraphicsBuffer})" />
+        public VulkanGraphicsPrimitive CreateVulkanGraphicsPrimitive(VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer = null, ReadOnlySpan<GraphicsBuffer> inputBuffers = default)
         {
             _state.ThrowIfDisposedOrDisposing();
-            return new VulkanGraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer);
+            return new VulkanGraphicsPrimitive(this, graphicsPipeline, vertexBuffer, indexBuffer, inputBuffers);
         }
 
         /// <inheritdoc cref="CreateGraphicsShader(GraphicsShaderKind, ReadOnlySpan{byte}, string)" />
@@ -155,10 +155,17 @@ namespace TerraFX.Graphics.Providers.Vulkan
         public override GraphicsBuffer CreateGraphicsBuffer(GraphicsBufferKind kind, ulong size, ulong stride) => CreateVulkanGraphicsBuffer(kind, size, stride);
 
         /// <inheritdoc />
-        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsShader? vertexShader = null, ReadOnlySpan<GraphicsPipelineInputElement> inputElements = default, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsShader?)vertexShader, inputElements, (VulkanGraphicsShader?)pixelShader);
+        public override GraphicsPipeline CreateGraphicsPipeline(GraphicsPipelineSignature signature, GraphicsShader? vertexShader = null, GraphicsShader? pixelShader = null) => CreateVulkanGraphicsPipeline((VulkanGraphicsPipelineSignature)signature, (VulkanGraphicsShader?)vertexShader, (VulkanGraphicsShader?)pixelShader);
 
         /// <inheritdoc />
-        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer, (VulkanGraphicsBuffer?)indexBuffer);
+        public override GraphicsPipelineSignature CreateGraphicsPipelineSignature(ReadOnlySpan<GraphicsPipelineInput> inputs = default, ReadOnlySpan<GraphicsPipelineResource> resources = default)
+        {
+            _state.ThrowIfDisposedOrDisposing();
+            return new VulkanGraphicsPipelineSignature(this, inputs, resources);
+        }
+
+        /// <inheritdoc />
+        public override GraphicsPrimitive CreateGraphicsPrimitive(GraphicsPipeline graphicsPipeline, GraphicsBuffer vertexBuffer, GraphicsBuffer? indexBuffer = null, ReadOnlySpan<GraphicsBuffer> inputBuffers = default) => CreateVulkanGraphicsPrimitive((VulkanGraphicsPipeline)graphicsPipeline, (VulkanGraphicsBuffer)vertexBuffer, (VulkanGraphicsBuffer?)indexBuffer, inputBuffers);
 
         /// <inheritdoc />
         public override GraphicsShader CreateGraphicsShader(GraphicsShaderKind kind, ReadOnlySpan<byte> bytecode, string entryPointName) => CreateVulkanGraphicsShader(kind, bytecode, entryPointName);

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cs
@@ -1,0 +1,323 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using TerraFX.Interop;
+using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
+using static TerraFX.Interop.VkCompareOp;
+using static TerraFX.Interop.VkDescriptorPoolCreateFlagBits;
+using static TerraFX.Interop.VkDescriptorType;
+using static TerraFX.Interop.VkFrontFace;
+using static TerraFX.Interop.VkFormat;
+using static TerraFX.Interop.VkPrimitiveTopology;
+using static TerraFX.Interop.VkSampleCountFlagBits;
+using static TerraFX.Interop.VkShaderStageFlagBits;
+using static TerraFX.Interop.VkStructureType;
+using static TerraFX.Interop.VkVertexInputRate;
+using static TerraFX.Interop.Vulkan;
+using static TerraFX.Utilities.DisposeUtilities;
+using static TerraFX.Utilities.InteropUtilities;
+using static TerraFX.Utilities.State;
+using TerraFX.Numerics;
+
+namespace TerraFX.Graphics.Providers.Vulkan
+{
+    /// <inheritdoc />
+    public sealed unsafe class VulkanGraphicsPipelineSignature : GraphicsPipelineSignature
+    {
+        private ValueLazy<VkDescriptorPool> _vulkanDescriptorPool;
+        private ValueLazy<VkDescriptorSet> _vulkanDescriptorSet;
+        private ValueLazy<VkDescriptorSetLayout> _vulkanDescriptorSetLayout;
+        private ValueLazy<VkPipelineLayout> _vulkanPipelineLayout;
+
+        private State _state;
+
+        internal VulkanGraphicsPipelineSignature(VulkanGraphicsDevice graphicsDevice, ReadOnlySpan<GraphicsPipelineInput> inputs, ReadOnlySpan<GraphicsPipelineResource> resources)
+            : base(graphicsDevice, inputs, resources)
+        {
+            _vulkanDescriptorPool = new ValueLazy<VkDescriptorPool>(CreateVulkanDescriptorPool);
+            _vulkanDescriptorSet = new ValueLazy<VkDescriptorSet>(CreateVulkanDescriptorSet);
+            _vulkanDescriptorSetLayout = new ValueLazy<VkDescriptorSetLayout>(CreateVulkanDescriptorSetLayout);
+            _vulkanPipelineLayout = new ValueLazy<VkPipelineLayout>(CreateVulkanPipelineLayout);
+
+            _ = _state.Transition(to: Initialized);
+        }
+
+        /// <summary>Finalizes an instance of the <see cref="VulkanGraphicsPipelineSignature" /> class.</summary>
+        ~VulkanGraphicsPipelineSignature()
+        {
+            Dispose(isDisposing: true);
+        }
+
+        /// <summary>Gets the <see cref="VkDescriptorPool" /> for the pipeline.</summary>
+        public VkDescriptorPool VulkanDescriptorPool => _vulkanDescriptorPool.Value;
+
+        /// <summary>Gets the <see cref="VkDescriptorSet" /> for the pipeline.</summary>
+        public VkDescriptorSet VulkanDescriptorSet => _vulkanDescriptorSet.Value;
+
+        /// <summary>Gets the underlying <see cref="VkDescriptorSetLayout" /> for the pipeline.</summary>
+        public VkDescriptorSetLayout VulkanDescriptorSetLayout => _vulkanDescriptorSetLayout.Value;
+
+        /// <inheritdoc cref="GraphicsPipeline.GraphicsDevice" />
+        public VulkanGraphicsDevice VulkanGraphicsDevice => (VulkanGraphicsDevice)GraphicsDevice;
+
+        /// <summary>Gets the underlying <see cref="VkPipelineLayout" /> for the pipeline.</summary>
+        public VkPipelineLayout VulkanPipelineLayout => _vulkanPipelineLayout.Value;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool isDisposing)
+        {
+            var priorState = _state.BeginDispose();
+
+            if (priorState < Disposing)
+            {
+                _vulkanDescriptorSet.Dispose(DisposeVulkanDescriptorSet);
+                _vulkanDescriptorSetLayout.Dispose(DisposeVulkanDescriptorSetLayout);
+                _vulkanDescriptorPool.Dispose(DisposeVulkanDescriptorPool);
+                _vulkanPipelineLayout.Dispose(DisposeVulkanPipelineLayout);
+            }
+
+            _state.EndDispose();
+        }
+
+        private VkDescriptorPool CreateVulkanDescriptorPool()
+        {
+            VkDescriptorPool vulkanDescriptorPool;
+
+            var vulkanDescriptorPoolSizes = Array.Empty<VkDescriptorPoolSize>();
+
+            var descriptorPoolCreateInfo = new VkDescriptorPoolCreateInfo {
+                sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+                flags = (uint)VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+                maxSets = 1,
+            };
+
+            var resources = Resources;
+            var resourcesLength = resources.Length;
+
+            if (resourcesLength != 0)
+            {
+                var vulkanDescriptorPoolSizesCount = 0;
+                var constantBufferCount = 0;
+
+                for (var resourceIndex = 0; resourceIndex < resourcesLength; resourceIndex++)
+                {
+                    var resource = resources[resourceIndex];
+
+                    switch (resource.Kind)
+                    {
+                        case GraphicsPipelineResourceKind.ConstantBuffer:
+                        {
+                            if (constantBufferCount == 0)
+                            {
+                                vulkanDescriptorPoolSizesCount++;
+                            }
+                            constantBufferCount++;
+                            break;
+                        }
+
+                        default:
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                vulkanDescriptorPoolSizes = new VkDescriptorPoolSize[vulkanDescriptorPoolSizesCount];
+                var vulkanDescriptorPoolSizesIndex = 0;
+
+                if (constantBufferCount != 0)
+                {
+                    vulkanDescriptorPoolSizes[vulkanDescriptorPoolSizesIndex] = new VkDescriptorPoolSize {
+                        type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                        descriptorCount = unchecked((uint)constantBufferCount),
+                    };
+                    vulkanDescriptorPoolSizesIndex++;
+                }
+            }
+
+            fixed (VkDescriptorPoolSize* pVulkanDescriptorPoolSizes = vulkanDescriptorPoolSizes)
+            {
+                descriptorPoolCreateInfo.poolSizeCount = unchecked((uint)vulkanDescriptorPoolSizes.Length);
+                descriptorPoolCreateInfo.pPoolSizes = pVulkanDescriptorPoolSizes;
+
+                ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDescriptorPool), vkCreateDescriptorPool(VulkanGraphicsDevice.VulkanDevice, &descriptorPoolCreateInfo, pAllocator: null, (ulong*)&vulkanDescriptorPool));
+            }
+
+            return vulkanDescriptorPool;
+        }
+
+        private VkDescriptorSet CreateVulkanDescriptorSet()
+        {
+            VkDescriptorSet vulkanDescriptorSet;
+
+            var vulkanDescriptorSetLayout = VulkanDescriptorSetLayout;
+
+            var descriptorSetAllocateInfo = new VkDescriptorSetAllocateInfo {
+                sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+                descriptorPool = VulkanDescriptorPool,
+                descriptorSetCount = 1,
+                pSetLayouts = (ulong*)&vulkanDescriptorSetLayout,
+            };
+            ThrowExternalExceptionIfNotSuccess(nameof(vkAllocateDescriptorSets), vkAllocateDescriptorSets(VulkanGraphicsDevice.VulkanDevice, &descriptorSetAllocateInfo, (ulong*)&vulkanDescriptorSet));
+
+            return vulkanDescriptorSet;
+        }
+
+        private VkDescriptorSetLayout CreateVulkanDescriptorSetLayout()
+        {
+            VkDescriptorSetLayout vulkanDescriptorSetLayout;
+
+            var descriptorSetLayoutBindings = Array.Empty<VkDescriptorSetLayoutBinding>();
+
+            var descriptorSetLayoutCreateInfo = new VkDescriptorSetLayoutCreateInfo {
+                sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+            };
+
+            var resources = Resources;
+            var resourcesLength = resources.Length;
+
+            var descriptorSetLayoutBindingsIndex = 0;
+
+            if (resourcesLength != 0)
+            {
+                descriptorSetLayoutBindings = new VkDescriptorSetLayoutBinding[resourcesLength];
+
+                for (var resourceIndex = 0; resourceIndex < resourcesLength; resourceIndex++)
+                {
+                    var resource = resources[resourceIndex];
+
+                    switch (resource.Kind)
+                    {
+                        case GraphicsPipelineResourceKind.ConstantBuffer:
+                        {
+                            var stageFlags = GetVulkanShaderStageFlags(resource.ShaderVisibility);
+
+                            descriptorSetLayoutBindings[descriptorSetLayoutBindingsIndex] = new VkDescriptorSetLayoutBinding {
+                                binding = unchecked((uint)descriptorSetLayoutBindingsIndex),
+                                descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                descriptorCount = 1,
+                                stageFlags = stageFlags,
+                            };
+
+                            descriptorSetLayoutBindingsIndex++;
+                            break;
+                        }
+
+                        default:
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                fixed (VkDescriptorSetLayoutBinding* pDescriptorSetLayoutBindings = descriptorSetLayoutBindings)
+                {
+                    descriptorSetLayoutCreateInfo.bindingCount = unchecked((uint)descriptorSetLayoutBindings.Length);
+                    descriptorSetLayoutCreateInfo.pBindings = pDescriptorSetLayoutBindings;
+
+                    ThrowExternalExceptionIfNotSuccess(nameof(vkCreateDescriptorSetLayout), vkCreateDescriptorSetLayout(VulkanGraphicsDevice.VulkanDevice, &descriptorSetLayoutCreateInfo, pAllocator: null, (ulong*)&vulkanDescriptorSetLayout));
+                }
+            }
+            else
+            {
+                vulkanDescriptorSetLayout = VK_NULL_HANDLE;
+            }
+
+            return vulkanDescriptorSetLayout;
+
+            static uint GetVulkanShaderStageFlags(GraphicsShaderVisibility shaderVisibility)
+            {
+                var stageFlags = VK_SHADER_STAGE_ALL;
+
+                if (shaderVisibility != GraphicsShaderVisibility.All)
+                {
+                    if (!shaderVisibility.HasFlag(GraphicsShaderVisibility.Vertex))
+                    {
+                        stageFlags &= ~VK_SHADER_STAGE_VERTEX_BIT;
+                    }
+
+                    if (!shaderVisibility.HasFlag(GraphicsShaderVisibility.Pixel))
+                    {
+                        stageFlags &= ~VK_SHADER_STAGE_FRAGMENT_BIT;
+                    }
+                }
+
+                return (uint)stageFlags;
+            }
+        }
+
+        private VkPipelineLayout CreateVulkanPipelineLayout()
+        {
+            VkPipelineLayout vulkanPipelineLayout;
+
+            var pipelineLayoutCreateInfo = new VkPipelineLayoutCreateInfo {
+                sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO
+            };
+
+            var descriptorSetLayout = VulkanDescriptorSetLayout;
+
+            if (descriptorSetLayout != VK_NULL_HANDLE)
+            {
+                pipelineLayoutCreateInfo.setLayoutCount = 1;
+                pipelineLayoutCreateInfo.pSetLayouts = (ulong*)&descriptorSetLayout;
+            }
+
+            ThrowExternalExceptionIfNotSuccess(nameof(vkCreatePipelineLayout), vkCreatePipelineLayout(VulkanGraphicsDevice.VulkanDevice, &pipelineLayoutCreateInfo, pAllocator: null, (ulong*)&vulkanPipelineLayout));
+
+            return vulkanPipelineLayout;
+        }
+
+        private void DisposeVulkanDescriptorPool(VkDescriptorPool vulkanDescriptorPool)
+        {
+            if (vulkanDescriptorPool != VK_NULL_HANDLE)
+            {
+                vkDestroyDescriptorPool(VulkanGraphicsDevice.VulkanDevice, vulkanDescriptorPool, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanDescriptorSet(VkDescriptorSet vulkanDescriptorSet)
+        {
+            if (vulkanDescriptorSet != VK_NULL_HANDLE)
+            {
+                _ = vkFreeDescriptorSets(VulkanGraphicsDevice.VulkanDevice, VulkanDescriptorPool, 1, (ulong*)&vulkanDescriptorSet);
+            }
+        }
+
+        private void DisposeVulkanDescriptorSetLayout(VkDescriptorSetLayout vulkanDescriptorSetLayout)
+        {
+            if (vulkanDescriptorSetLayout != VK_NULL_HANDLE)
+            {
+                vkDestroyDescriptorSetLayout(VulkanGraphicsDevice.VulkanDevice, vulkanDescriptorSetLayout, pAllocator: null);
+            }
+        }
+
+        private void DisposeVulkanPipelineLayout(VkPipelineLayout vulkanPipelineLayout)
+        {
+            if (vulkanPipelineLayout != VK_NULL_HANDLE)
+            {
+                vkDestroyPipelineLayout(VulkanGraphicsDevice.VulkanDevice, vulkanPipelineLayout, pAllocator: null);
+            }
+        }
+
+        private VkFormat GetInputElementFormat(Type type)
+        {
+            var inputElementFormat = VK_FORMAT_UNDEFINED;
+
+            if (type == typeof(Vector2))
+            {
+                inputElementFormat = VK_FORMAT_R32G32_SFLOAT;
+            }
+            else if (type == typeof(Vector3))
+            {
+                inputElementFormat = VK_FORMAT_R32G32B32_SFLOAT;
+            }
+            else if (type == typeof(Vector4))
+            {
+                inputElementFormat = VK_FORMAT_R32G32B32A32_SFLOAT;
+            }
+
+            return inputElementFormat;
+        }
+    }
+}

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
@@ -1,5 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using TerraFX.Utilities;
 using static TerraFX.Utilities.DisposeUtilities;
 using static TerraFX.Utilities.State;
@@ -11,8 +12,8 @@ namespace TerraFX.Graphics.Providers.Vulkan
     {
         private State _state;
 
-        internal VulkanGraphicsPrimitive(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer)
-            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer)
+        internal VulkanGraphicsPrimitive(VulkanGraphicsDevice graphicsDevice, VulkanGraphicsPipeline graphicsPipeline, VulkanGraphicsBuffer vertexBuffer, VulkanGraphicsBuffer? indexBuffer, ReadOnlySpan<GraphicsBuffer> inputBuffers = default)
+            : base(graphicsDevice, graphicsPipeline, vertexBuffer, indexBuffer, inputBuffers)
         {
             _ = _state.Transition(to: Initialized);
         }


### PR DESCRIPTION
This adds basic support for declaring, updating, and consuming constant/uniform buffers.

There needs to be a bit of cleanup with resource management and being able to schedule updates (rather than forcing it as part of the draw call).