### PR TITLE
Quote the packages to push to avoid bash globbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,4 @@ jobs:
         source-url: https://nuget.pkg.github.com/terrafx/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - run: dotnet nuget push ./artifacts/pkg/Release/*.nupkg
+    - run: dotnet nuget push "./artifacts/pkg/Release/*.nupkg"


### PR DESCRIPTION
This should allow all nuget packages to be pushed, rather than just TerraFX