### PR TITLE
Adding a basic graphics surface that can be used with WinForms

### DIFF
--- a/sources/Providers/UI/Win32/Win32Window.cs
+++ b/sources/Providers/UI/Win32/Win32Window.cs
@@ -418,7 +418,7 @@ namespace TerraFX.UI.Providers.Win32
 
         private void OnSizeChanged(Vector2 previousSize, Vector2 currentSize)
         {
-            if (SizeChanged != null)
+            if (SizeChanged is not null)
             {
                 var eventArgs = new PropertyChangedEventArgs<Vector2>(previousSize, currentSize);
                 SizeChanged(this, eventArgs);

--- a/sources/WinForms/GraphicsSurface.cs
+++ b/sources/WinForms/GraphicsSurface.cs
@@ -1,0 +1,70 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using TerraFX.Graphics;
+using TerraFX.Numerics;
+using static TerraFX.Utilities.ExceptionUtilities;
+
+namespace TerraFX.WinForms
+{
+    /// <summary>Defines a graphics surface usable by WinForms.</summary>
+    public sealed unsafe class GraphicsSurface : IGraphicsSurface
+    {
+        private static readonly IntPtr EntryPointModule = Marshal.GetHINSTANCE(Assembly.GetEntryAssembly()!.Modules.First());
+
+        private readonly Control _control;
+        private Vector2 _size;
+
+        /// <summary>Initializes a new instance of the <see cref="GraphicsSurface" /> class.</summary>
+        /// <param name="control">The control that will be used as the underlying surface.</param>
+        public GraphicsSurface(Control control)
+        {
+            ThrowIfNull(control, nameof(control));
+
+            _control = control;
+            _control.ClientSizeChanged += HandleControlClientSizeChanged;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<PropertyChangedEventArgs<Vector2>>? SizeChanged;
+
+        /// <inheritdoc />
+        public IntPtr SurfaceContextHandle => EntryPointModule;
+
+        /// <inheritdoc />
+        public IntPtr SurfaceHandle => _control.Handle;
+
+        /// <inheritdoc />
+        public GraphicsSurfaceKind SurfaceKind => GraphicsSurfaceKind.Win32;
+
+        /// <inheritdoc />
+        public Vector2 Size => _size;
+
+        /// <inheritdoc />
+        public void Dispose() => _control?.Dispose();
+
+        private void HandleControlClientSizeChanged(object? sender, EventArgs eventArgs)
+        {
+            var controlClientSize = _control.ClientSize;
+            var currentSize = new Vector2(controlClientSize.Width, controlClientSize.Height);
+
+            var previousSize = _size;
+            _size = currentSize;
+
+            OnSizeChanged(previousSize, currentSize);
+        }
+
+        private void OnSizeChanged(Vector2 previousSize, Vector2 currentSize)
+        {
+            if (SizeChanged is not null)
+            {
+                var eventArgs = new PropertyChangedEventArgs<Vector2>(previousSize, currentSize);
+                SizeChanged(this, eventArgs);
+            }
+        }
+    }
+}

--- a/sources/WinForms/TerraFX.WinForms.csproj
+++ b/sources/WinForms/TerraFX.WinForms.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/sources/WinForms/TerraFX.WinForms.csproj.user
+++ b/sources/WinForms/TerraFX.WinForms.csproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>


### PR DESCRIPTION
This adds a basic graphics surface that can be used with WinForms. It is defined as a simple wrapper over a `Control` so it can be used directly with something like a `Form` or via some child control like a `Panel`.