### PR TITLE
Don't use SRGB, fix vulkan, and enable samples

### DIFF
--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -20,28 +20,28 @@ namespace TerraFX.Samples
         internal static readonly Assembly s_graphicsProviderVulkan = Assembly.LoadFrom("TerraFX.Graphics.Providers.Vulkan.dll");
 
         private static readonly Sample[] s_samples = {
-            // new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_graphicsProviderD3D12),
-            // new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_graphicsProviderVulkan),
-            // 
-            // new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
-            // new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
-            // 
-            // new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
-            // new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
-            // 
-            // new HelloQuad("D3D12.HelloQuad", s_graphicsProviderD3D12),
-            // new HelloQuad("Vulkan.HelloQuad", s_graphicsProviderVulkan),
-            // 
-            // new HelloConstantBuffer("D3D12.HelloConstantBuffer", s_graphicsProviderD3D12),
-            // new HelloConstantBuffer("Vulkan.HelloConstantBuffer", s_graphicsProviderVulkan),
-            // 
-            // new HelloTexture("D3D12.HelloTexture", s_graphicsProviderD3D12),
+            new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_graphicsProviderD3D12),
+            new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_graphicsProviderVulkan),
+
+            new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
+            new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
+
+            new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
+            new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
+
+            new HelloQuad("D3D12.HelloQuad", s_graphicsProviderD3D12),
+            new HelloQuad("Vulkan.HelloQuad", s_graphicsProviderVulkan),
+
+            new HelloConstantBuffer("D3D12.HelloConstantBuffer", s_graphicsProviderD3D12),
+            new HelloConstantBuffer("Vulkan.HelloConstantBuffer", s_graphicsProviderVulkan),
+
+            new HelloTexture("D3D12.HelloTexture", s_graphicsProviderD3D12),
             new HelloTexture("Vulkan.HelloTexture", s_graphicsProviderVulkan),
-            // 
-            // new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
-            // new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),
-            // 
-            // new PlaySampleAudio("PulseAudio.PlaySampleAudio", s_audioProviderPulseAudio),
+
+            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
+            new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),
+
+            new PlaySampleAudio("PulseAudio.PlaySampleAudio", s_audioProviderPulseAudio),
         };
 
         public static void Main(string[] args)
@@ -149,12 +149,10 @@ namespace TerraFX.Samples
         private static void RunSample(Sample sample)
         {
             Console.WriteLine($"Running: {sample.Name}");
-            Run(sample);
-
-            // var thread = new Thread(() => Run(sample));
-            // 
-            // thread.Start();
-            // thread.Join();
+            var thread = new Thread(() => Run(sample));
+            
+            thread.Start();
+            thread.Join();
         }
     }
 }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -315,7 +315,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             // Fullscreen transitions are not currently supported
             ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(graphicsSurfaceHandle, DXGI_MWA_NO_ALT_ENTER));
 
-            _dxgiSwapChainFormat = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+            _dxgiSwapChainFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
             return dxgiSwapChain;
         }
 

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
@@ -271,7 +271,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     {
                         var descriptorBufferInfo = new VkDescriptorBufferInfo {
                             buffer = vulkanGraphicsBuffer.VulkanBuffer,
-                            offset = vulkanGraphicsBuffer.Offset,
+                            offset = 0,
                             range = vulkanGraphicsBuffer.Size,
                         };
 

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -423,7 +423,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             for (uint i = 0; i < surfaceFormatCount; i++)
             {
-                if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_SRGB)
+                if (surfaceFormats[i].format == VK_FORMAT_R8G8B8A8_UNORM)
                 {
                     swapChainCreateInfo.imageFormat = surfaceFormats[i].format;
                     swapChainCreateInfo.imageColorSpace = surfaceFormats[i].colorSpace;


### PR DESCRIPTION
This changes the graphics device to no longer use SRGB by default, fixes the vulkan implementation by ensuring the VkDescriptorBufferInfo is correctly created, and ensures that all samples are enabled again.