### PR TITLE
[IMPL] Add core Vector2 functionality

### DIFF
--- a/sources/Core/Numerics/Vector2.cs
+++ b/sources/Core/Numerics/Vector2.cs
@@ -33,6 +33,14 @@ namespace TerraFX.Numerics
             _y = y;
         }
 
+        /// <summary>Initializes a new instance of the <see cref="Vector2"/> struct with each component set to <paramref name="value"/>.</summary>
+        /// <param name="value">The value to set each component to.</param>
+        public Vector2(float value)
+        {
+            _x = value;
+            _y = value;
+        }
+
         /// <summary>Gets the value of the x-dimension.</summary>
         public float X => _x;
 

--- a/sources/Core/Numerics/Vector2.cs
+++ b/sources/Core/Numerics/Vector2.cs
@@ -39,6 +39,12 @@ namespace TerraFX.Numerics
         /// <summary>Gets the value of the y-dimension.</summary>
         public float Y => _y;
 
+        /// <summary>Gets the square-rooted length of the vector.</summary>
+        public float Length => MathF.Sqrt(LengthSquared);
+
+        /// <summary>Gets the squared length of the vector.</summary>
+        public float LengthSquared => Dot(this, this);
+
         /// <summary>Compares two <see cref="Vector2" /> instances to determine equality.</summary>
         /// <param name="left">The <see cref="Vector2" /> to compare with <paramref name="right" />.</param>
         /// <param name="right">The <see cref="Vector2" /> to compare with <paramref name="left" />.</param>
@@ -58,6 +64,63 @@ namespace TerraFX.Numerics
             return (left.X != right.X)
                 || (left.Y != right.Y);
         }
+
+        /// <summary>Returns the value of the <see cref="Vector2" /> operand (the sign of the operand is unchanged).</summary>
+        /// <param name="value">The operand to return</param>
+        /// <returns>The value of the operand, <paramref name="value"/>.</returns>
+        public static Vector2 operator +(Vector2 value) => value;
+
+        /// <summary>Negates the value of the specified <see cref="Vector2" /> operand.</summary>
+        /// <param name="value">The value to negate.</param>
+        /// <returns>The result of <paramref name="value"/> multiplied by negative one (-1).</returns>
+        public static Vector2 operator -(Vector2 value) => value * -1;
+
+        /// <summary>Adds two specified <see cref="Vector2"/> values.</summary>
+        /// <param name="left">The first value to add.</param>
+        /// <param name="right">The second value to add.</param>
+        /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
+        public static Vector2 operator +(Vector2 left, Vector2 right) => new Vector2(left.X + right.X, left.Y + right.Y);
+
+        /// <summary>Subtracts two specified <see cref="Vector2"/> values.</summary>
+        /// <param name="left">The minuend.</param>
+        /// <param name="right">The subtrahend.</param>
+        /// <returns>The result of subtracting <paramref name="right"/> from <paramref name="left"/>.</returns>
+        public static Vector2 operator -(Vector2 left, Vector2 right) => new Vector2(left.X - right.X, left.Y - right.Y);
+
+        /// <summary>Multiplies two specified <see cref="Vector2"/> values.</summary>
+        /// <param name="left">The first value to multiply.</param>
+        /// <param name="right">The second value to multiply.</param>
+        /// <returns>The result of multiplying <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector2 operator *(Vector2 left, Vector2 right) => new Vector2(left.X * right.X, left.Y * right.Y);
+
+        /// <summary>Divides two specified <see cref="Vector2"/> values.</summary>
+        /// <param name="left">The dividend.</param>
+        /// <param name="right">The divisor.</param>
+        /// <returns>The result of dividing <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector2 operator /(Vector2 left, Vector2 right) => new Vector2(left.X / right.X, left.Y / right.Y);
+
+        /// <summary>Multiplies each component of a <see cref="Vector2"/> value by a given <see cref="float"/> value.</summary>
+        /// <param name="left">The vector to multiply.</param>
+        /// <param name="right">The value to multiply each component by.</param>
+        /// <returns>The result of multiplying each component of <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector2 operator *(Vector2 left, float right) => new Vector2(left.X * right, left.Y * right);
+
+        /// <summary>Divides each component of a <see cref="Vector2"/> value by a given <see cref="float"/> value.</summary>
+        /// <param name="left">The dividend.</param>
+        /// <param name="right">The divisor to divide each component by.</param>
+        /// <returns>The result of multiplying each component of <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector2 operator /(Vector2 left, float right) => new Vector2(left.X / right, left.Y / right);
+
+        /// <summary>Calculates the dot product of two <see cref="Vector2"/> values.</summary>
+        /// <param name="left">The first value to dot.</param>
+        /// <param name="right">The second value to dot.</param>
+        /// <returns>The result of adding the multiplication of each component of <paramref name="left"/> by each component of <paramref name="right"/>.</returns>
+        public static float Dot(Vector2 left, Vector2 right) => (left.X * right.X) + (left.Y * right.Y);
+
+        /// <summary>Computes the normalized value of the given <see cref="Vector2"/> value.</summary>
+        /// <param name="value">The value to normalize.</param>
+        /// <returns>The unit vector of <paramref name="value"/>.</returns>
+        public static Vector2 Normalize(Vector2 value) => value / value.Length;
 
         /// <summary>Creates a new <see cref="Vector2" /> instance with <see cref="X" /> set to the specified value.</summary>
         /// <param name="value">The new value of the x-dimension.</param>

--- a/tests/Core/Numerics/Vector2Tests.cs
+++ b/tests/Core/Numerics/Vector2Tests.cs
@@ -1,0 +1,129 @@
+using NUnit.Framework;
+using TerraFX.Numerics;
+
+namespace TerraFX.UnitTests.Numerics
+{
+    /// <summary>Unit tests for <see cref="Vector2"/>.</summary>
+    public class Vector2Tests
+    {
+        /// <summary>Ensures that two vectors that are expected to compare equal do, in fact compare equal.</summary>
+        [Test]
+        public static void VectorsCompareEqual()
+        {
+            Assert.True(new Vector2(0, 0) == new Vector2(0, 0));
+            Assert.False(new Vector2(0, 0) == new Vector2(1, 1));
+        }
+
+        /// <summary>Ensures that two vectors that are expected to compare not equal do, in fact compare not equal.</summary>
+        [Test]
+        public static void VectorsCompareNotEqual()
+        {
+            Assert.False(new Vector2(0, 0) != new Vector2(0, 0));
+            Assert.True(new Vector2(0, 0) != new Vector2(1, 1));
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator+(Vector2)"/> returns its input unchanced.</summary>
+        [Test]
+        public static void UnaryPlusReturnsUnchanged()
+        {
+            Assert.True(+Vector2.Zero == Vector2.Zero);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator-(Vector2)"/> returns the negation of its input.</summary>
+        [Test]
+        public static void UnaryNegationReturnsNegative()
+        {
+            var minusOne = -new Vector2(1, 1);
+
+            Assert.AreEqual(-1, minusOne.X);
+            Assert.AreEqual(-1, minusOne.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator+(Vector2,Vector2)"/> returns the vector sum of its components.</summary>
+        [Test]
+        public static void AdditionReturnsSumOfValues()
+        {
+            var vector = new Vector2(1, 2) + new Vector2(1, 2);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(4, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator-(Vector2,Vector2)"/> returns the vector difference of its components.</summary>
+        [Test]
+        public static void SubtractionReturnsDifferenceOfValues()
+        {
+            var vector = new Vector2(3, 2) - new Vector2(1, 2);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(0, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator*(Vector2,Vector2)"/> returns the vector product of its components.</summary>
+        [Test]
+        public static void VectorMultiplicationReturnsProductOfValues()
+        {
+            var vector = new Vector2(1, 2) * new Vector2(3, 2);
+
+            Assert.AreEqual(3, vector.X);
+            Assert.AreEqual(4, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator/(Vector2,Vector2)"/> returns the vector division of its components.</summary>
+        [Test]
+        public static void VectorDivisionReturnsDivisionOfValues()
+        {
+            var vector = new Vector2(6, 12) / new Vector2(3, 6);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(2, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator*(Vector2,float)"/> returns a vector with each component multiplied by the given float.</summary>
+        [Test]
+        public static void ScalarMultiplicationReturnValuesScaled()
+        {
+            var vector = new Vector2(1, 2) * 5;
+
+            Assert.AreEqual(5, vector.X);
+            Assert.AreEqual(10, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.operator/(Vector2,float)"/> returns a vector with each component divided by the given float.</summary>
+        [Test]
+        public static void ScalarDivisionReturnsValuesScaled()
+        {
+            var vector = new Vector2(5, 10) / 5;
+
+            Assert.AreEqual(1, vector.X);
+            Assert.AreEqual(2, vector.Y);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.Dot(Vector2,Vector2)"/> returns the scalar product of both input vectors.</summary>
+        [Test]
+        public static void DotProductReturnsScalarProduct()
+        {
+            var product = Vector2.Dot(new Vector2(1, 0.5f), new Vector2(2, 1));
+
+            Assert.AreEqual(2.5f, product);
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.Normalize(Vector2)"/> returns a unit vector.</summary>
+        [Test]
+        public static void NormalizeReturnsUnitVector()
+        {
+            Assert.AreEqual(new Vector2(0, 1), Vector2.Normalize(new Vector2(0, 2)));
+            Assert.AreEqual(new Vector2(1, 0), Vector2.Normalize(new Vector2(1, 0)));
+        }
+
+        /// <summary>Ensures that <see cref="Vector2.Length"/> and <see cref="Vector2.LengthSquared"/> return the magnitude and squared magnitude of the input vector.</summary>
+        [Test]
+        public static void LengthReturnsMagnitudeOfVector()
+        {
+            var vector = new Vector2(0, 5);
+
+            Assert.AreEqual(5, vector.Length);
+            Assert.AreEqual(25, vector.LengthSquared);
+        }
+    }
+}

--- a/tests/Core/Numerics/Vector2Tests.cs
+++ b/tests/Core/Numerics/Vector2Tests.cs
@@ -6,37 +6,48 @@ namespace TerraFX.UnitTests.Numerics
     /// <summary>Unit tests for <see cref="Vector2"/>.</summary>
     public class Vector2Tests
     {
+        /// <summary>Ensures that a vector's components are equal to the parameters used to construct one.</summary>
+        [Test]
+        public static void ComponentsReturnCorrectValues(
+            [Values(1, 2, 3)] float x,
+            [Values(1, 2, 3)] float y)
+        {
+            var vector = new Vector2(x, y);
+
+            Assert.That(vector.X, Is.EqualTo(x));
+            Assert.That(vector.Y, Is.EqualTo(y));
+        }
+
         /// <summary>Ensures that two vectors that are expected to compare equal do, in fact compare equal.</summary>
         [Test]
         public static void VectorsCompareEqual()
         {
-            Assert.True(new Vector2(0, 0) == new Vector2(0, 0));
-            Assert.False(new Vector2(0, 0) == new Vector2(1, 1));
+            Assert.That(new Vector2(0, 0) == new Vector2(0, 0), Is.True);
+            Assert.That(new Vector2(0, 0) == new Vector2(1, 1), Is.False);
         }
 
         /// <summary>Ensures that two vectors that are expected to compare not equal do, in fact compare not equal.</summary>
         [Test]
         public static void VectorsCompareNotEqual()
         {
-            Assert.False(new Vector2(0, 0) != new Vector2(0, 0));
-            Assert.True(new Vector2(0, 0) != new Vector2(1, 1));
+            Assert.That(new Vector2(0, 0) != new Vector2(0, 0), Is.False);
+            Assert.That(new Vector2(0, 0) != new Vector2(1, 1), Is.True);
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator+(Vector2)"/> returns its input unchanced.</summary>
         [Test]
         public static void UnaryPlusReturnsUnchanged()
         {
-            Assert.True(+Vector2.Zero == Vector2.Zero);
+            Assert.That(+Vector2.Zero == Vector2.Zero, Is.True);
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator-(Vector2)"/> returns the negation of its input.</summary>
         [Test]
         public static void UnaryNegationReturnsNegative()
         {
-            var minusOne = -new Vector2(1, 1);
+            var vector = -new Vector2(1, 1);
 
-            Assert.AreEqual(-1, minusOne.X);
-            Assert.AreEqual(-1, minusOne.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(-1, -1)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator+(Vector2,Vector2)"/> returns the vector sum of its components.</summary>
@@ -45,8 +56,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(1, 2) + new Vector2(1, 2);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(4, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(2, 4)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator-(Vector2,Vector2)"/> returns the vector difference of its components.</summary>
@@ -55,8 +65,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(3, 2) - new Vector2(1, 2);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(0, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(2, 0)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator*(Vector2,Vector2)"/> returns the vector product of its components.</summary>
@@ -65,8 +74,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(1, 2) * new Vector2(3, 2);
 
-            Assert.AreEqual(3, vector.X);
-            Assert.AreEqual(4, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(3, 4)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator/(Vector2,Vector2)"/> returns the vector division of its components.</summary>
@@ -75,8 +83,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(6, 12) / new Vector2(3, 6);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(2, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(2, 2)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator*(Vector2,float)"/> returns a vector with each component multiplied by the given float.</summary>
@@ -85,8 +92,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(1, 2) * 5;
 
-            Assert.AreEqual(5, vector.X);
-            Assert.AreEqual(10, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(5, 10)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.operator/(Vector2,float)"/> returns a vector with each component divided by the given float.</summary>
@@ -95,8 +101,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(5, 10) / 5;
 
-            Assert.AreEqual(1, vector.X);
-            Assert.AreEqual(2, vector.Y);
+            Assert.That(vector, Is.EqualTo(new Vector2(1, 2)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.Dot(Vector2,Vector2)"/> returns the scalar product of both input vectors.</summary>
@@ -105,15 +110,15 @@ namespace TerraFX.UnitTests.Numerics
         {
             var product = Vector2.Dot(new Vector2(1, 0.5f), new Vector2(2, 1));
 
-            Assert.AreEqual(2.5f, product);
+            Assert.That(product, Is.EqualTo(2.5f));
         }
 
         /// <summary>Ensures that <see cref="Vector2.Normalize(Vector2)"/> returns a unit vector.</summary>
         [Test]
         public static void NormalizeReturnsUnitVector()
         {
-            Assert.AreEqual(new Vector2(0, 1), Vector2.Normalize(new Vector2(0, 2)));
-            Assert.AreEqual(new Vector2(1, 0), Vector2.Normalize(new Vector2(1, 0)));
+            Assert.That(Vector2.Normalize(new Vector2(1, 0)), Is.EqualTo(new Vector2(1, 0)));
+            Assert.That(Vector2.Normalize(new Vector2(0, 2)), Is.EqualTo(new Vector2(0, 1)));
         }
 
         /// <summary>Ensures that <see cref="Vector2.Length"/> and <see cref="Vector2.LengthSquared"/> return the magnitude and squared magnitude of the input vector.</summary>
@@ -122,8 +127,8 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector2(0, 5);
 
-            Assert.AreEqual(5, vector.Length);
-            Assert.AreEqual(25, vector.LengthSquared);
+            Assert.That(vector.Length, Is.EqualTo(5));
+            Assert.That(vector.LengthSquared, Is.EqualTo(25));
         }
     }
 }


### PR DESCRIPTION
Fixes #101.

Likewise with #109, this adds the core functionality and unit tests for Vector2. It's basically a direct copy+paste of the Vector3 code but with the 'Z' component removed.

In addition, I've also left out the single-parameter constructor for the same reason as in the Vector3 PR.