### PR TITLE
Cleaning up unnecessary InteropUtilities methods

### DIFF
--- a/samples/TerraFX/Graphics/HelloConstantBuffer.cs
+++ b/samples/TerraFX/Graphics/HelloConstantBuffer.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
+using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples.Graphics
 {
@@ -88,7 +89,7 @@ namespace TerraFX.Samples.Graphics
                 CreateConstantBuffer(graphicsContext),
                 CreateConstantBuffer(graphicsContext),
             };
-            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, (uint)sizeof(IdentityVertex)), indexBufferView: default, inputResources);
+            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, SizeOf<IdentityVertex>()), indexBufferView: default, inputResources);
 
             static GraphicsBuffer CreateConstantBuffer(GraphicsContext graphicsContext)
             {

--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
+using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples.Graphics
 {
@@ -57,7 +58,7 @@ namespace TerraFX.Samples.Graphics
             var vertexBuffer = CreateVertexBuffer(graphicsContext, vertexStagingBuffer, aspectRatio: graphicsSurface.Width / graphicsSurface.Height);
             var indexBuffer = CreateIndexBuffer(graphicsContext, indexStagingBuffer);
 
-            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, (uint)sizeof(IdentityVertex)), new GraphicsBufferView(indexBuffer, indexBuffer.Size, sizeof(ushort)));
+            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, SizeOf<IdentityVertex>()), new GraphicsBufferView(indexBuffer, indexBuffer.Size, sizeof(ushort)));
 
             static GraphicsBuffer CreateVertexBuffer(GraphicsContext graphicsContext, GraphicsBuffer vertexStagingBuffer, float aspectRatio)
             {

--- a/samples/TerraFX/Graphics/HelloTexture.cs
+++ b/samples/TerraFX/Graphics/HelloTexture.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
+using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples.Graphics
 {
@@ -59,7 +60,7 @@ namespace TerraFX.Samples.Graphics
             var inputResources = new GraphicsResource[1] {
                 CreateTexture2D(graphicsContext, textureStagingBuffer),
             };
-            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, (uint)sizeof(TextureVertex)), indexBufferView: default, inputResources);
+            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, SizeOf<TextureVertex>()), indexBufferView: default, inputResources);
 
             static GraphicsTexture CreateTexture2D(GraphicsContext graphicsContext, GraphicsBuffer textureStagingBuffer)
             {

--- a/samples/TerraFX/Graphics/HelloTriangle.cs
+++ b/samples/TerraFX/Graphics/HelloTriangle.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
 using TerraFX.Numerics;
+using static TerraFX.Utilities.InteropUtilities;
 
 namespace TerraFX.Samples.Graphics
 {
@@ -55,7 +56,7 @@ namespace TerraFX.Samples.Graphics
             var graphicsPipeline = CreateGraphicsPipeline(graphicsDevice, "Identity", "main", "main");
             var vertexBuffer = CreateVertexBuffer(graphicsContext, vertexStagingBuffer, aspectRatio: graphicsSurface.Width / graphicsSurface.Height);
 
-            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, (uint)sizeof(IdentityVertex)));
+            return graphicsDevice.CreatePrimitive(graphicsPipeline, new GraphicsBufferView(vertexBuffer, vertexBuffer.Size, SizeOf<IdentityVertex>()));
 
             static GraphicsBuffer CreateVertexBuffer(GraphicsContext graphicsContext, GraphicsBuffer vertexStagingBuffer, float aspectRatio)
             {

--- a/sources/Providers/Graphics/Vulkan/VulkanGraphicsProvider.cs
+++ b/sources/Providers/Graphics/Vulkan/VulkanGraphicsProvider.cs
@@ -346,7 +346,7 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             static int MarshalNames(string[] names, out sbyte* namesBuffer)
             {
-                var sizePerEntry = (nuint)sizeof(nuint) + VK_MAX_EXTENSION_NAME_SIZE;
+                nuint sizePerEntry = SizeOf<nuint>() + VK_MAX_EXTENSION_NAME_SIZE;
                 namesBuffer = (sbyte*)Allocate((nuint)names.Length * sizePerEntry);
 
                 var pCurrent = namesBuffer;

--- a/sources/Utilities/InteropUtilities.cs
+++ b/sources/Utilities/InteropUtilities.cs
@@ -1,7 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -117,21 +116,6 @@ namespace TerraFX.Utilities
         /// <param name="memory">The memory to free</param>
         public static void Free(void* memory) => Marshal.FreeHGlobal((IntPtr)memory);
 
-        /// <summary>Marshals a managed delegate to get a function pointer which will invoke it.</summary>
-        /// <typeparam name="TDelegate">The type of the managed delegate.</typeparam>
-        /// <param name="function">The managed delegate for which to marshal.</param>
-        /// <returns>A function pointer that invokes <paramref name="function" />.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IntPtr MarshalDelegate<TDelegate>(TDelegate function)
-            where TDelegate : notnull => Marshal.GetFunctionPointerForDelegate(function);
-
-        /// <summary>Marshals a function pointer to get a managed delegate which will invoke it.</summary>
-        /// <typeparam name="TDelegate">The type of the managed delegate.</typeparam>
-        /// <param name="function">The function pointer for which to marshal.</param>
-        /// <returns>A managed delegate that invokes <paramref name="function" />.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TDelegate MarshalFunctionPointer<TDelegate>(IntPtr function) => Marshal.GetDelegateForFunctionPointer<TDelegate>(function);
-
         /// <summary>Marshals a string to a null-terminated UTF8 string.</summary>
         /// <param name="source">The string for which to marshal.</param>
         /// <returns>A null-terminated UTF8 string that is equivalent to <paramref name="source" />.</returns>
@@ -222,22 +206,10 @@ namespace TerraFX.Utilities
             return span;
         }
 
-        /// <summary>Gets a null reference of <typeparamref name="T"/>.</summary>
-        /// <typeparam name="T">The type of the null reference to retrieve.</typeparam>
-        /// <returns>A null reference of <typeparamref name="T"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T NullRef<T>() => ref Unsafe.AsRef<T>(null);
-
         /// <summary>Gets the size of <typeparamref name="T" />.</summary>
         /// <typeparam name="T">The type for which to get the size.</typeparam>
         /// <returns>The size of <typeparamref name="T" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint SizeOf<T>() => unchecked((uint)Unsafe.SizeOf<T>());
-
-        /// <summary>Bypasses definite assignment rules by taking advantage of <c>out</c> semantics.</summary>
-        /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The value for which to skip initialization.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SkipInit<T>([MaybeNull] out T value) => Unsafe.SkipInit(out value);
     }
 }

--- a/sources/Utilities/ValueLazy`1.cs
+++ b/sources/Utilities/ValueLazy`1.cs
@@ -1,11 +1,11 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
-using static TerraFX.Utilities.InteropUtilities;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Utilities
@@ -26,7 +26,7 @@ namespace TerraFX.Utilities
         /// <exception cref="ArgumentNullException"><paramref name="factory" /> is <c>null</c>.</exception>
         public ValueLazy(Func<T> factory)
         {
-            SkipInit(out this);
+            Unsafe.SkipInit(out this);
             Reset(factory);
         }
 


### PR DESCRIPTION
`InteropUtilities.SkipInit` can be replaced with `Unsafe.SkipInit`. Also fixes several `(uint)sizeof` casts to use the `SizeOf<T>` helper method.