### PR TITLE
Updating the Vulkan Provider to cull and have the same origin as DirectX by default.

### DIFF
--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsContext.cs
@@ -122,8 +122,10 @@ namespace TerraFX.Graphics.Providers.Vulkan
             vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
             var viewport = new VkViewport {
+                x = 0,
+                y = graphicsSurface.Height,
                 width = graphicsSurface.Width,
-                height = graphicsSurface.Height,
+                height = -graphicsSurface.Height,
                 minDepth = 0.0f,
                 maxDepth = 1.0f,
             };

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
@@ -5,6 +5,7 @@ using TerraFX.Interop;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
 using static TerraFX.Interop.VkCompareOp;
+using static TerraFX.Interop.VkDynamicState;
 using static TerraFX.Interop.VkFrontFace;
 using static TerraFX.Interop.VkFormat;
 using static TerraFX.Interop.VkPrimitiveTopology;
@@ -102,26 +103,10 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
                 };
 
-                var viewport = new VkViewport {
-                    width = graphicsSurface.Width,
-                    height = graphicsSurface.Height,
-                    minDepth = 0.0f,
-                    maxDepth = 1.0f,
-                };
-
-                var scissorRect2D = new VkRect2D {
-                    extent = new VkExtent2D {
-                        width = (uint)viewport.width,
-                        height = (uint)viewport.height,
-                    },
-                };
-
                 var pipelineViewportStateCreateInfo = new VkPipelineViewportStateCreateInfo {
                     sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
                     viewportCount = 1,
-                    pViewports = &viewport,
                     scissorCount = 1,
-                    pScissors = &scissorRect2D,
                 };
 
                 var pipelineRasterizationStateCreateInfo = new VkPipelineRasterizationStateCreateInfo {
@@ -156,6 +141,17 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     pAttachments = &pipelineColorBlendAttachmentState,
                 };
 
+                var dynamicStates = stackalloc VkDynamicState[2] {
+                    VK_DYNAMIC_STATE_VIEWPORT,
+                    VK_DYNAMIC_STATE_SCISSOR,
+                };
+
+                var pipelineDynamicStateCreateInfo = new VkPipelineDynamicStateCreateInfo {
+                    sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+                    dynamicStateCount = 2,
+                    pDynamicStates = dynamicStates,
+                };
+
                 var graphicsPipelineCreateInfo = new VkGraphicsPipelineCreateInfo {
                     sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
                     pViewportState = &pipelineViewportStateCreateInfo,
@@ -163,6 +159,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     pMultisampleState = &pipelineMultisampleStateCreateInfo,
                     pDepthStencilState = &pipelineDepthStencilStateCreateInfo,
                     pColorBlendState = &pipelineColorBlendStateCreateInfo,
+                    pDynamicState = &pipelineDynamicStateCreateInfo,
                     layout = VulkanSignature.VulkanPipelineLayout,
                     renderPass = graphicsDevice.VulkanRenderPass,
                 };

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPipeline.cs
@@ -5,6 +5,7 @@ using TerraFX.Interop;
 using TerraFX.Utilities;
 using static TerraFX.Graphics.Providers.Vulkan.HelperUtilities;
 using static TerraFX.Interop.VkCompareOp;
+using static TerraFX.Interop.VkCullModeFlagBits;
 using static TerraFX.Interop.VkDynamicState;
 using static TerraFX.Interop.VkFrontFace;
 using static TerraFX.Interop.VkFormat;
@@ -112,6 +113,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 var pipelineRasterizationStateCreateInfo = new VkPipelineRasterizationStateCreateInfo {
                     sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
                     frontFace = VK_FRONT_FACE_CLOCKWISE,
+                    cullMode = (uint)VK_CULL_MODE_BACK_BIT,
                     lineWidth = 1.0f,
                 };
 

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsProvider.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsProvider.cs
@@ -215,7 +215,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                         applicationVersion = 1,
                         pEngineName = engineName,
                         engineVersion = VK_MAKE_VERSION(0, 1, 0),
-                        apiVersion = VK_API_VERSION_1_0,
+                        apiVersion = VK_API_VERSION_1_1,
                     };
 
                     var instanceCreateInfo = new VkInstanceCreateInfo {


### PR DESCRIPTION
This updates the Vulkan Provider to cull backfaces and to have the same origin as DirectX by default.