### PR TITLE
Ensure that resources are properly cleaned up

### DIFF
--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -1,22 +1,15 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
-using System.Linq;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
-using TerraFX.UI;
-using TerraFX.Utilities;
 
 namespace TerraFX.Samples.Graphics
 {
-    public sealed class HelloQuad : Sample
+    public sealed class HelloQuad : HelloWindow
     {
-        private GraphicsDevice _graphicsDevice = null!;
         private GraphicsPrimitive _quadPrimitive = null!;
-        private Window _window = null!;
-        private TimeSpan _elapsedTime;
 
         public HelloQuad(string name, params Assembly[] compositionAssemblies)
             : base(name, compositionAssemblies)
@@ -26,72 +19,38 @@ namespace TerraFX.Samples.Graphics
         public override void Cleanup()
         {
             _quadPrimitive?.Dispose();
-            _graphicsDevice?.Dispose();
-            _window?.Dispose();
-
             base.Cleanup();
         }
 
         public override void Initialize(Application application)
         {
-            ExceptionUtilities.ThrowIfNull(application, nameof(application));
+            base.Initialize(application);
 
-            var windowProvider = application.GetService<WindowProvider>();
-            _window = windowProvider.CreateWindow();
-            _window.Show();
-
-            var graphicsProvider = application.GetService<GraphicsProvider>();
-            var graphicsAdapter = graphicsProvider.Adapters.First();
-
-            var graphicsDevice = graphicsAdapter.CreateDevice(_window, contextCount: 2);
-
-            _graphicsDevice = graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
 
             using (var vertexStagingBuffer = graphicsDevice.MemoryAllocator.CreateBuffer(GraphicsBufferKind.Default, GraphicsResourceCpuAccess.Write, 64 * 1024))
             using (var indexStagingBuffer = graphicsDevice.MemoryAllocator.CreateBuffer(GraphicsBufferKind.Default, GraphicsResourceCpuAccess.Write, 64 * 1024))
             {
                 var currentGraphicsContext = graphicsDevice.CurrentContext;
+
                 currentGraphicsContext.BeginFrame();
-
                 _quadPrimitive = CreateQuadPrimitive(currentGraphicsContext, vertexStagingBuffer, indexStagingBuffer);
-
                 currentGraphicsContext.EndFrame();
 
                 graphicsDevice.Signal(currentGraphicsContext.Fence);
                 graphicsDevice.WaitForIdle();
             }
-
-            base.Initialize(application);
         }
 
-        protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
+        protected override void Draw(GraphicsContext graphicsContext)
         {
-            ExceptionUtilities.ThrowIfNull(sender, nameof(sender));
-
-            _elapsedTime += eventArgs.Delta;
-
-            if (_elapsedTime.TotalSeconds >= 2.5)
-            {
-                var application = (Application)sender;
-                application.RequestExit();
-            }
-
-            if (_window.IsVisible)
-            {
-                var currentGraphicsContext = _graphicsDevice.CurrentContext;
-                currentGraphicsContext.BeginFrame();
-
-                Update(eventArgs.Delta);
-                Render();
-
-                currentGraphicsContext.EndFrame();
-                Present();
-            }
+            graphicsContext.Draw(_quadPrimitive);
+            base.Draw(graphicsContext);
         }
 
         private unsafe GraphicsPrimitive CreateQuadPrimitive(GraphicsContext graphicsContext, GraphicsBuffer vertexStagingBuffer, GraphicsBuffer indexStagingBuffer)
         {
-            var graphicsDevice = _graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
             var graphicsSurface = graphicsDevice.Surface;
 
             var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "main", "main");
@@ -172,24 +131,6 @@ namespace TerraFX.Samples.Graphics
 
                 return graphicsDevice.CreatePipelineSignature(inputs);
             }
-        }
-
-        private void Present() => _graphicsDevice.PresentFrame();
-
-        private void Render()
-        {
-            var graphicsDevice = _graphicsDevice;
-            var graphicsContext = graphicsDevice.CurrentContext;
-
-            var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
-
-            graphicsContext.BeginDrawing(backgroundColor);
-            graphicsContext.Draw(_quadPrimitive);
-            graphicsContext.EndDrawing();
-        }
-
-        private unsafe void Update(TimeSpan delta)
-        {
         }
     }
 }

--- a/samples/TerraFX/Graphics/HelloTexture.cs
+++ b/samples/TerraFX/Graphics/HelloTexture.cs
@@ -1,22 +1,15 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
-using System.Linq;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
-using TerraFX.UI;
-using TerraFX.Utilities;
 
 namespace TerraFX.Samples.Graphics
 {
-    public sealed class HelloTexture : Sample
+    public sealed class HelloTexture : HelloWindow
     {
-        private GraphicsDevice _graphicsDevice = null!;
         private GraphicsPrimitive _trianglePrimitive = null!;
-        private Window _window = null!;
-        private TimeSpan _elapsedTime;
 
         public HelloTexture(string name, params Assembly[] compositionAssemblies)
             : base(name, compositionAssemblies)
@@ -26,72 +19,38 @@ namespace TerraFX.Samples.Graphics
         public override void Cleanup()
         {
             _trianglePrimitive?.Dispose();
-            _graphicsDevice?.Dispose();
-            _window?.Dispose();
-
             base.Cleanup();
         }
 
         public override void Initialize(Application application)
         {
-            ExceptionUtilities.ThrowIfNull(application, nameof(application));
+            base.Initialize(application);
 
-            var windowProvider = application.GetService<WindowProvider>();
-            _window = windowProvider.CreateWindow();
-            _window.Show();
-
-            var graphicsProvider = application.GetService<GraphicsProvider>();
-            var graphicsAdapter = graphicsProvider.Adapters.First();
-
-            var graphicsDevice = graphicsAdapter.CreateDevice(_window, contextCount: 2);
-
-            _graphicsDevice = graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
 
             using (var vertexStagingBuffer = graphicsDevice.MemoryAllocator.CreateBuffer(GraphicsBufferKind.Default, GraphicsResourceCpuAccess.Write, 64 * 1024))
             using (var textureStagingBuffer = graphicsDevice.MemoryAllocator.CreateBuffer(GraphicsBufferKind.Default, GraphicsResourceCpuAccess.Write, 64 * 1024 * 4))
             {
                 var currentGraphicsContext = graphicsDevice.CurrentContext;
+
                 currentGraphicsContext.BeginFrame();
-
                 _trianglePrimitive = CreateTrianglePrimitive(currentGraphicsContext, vertexStagingBuffer, textureStagingBuffer);
-
                 currentGraphicsContext.EndFrame();
 
                 graphicsDevice.Signal(currentGraphicsContext.Fence);
                 graphicsDevice.WaitForIdle();
             }
-
-            base.Initialize(application);
         }
 
-        protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
+        protected override void Draw(GraphicsContext graphicsContext)
         {
-            ExceptionUtilities.ThrowIfNull(sender, nameof(sender));
-
-            _elapsedTime += eventArgs.Delta;
-
-            if (_elapsedTime.TotalSeconds >= 2.5)
-            {
-                var application = (Application)sender;
-                application.RequestExit();
-            }
-
-            if (_window.IsVisible)
-            {
-                var currentGraphicsContext = _graphicsDevice.CurrentContext;
-                currentGraphicsContext.BeginFrame();
-
-                Update(eventArgs.Delta);
-                Render();
-
-                currentGraphicsContext.EndFrame();
-                Present();
-            }
+            graphicsContext.Draw(_trianglePrimitive);
+            base.Draw(graphicsContext);
         }
 
         private unsafe GraphicsPrimitive CreateTrianglePrimitive(GraphicsContext graphicsContext, GraphicsBuffer vertexStagingBuffer, GraphicsBuffer textureStagingBuffer)
         {
-            var graphicsDevice = _graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
             var graphicsSurface = graphicsDevice.Surface;
 
             var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Texture", "main", "main");
@@ -187,24 +146,6 @@ namespace TerraFX.Samples.Graphics
 
                 return graphicsDevice.CreatePipelineSignature(inputs, resources);
             }
-        }
-
-        private void Present() => _graphicsDevice.PresentFrame();
-
-        private void Render()
-        {
-            var graphicsDevice = _graphicsDevice;
-            var graphicsContext = graphicsDevice.CurrentContext;
-
-            var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
-
-            graphicsContext.BeginDrawing(backgroundColor);
-            graphicsContext.Draw(_trianglePrimitive);
-            graphicsContext.EndDrawing();
-        }
-
-        private unsafe void Update(TimeSpan delta)
-        {
         }
     }
 }

--- a/samples/TerraFX/Graphics/HelloTriangle.cs
+++ b/samples/TerraFX/Graphics/HelloTriangle.cs
@@ -1,22 +1,15 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
-using System.Linq;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
-using TerraFX.UI;
-using TerraFX.Utilities;
 
 namespace TerraFX.Samples.Graphics
 {
-    public sealed class HelloTriangle : Sample
+    public sealed class HelloTriangle : HelloWindow
     {
-        private GraphicsDevice _graphicsDevice = null!;
         private GraphicsPrimitive _trianglePrimitive = null!;
-        private Window _window = null!;
-        private TimeSpan _elapsedTime;
 
         public HelloTriangle(string name, params Assembly[] compositionAssemblies)
             : base(name, compositionAssemblies)
@@ -26,71 +19,37 @@ namespace TerraFX.Samples.Graphics
         public override void Cleanup()
         {
             _trianglePrimitive?.Dispose();
-            _graphicsDevice?.Dispose();
-            _window?.Dispose();
-
             base.Cleanup();
         }
 
         public override void Initialize(Application application)
         {
-            ExceptionUtilities.ThrowIfNull(application, nameof(application));
+            base.Initialize(application);
 
-            var windowProvider = application.GetService<WindowProvider>();
-            _window = windowProvider.CreateWindow();
-            _window.Show();
-
-            var graphicsProvider = application.GetService<GraphicsProvider>();
-            var graphicsAdapter = graphicsProvider.Adapters.First();
-
-            var graphicsDevice = graphicsAdapter.CreateDevice(_window, contextCount: 2);
-
-            _graphicsDevice = graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
 
             using (var vertexStagingBuffer = graphicsDevice.MemoryAllocator.CreateBuffer(GraphicsBufferKind.Default, GraphicsResourceCpuAccess.Write, 64 * 1024))
             {
                 var currentGraphicsContext = graphicsDevice.CurrentContext;
+
                 currentGraphicsContext.BeginFrame();
-
                 _trianglePrimitive = CreateTrianglePrimitive(currentGraphicsContext, vertexStagingBuffer);
-
                 currentGraphicsContext.EndFrame();
 
                 graphicsDevice.Signal(currentGraphicsContext.Fence);
                 graphicsDevice.WaitForIdle();
             }
-            
-            base.Initialize(application);
         }
 
-        protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
+        protected override void Draw(GraphicsContext graphicsContext)
         {
-            ExceptionUtilities.ThrowIfNull(sender, nameof(sender));
-
-            _elapsedTime += eventArgs.Delta;
-
-            if (_elapsedTime.TotalSeconds >= 2.5)
-            {
-                var application = (Application)sender;
-                application.RequestExit();
-            }
-
-            if (_window.IsVisible)
-            {
-                var currentGraphicsContext = _graphicsDevice.CurrentContext;
-                currentGraphicsContext.BeginFrame();
-
-                Update(eventArgs.Delta);
-                Render();
-
-                currentGraphicsContext.EndFrame();
-                Present();
-            }
+            graphicsContext.Draw(_trianglePrimitive);
+            base.Draw(graphicsContext);
         }
 
         private unsafe GraphicsPrimitive CreateTrianglePrimitive(GraphicsContext graphicsContext, GraphicsBuffer vertexStagingBuffer)
         {
-            var graphicsDevice = _graphicsDevice;
+            var graphicsDevice = GraphicsDevice;
             var graphicsSurface = graphicsDevice.Surface;
 
             var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "main", "main");
@@ -146,24 +105,6 @@ namespace TerraFX.Samples.Graphics
 
                 return graphicsDevice.CreatePipelineSignature(inputs);
             }
-        }
-
-        private void Present() => _graphicsDevice.PresentFrame();
-
-        private void Render()
-        {
-            var graphicsDevice = _graphicsDevice;
-            var graphicsContext = graphicsDevice.CurrentContext;
-
-            var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
-
-            graphicsContext.BeginDrawing(backgroundColor);
-            graphicsContext.Draw(_trianglePrimitive);
-            graphicsContext.EndDrawing();
-        }
-
-        private unsafe void Update(TimeSpan delta)
-        {
         }
     }
 }

--- a/samples/TerraFX/Graphics/HelloWindow.cs
+++ b/samples/TerraFX/Graphics/HelloWindow.cs
@@ -10,7 +10,7 @@ using TerraFX.Utilities;
 
 namespace TerraFX.Samples.Graphics
 {
-    public sealed class HelloWindow : Sample
+    public class HelloWindow : Sample
     {
         private GraphicsDevice _graphicsDevice = null!;
         private Window _window = null!;
@@ -20,6 +20,10 @@ namespace TerraFX.Samples.Graphics
             : base(name, compositionAssemblies)
         {
         }
+
+        public GraphicsDevice GraphicsDevice => _graphicsDevice;
+
+        public Window Window => _window;
 
         public override void Cleanup()
         {
@@ -44,6 +48,10 @@ namespace TerraFX.Samples.Graphics
 
             base.Initialize(application);
         }
+
+        protected virtual void Draw(GraphicsContext graphicsContext) { }
+
+        protected virtual void Update(TimeSpan delta) { }
 
         protected override void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs)
         {
@@ -74,17 +82,12 @@ namespace TerraFX.Samples.Graphics
 
         private void Render()
         {
-            var graphicsDevice = _graphicsDevice;
-            var graphicsContext = graphicsDevice.CurrentContext;
-
+            var graphicsContext = GraphicsDevice.CurrentContext;
             var backgroundColor = new ColorRgba(red: 100.0f / 255.0f, green: 149.0f / 255.0f, blue: 237.0f / 255.0f, alpha: 1.0f);
 
             graphicsContext.BeginDrawing(backgroundColor);
+            Draw(graphicsContext);
             graphicsContext.EndDrawing();
-        }
-
-        private unsafe void Update(TimeSpan delta)
-        {
         }
     }
 }

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -22,25 +22,25 @@ namespace TerraFX.Samples
         private static readonly Sample[] s_samples = {
             new EnumerateGraphicsAdapters("D3D12.EnumerateGraphicsAdapters", s_graphicsProviderD3D12),
             new EnumerateGraphicsAdapters("Vulkan.EnumerateGraphicsAdapters", s_graphicsProviderVulkan),
-
+            
             new HelloWindow("D3D12.HelloWindow", s_graphicsProviderD3D12),
             new HelloWindow("Vulkan.HelloWindow", s_graphicsProviderVulkan),
-
+            
             new HelloTriangle("D3D12.HelloTriangle", s_graphicsProviderD3D12),
             new HelloTriangle("Vulkan.HelloTriangle", s_graphicsProviderVulkan),
-
+            
             new HelloQuad("D3D12.HelloQuad", s_graphicsProviderD3D12),
             new HelloQuad("Vulkan.HelloQuad", s_graphicsProviderVulkan),
-
+            
             new HelloConstantBuffer("D3D12.HelloConstantBuffer", s_graphicsProviderD3D12),
             new HelloConstantBuffer("Vulkan.HelloConstantBuffer", s_graphicsProviderVulkan),
-
+            
             new HelloTexture("D3D12.HelloTexture", s_graphicsProviderD3D12),
             new HelloTexture("Vulkan.HelloTexture", s_graphicsProviderVulkan),
-
+            
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Sync", false, s_audioProviderPulseAudio),
             new EnumerateAudioAdapters("PulseAudio.EnumerateAudioAdapters.Async", true, s_audioProviderPulseAudio),
-
+            
             new PlaySampleAudio("PulseAudio.PlaySampleAudio", s_audioProviderPulseAudio),
         };
 
@@ -104,11 +104,9 @@ namespace TerraFX.Samples
         private static void Run(Sample sample)
         {
             using var application = new Application(sample.CompositionAssemblies);
-            {
-                sample.Initialize(application);
-            }
-            application.Run();
+            sample.Initialize(application);
 
+            application.Run();
             sample.Cleanup();
         }
 

--- a/samples/TerraFX/Shared/Sample.cs
+++ b/samples/TerraFX/Shared/Sample.cs
@@ -15,7 +15,7 @@ using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples
 {
-    public abstract class Sample
+    public abstract class Sample : IDisposable
     {
         internal static readonly Assembly s_uiProviderWin32 = Assembly.LoadFrom("TerraFX.UI.Providers.Win32.dll");
         internal static readonly Assembly s_uiProviderXlib = Assembly.LoadFrom("TerraFX.UI.Providers.Xlib.dll");
@@ -37,6 +37,8 @@ namespace TerraFX.Samples
             Array.Copy(compositionAssemblies, 0, _compositionAssemblies, 1, compositionAssemblies.Length);
         }
 
+        ~Sample() => Dispose(isDisposing: false);
+
         // ps_5_0
         private static ReadOnlySpan<sbyte> D3D12CompileTarget_ps_5_0 => new sbyte[] { 0x70, 0x73, 0x5F, 0x35, 0x5F, 0x30, 0x00 };
 
@@ -47,13 +49,15 @@ namespace TerraFX.Samples
 
         public string Name => _name;
 
-        public virtual void Cleanup()
+        public virtual void Cleanup() { }
+
+        public void Dispose()
         {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
         }
 
         public virtual void Initialize(Application application) => application.Idle += OnIdle;
-
-        protected abstract void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs);
 
         protected unsafe GraphicsShader CompileShader(GraphicsDevice graphicsDevice, GraphicsShaderKind kind, string shaderName, string entryPointName)
         {
@@ -179,6 +183,10 @@ namespace TerraFX.Samples
                 return vulkanShaderStage;
             }
         }
+
+        protected virtual void Dispose(bool isDisposing) => Cleanup();
+
+        protected abstract void OnIdle(object? sender, ApplicationIdleEventArgs eventArgs);
 
         private string GetAssetFullPath(string assetCategory, string assetName) => Path.Combine(_assemblyPath, "Assets", assetCategory, assetName);
     }

--- a/sources/Graphics/GraphicsPrimitive.cs
+++ b/sources/Graphics/GraphicsPrimitive.cs
@@ -10,47 +10,47 @@ namespace TerraFX.Graphics
     {
         private readonly GraphicsDevice _device;
         private readonly GraphicsPipeline _pipeline;
-        private readonly GraphicsBufferView _vertexBuffer;
-        private readonly GraphicsBufferView _indexBuffer;
+        private readonly GraphicsBufferView _vertexBufferView;
+        private readonly GraphicsBufferView _indexBufferView;
         private readonly GraphicsResource[] _inputResources;
 
         /// <summary>Initializes a new instance of the <see cref="GraphicsPrimitive" /> class.</summary>
         /// <param name="device">The device for which the primitive was created.</param>
         /// <param name="pipeline">The pipeline used for rendering the primitive.</param>
-        /// <param name="vertexBuffer">The buffer which holds the vertices for the primitive.</param>
-        /// <param name="indexBuffer">The buffer which holds the indices for the primitive or <c>default</c> if none exists.</param>
+        /// <param name="vertexBufferView">The buffer which holds the vertices for the primitive.</param>
+        /// <param name="indexBufferView">The buffer which holds the indices for the primitive or <c>default</c> if none exists.</param>
         /// <param name="inputResources">The resources which hold the input data for the primitive or an empty span if none exist.</param>
         /// <exception cref="ArgumentNullException"><paramref name="device" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="pipeline" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="vertexBuffer" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="vertexBufferView" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pipeline" /> was not created for <paramref name="device" />.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBuffer" /> was not created for <paramref name="device" />.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBuffer" /> was not created for <paramref name="device" />.</exception>
-        protected GraphicsPrimitive(GraphicsDevice device, GraphicsPipeline pipeline, in GraphicsBufferView vertexBuffer, in GraphicsBufferView indexBuffer, ReadOnlySpan<GraphicsResource> inputResources)
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertexBufferView" /> was not created for <paramref name="device" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexBufferView" /> was not created for <paramref name="device" />.</exception>
+        protected GraphicsPrimitive(GraphicsDevice device, GraphicsPipeline pipeline, in GraphicsBufferView vertexBufferView, in GraphicsBufferView indexBufferView, ReadOnlySpan<GraphicsResource> inputResources)
         {
             ThrowIfNull(pipeline, nameof(pipeline));
-            ThrowIfNull(vertexBuffer.Buffer, nameof(vertexBuffer));
+            ThrowIfNull(vertexBufferView.Buffer, nameof(vertexBufferView));
 
             if (pipeline.Device != device)
             {
                 ThrowArgumentOutOfRangeException(nameof(pipeline), pipeline);
             }
 
-            if (vertexBuffer.Buffer.Allocator.Device != device)
+            if (vertexBufferView.Buffer.Allocator.Device != device)
             {
-                ThrowArgumentOutOfRangeException(nameof(vertexBuffer), vertexBuffer);
+                ThrowArgumentOutOfRangeException(nameof(vertexBufferView), vertexBufferView);
             }
 
-            if ((indexBuffer.Buffer is not null) && (indexBuffer.Buffer.Allocator.Device != device))
+            if ((indexBufferView.Buffer is not null) && (indexBufferView.Buffer.Allocator.Device != device))
             {
-                ThrowArgumentOutOfRangeException(nameof(indexBuffer), indexBuffer);
+                ThrowArgumentOutOfRangeException(nameof(indexBufferView), indexBufferView);
             }
 
             _device = device;
             _pipeline = pipeline;
 
-            _vertexBuffer = vertexBuffer;
-            _indexBuffer = indexBuffer;
+            _vertexBufferView = vertexBufferView;
+            _indexBufferView = indexBufferView;
             _inputResources = inputResources.ToArray();
         }
 
@@ -61,13 +61,13 @@ namespace TerraFX.Graphics
         public ReadOnlySpan<GraphicsResource> InputResources => _inputResources;
 
         /// <summary>Gets the buffer which holds the indices for the primitive or <c>default</c> if none exists.</summary>
-        public ref readonly GraphicsBufferView IndexBufferView => ref _indexBuffer;
+        public ref readonly GraphicsBufferView IndexBufferView => ref _indexBufferView;
 
         /// <summary>Gets the pipeline used for rendering the primitive.</summary>
         public GraphicsPipeline Pipeline => _pipeline;
 
         /// <summary>Gets the buffer which holds the vertices for the primitive.</summary>
-        public ref readonly GraphicsBufferView VertexBufferView => ref _vertexBuffer;
+        public ref readonly GraphicsBufferView VertexBufferView => ref _vertexBufferView;
 
         /// <inheritdoc />
         public void Dispose()

--- a/sources/Graphics/Memory/GraphicsMemoryAllocator.cs
+++ b/sources/Graphics/Memory/GraphicsMemoryAllocator.cs
@@ -11,7 +11,7 @@ using System;
 namespace TerraFX.Graphics
 {
     /// <summary>A memory allocator which manages memory for a graphics device.</summary>
-    public abstract class GraphicsMemoryAllocator
+    public abstract class GraphicsMemoryAllocator : IDisposable
     {
         /// <summary>The name of the data value that controls the value of <see cref="BlockMarginSize" />.</summary>
         /// <remarks>
@@ -125,5 +125,16 @@ namespace TerraFX.Graphics
         /// <param name="budget">On return, contains the budget for <paramref name="blockCollection" />.</param>
         /// <exception cref="ArgumentNullException"><paramref name="blockCollection" /> is <c>null</c>.</exception>
         public abstract void GetBudget(GraphicsMemoryBlockCollection blockCollection, out GraphicsMemoryBudget budget);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(isDisposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc cref="Dispose()" />
+        /// <param name="isDisposing"><c>true</c> if the method was called from <see cref="Dispose()" />; otherwise, <c>false</c>.</param>
+        protected abstract void Dispose(bool isDisposing);
     }
 }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsBuffer.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsBuffer.cs
@@ -77,6 +77,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             if (priorState < Disposing)
             {
                 _d3d12Resource.Dispose(ReleaseIfNotNull);
+                MemoryBlockRegion.Block.Free(in MemoryBlockRegion);
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsContext.cs
@@ -415,7 +415,6 @@ namespace TerraFX.Graphics.Providers.D3D12
             {
                 _d3d12GraphicsCommandList.Dispose(ReleaseIfNotNull);
                 _d3d12CommandAllocator.Dispose(ReleaseIfNotNull);
-                _d3d12RenderTargetView.Dispose();
                 _d3d12RenderTargetResource.Dispose(ReleaseIfNotNull);
 
                 _waitForExecuteCompletionFence?.Dispose();

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -199,6 +199,7 @@ namespace TerraFX.Graphics.Providers.D3D12
                     context?.Dispose();
                 }
 
+                _memoryAllocator.Dispose(DisposeMemoryAllocator);
                 _d3d12ShaderResourceDescriptorHeap.Dispose(ReleaseIfNotNull);
                 _d3d12RenderTargetDescriptorHeap.Dispose(ReleaseIfNotNull);
                 _dxgiSwapChain.Dispose(ReleaseIfNotNull);
@@ -328,6 +329,11 @@ namespace TerraFX.Graphics.Providers.D3D12
 
         private D3D12GraphicsMemoryAllocator CreateMemoryAllocator()
             => new D3D12GraphicsMemoryAllocator(this, blockPreferredSize: 0);
+
+        private void DisposeMemoryAllocator(D3D12GraphicsMemoryAllocator memoryAllocator)
+        {
+            memoryAllocator?.Dispose();
+        }
 
         private D3D12_FEATURE_DATA_D3D12_OPTIONS GetD3D12Options()
         {

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
@@ -39,6 +39,9 @@ namespace TerraFX.Graphics.Providers.D3D12
                 {
                     inputResource?.Dispose();
                 }
+
+                VertexBufferView.Buffer?.Dispose();
+                IndexBufferView.Buffer?.Dispose();
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsTexture.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsTexture.cs
@@ -52,6 +52,7 @@ namespace TerraFX.Graphics.Providers.D3D12
             if (priorState < Disposing)
             {
                 _d3d12Resource.Dispose(ReleaseIfNotNull);
+                MemoryBlockRegion.Block.Free(in MemoryBlockRegion);
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsBuffer.cs
@@ -107,6 +107,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
             if (priorState < Disposing)
             {
                 DisposeVulkanBuffer(_vulkanBuffer);
+                MemoryBlockRegion.Block.Free(in MemoryBlockRegion);
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsDevice.cs
@@ -227,6 +227,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
                     context?.Dispose();
                 }
 
+                _memoryAllocator.Dispose(DisposeMemoryAllocator);
                 _vulkanRenderPass.Dispose(DisposeVulkanRenderPass);
                 _vulkanSwapchain.Dispose(DisposeVulkanSwapchain);
                 _vulkanSurface.Dispose(DisposeVulkanSurface);
@@ -429,6 +430,11 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             _vulkanSwapchainFormat = swapChainCreateInfo.imageFormat;
             return vulkanSwapchain;
+        }
+
+        private void DisposeMemoryAllocator(VulkanGraphicsMemoryAllocator memoryAllocator)
+        {
+            memoryAllocator?.Dispose();
         }
 
         private void DisposeVulkanDevice(VkDevice vulkanDevice)

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsPrimitive.cs
@@ -39,6 +39,9 @@ namespace TerraFX.Graphics.Providers.Vulkan
                 {
                     inputResource?.Dispose();
                 }
+
+                VertexBufferView.Buffer?.Dispose();
+                IndexBufferView.Buffer?.Dispose();
             }
 
             _state.EndDispose();

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsTexture.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsTexture.cs
@@ -128,7 +128,9 @@ namespace TerraFX.Graphics.Providers.Vulkan
             {
                 _vulkanSampler.Dispose(DisposeVulkanSampler);
                 _vulkanImageView.Dispose(DisposeVulkanImageView);
+
                 DisposeVulkanImage(_vulkanImage);
+                MemoryBlockRegion.Block.Free(in MemoryBlockRegion);
             }
 
             _state.EndDispose();


### PR DESCRIPTION
A few dispose statements were missed for the new memory allocators, this adds them and ensures no diagnostics are reported on close.