### PR TITLE
Ensure that the GraphicsDevice and GraphicsDeviceContext properly update when the backing surface changes size

### DIFF
--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -434,6 +434,8 @@ namespace TerraFX.Graphics.Providers.D3D12
         {
             if (_d3d12RenderTargetView.IsCreated)
             {
+                _d3d12RenderTargetView.Reset(CreateD3D12RenderTargetDescriptor);
+
                 ReleaseIfNotNull(_d3d12RenderTargetResource.Value);
                 _d3d12RenderTargetResource.Reset(CreateD3D12RenderTargetResource);
             }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -315,7 +315,9 @@ namespace TerraFX.Graphics.Providers.D3D12
             // Fullscreen transitions are not currently supported
             ThrowExternalExceptionIfFailed(nameof(IDXGIFactory.MakeWindowAssociation), graphicsProvider.DxgiFactory->MakeWindowAssociation(graphicsSurfaceHandle, DXGI_MWA_NO_ALT_ENTER));
 
-            _dxgiSwapChainFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+            _dxgiSwapChainFormat = swapChainDesc.Format;
+            _graphicsContextIndex = unchecked((int)dxgiSwapChain->GetCurrentBackBufferIndex());
+
             return dxgiSwapChain;
         }
 
@@ -333,6 +335,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             {
                 var graphicsSurface = GraphicsSurface;
                 ThrowExternalExceptionIfFailed(nameof(IDXGISwapChain.ResizeBuffers), DxgiSwapChain->ResizeBuffers((uint)D3D12GraphicsContexts.Length, (uint)graphicsSurface.Width, (uint)graphicsSurface.Height, DXGI_FORMAT_R8G8B8A8_UNORM, SwapChainFlags: 0));
+                _graphicsContextIndex = unchecked((int)DxgiSwapChain->GetCurrentBackBufferIndex());
             }
         }
     }

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -542,15 +542,20 @@ namespace TerraFX.Graphics.Providers.Vulkan
         {
             WaitForIdle();
 
-            foreach (var graphicsContext in VulkanGraphicsContexts)
+            if (_vulkanSwapchainImages.IsCreated)
             {
-                graphicsContext.OnGraphicsSurfaceSizeChanged(sender, eventArgs);
+                _vulkanSwapchainImages.Reset(GetVulkanSwapchainImages);
             }
 
             if (_vulkanSwapchain.IsCreated)
             {
                 vkDestroySwapchainKHR(_vulkanDevice.Value, _vulkanSwapchain.Value, pAllocator: null);
                 _vulkanSwapchain.Reset(CreateVulkanSwapchain);
+            }
+
+            foreach (var graphicsContext in VulkanGraphicsContexts)
+            {
+                graphicsContext.OnGraphicsSurfaceSizeChanged(sender, eventArgs);
             }
         }
     }


### PR DESCRIPTION
Not everything was being properly reset and so certain fields would be in an incorrect state. This looks to have occurred due to a previous refactoring.