### PR TITLE
[IMPL] Add core Vector4 functionality

### DIFF
--- a/sources/Core/Numerics/Vector4.cs
+++ b/sources/Core/Numerics/Vector4.cs
@@ -33,10 +33,10 @@ namespace TerraFX.Numerics
         private readonly float _w;
 
         /// <summary>Initializes a new instance of the <see cref="Vector4" /> struct.</summary>
-        /// <param name="x">The value of the x-component.</param>
-        /// <param name="y">The value of the y-component.</param>
-        /// <param name="z">The value of the z-component.</param>
-        /// <param name="w">The value of the w-component.</param>
+        /// <param name="x">The value of the x-dimension.</param>
+        /// <param name="y">The value of the y-dimension.</param>
+        /// <param name="z">The value of the z-dimension.</param>
+        /// <param name="w">The value of the w-dimension.</param>
         public Vector4(float x, float y, float z, float w)
         {
             _x = x;
@@ -45,16 +45,26 @@ namespace TerraFX.Numerics
             _w = w;
         }
 
-        /// <summary>Gets the value of the x-component.</summary>
+        /// <summary>Initializes a new instance of the <see cref="Vector4"/> struct with each component set to <paramref name="value"/>.</summary>
+        /// <param name="value">The value to set each component to.</param>
+        public Vector4(float value)
+        {
+            _x = value;
+            _y = value;
+            _z = value;
+            _w = value;
+        }
+
+        /// <summary>Gets the value of the x-dimension.</summary>
         public float X => _x;
 
-        /// <summary>Gets the value of the y-component.</summary>
+        /// <summary>Gets the value of the y-dimension.</summary>
         public float Y => _y;
 
-        /// <summary>Gets the value of the z-component.</summary>
+        /// <summary>Gets the value of the z-dimension.</summary>
         public float Z => _z;
 
-        /// <summary>Gets the value of the w-component.</summary>
+        /// <summary>Gets the value of the w-dimension.</summary>
         public float W => _w;
 
         /// <summary>Gets the square-rooted length of the vector.</summary>
@@ -145,22 +155,22 @@ namespace TerraFX.Numerics
         public static Vector4 Normalize(Vector4 value) => value / value.Length;
 
         /// <summary>Creates a new <see cref="Vector4" /> instance with <see cref="X" /> set to the specified value.</summary>
-        /// <param name="value">The new value of the x-component.</param>
+        /// <param name="value">The new value of the x-dimension.</param>
         /// <returns>A new <see cref="Vector4" /> instance with <see cref="X" /> set to <paramref name="value" />.</returns>
         public Vector4 WithX(float value) => new Vector4(value, Y, Z, W);
 
         /// <summary>Creates a new <see cref="Vector4" /> instance with <see cref="Y" /> set to the specified value.</summary>
-        /// <param name="value">The new value of the y-component.</param>
+        /// <param name="value">The new value of the y-dimension.</param>
         /// <returns>A new <see cref="Vector4" /> instance with <see cref="Y" /> set to <paramref name="value" />.</returns>
         public Vector4 WithY(float value) => new Vector4(X, value, Z, W);
 
         /// <summary>Creates a new <see cref="Vector4" /> instance with <see cref="Z" /> set to the specified value.</summary>
-        /// <param name="value">The new value of the z-component.</param>
+        /// <param name="value">The new value of the z-dimension.</param>
         /// <returns>A new <see cref="Vector4" /> instance with <see cref="Z" /> set to <paramref name="value" />.</returns>
         public Vector4 WithZ(float value) => new Vector4(X, Y, value, W);
 
         /// <summary>Creates a new <see cref="Vector4" /> instance with <see cref="W" /> set to the specified value.</summary>
-        /// <param name="value">The new value of the w-component.</param>
+        /// <param name="value">The new value of the w-dimension.</param>
         /// <returns>A new <see cref="Vector4" /> instance with <see cref="W" /> set to <paramref name="value" />.</returns>
         public Vector4 WithW(float value) => new Vector4(X, Y, Z, value);
 

--- a/sources/Core/Numerics/Vector4.cs
+++ b/sources/Core/Numerics/Vector4.cs
@@ -57,6 +57,12 @@ namespace TerraFX.Numerics
         /// <summary>Gets the value of the w-component.</summary>
         public float W => _w;
 
+        /// <summary>Gets the square-rooted length of the vector.</summary>
+        public float Length => MathF.Sqrt(LengthSquared);
+
+        /// <summary>Gets the squared length of the vector.</summary>
+        public float LengthSquared => Dot(this, this);
+
         /// <summary>Compares two <see cref="Vector4" /> instances to determine equality.</summary>
         /// <param name="left">The <see cref="Vector4" /> to compare with <paramref name="right" />.</param>
         /// <param name="right">The <see cref="Vector4" /> to compare with <paramref name="left" />.</param>
@@ -80,6 +86,63 @@ namespace TerraFX.Numerics
                 || (left.Z != right.Z)
                 || (left.W != right.W);
         }
+
+        /// <summary>Returns the value of the <see cref="Vector4" /> operand (the sign of the operand is unchanged).</summary>
+        /// <param name="value">The operand to return</param>
+        /// <returns>The value of the operand, <paramref name="value"/>.</returns>
+        public static Vector4 operator +(Vector4 value) => value;
+
+        /// <summary>Negates the value of the specified <see cref="Vector4" /> operand.</summary>
+        /// <param name="value">The value to negate.</param>
+        /// <returns>The result of <paramref name="value"/> multiplied by negative one (-1).</returns>
+        public static Vector4 operator -(Vector4 value) => value * -1;
+
+        /// <summary>Adds two specified <see cref="Vector4"/> values.</summary>
+        /// <param name="left">The first value to add.</param>
+        /// <param name="right">The second value to add.</param>
+        /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
+        public static Vector4 operator +(Vector4 left, Vector4 right) => new Vector4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+
+        /// <summary>Subtracts two specified <see cref="Vector4"/> values.</summary>
+        /// <param name="left">The minuend.</param>
+        /// <param name="right">The subtrahend.</param>
+        /// <returns>The result of subtracting <paramref name="right"/> from <paramref name="left"/>.</returns>
+        public static Vector4 operator -(Vector4 left, Vector4 right) => new Vector4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+
+        /// <summary>Multiplies two specified <see cref="Vector4"/> values.</summary>
+        /// <param name="left">The first value to multiply.</param>
+        /// <param name="right">The second value to multiply.</param>
+        /// <returns>The result of multiplying <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector4 operator *(Vector4 left, Vector4 right) => new Vector4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
+
+        /// <summary>Divides two specified <see cref="Vector4"/> values.</summary>
+        /// <param name="left">The dividend.</param>
+        /// <param name="right">The divisor.</param>
+        /// <returns>The result of dividing <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector4 operator /(Vector4 left, Vector4 right) => new Vector4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
+
+        /// <summary>Multiplies each component of a <see cref="Vector4"/> value by a given <see cref="float"/> value.</summary>
+        /// <param name="left">The vector to multiply.</param>
+        /// <param name="right">The value to multiply each component by.</param>
+        /// <returns>The result of multiplying each component of <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector4 operator *(Vector4 left, float right) => new Vector4(left.X * right, left.Y * right, left.Z * right, left.W * right);
+
+        /// <summary>Divides each component of a <see cref="Vector4"/> value by a given <see cref="float"/> value.</summary>
+        /// <param name="left">The dividend.</param>
+        /// <param name="right">The divisor to divide each component by.</param>
+        /// <returns>The result of multiplying each component of <paramref name="left"/> by <paramref name="right"/>.</returns>
+        public static Vector4 operator /(Vector4 left, float right) => new Vector4(left.X / right, left.Y / right, left.Z / right, left.W / right);
+
+        /// <summary>Calculates the dot product of two <see cref="Vector4"/> values.</summary>
+        /// <param name="left">The first value to dot.</param>
+        /// <param name="right">The second value to dot.</param>
+        /// <returns>The result of adding the multiplication of each component of <paramref name="left"/> by each component of <paramref name="right"/>.</returns>
+        public static float Dot(Vector4 left, Vector4 right) => (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
+
+        /// <summary>Computes the normalized value of the given <see cref="Vector4"/> value.</summary>
+        /// <param name="value">The value to normalize.</param>
+        /// <returns>The unit vector of <paramref name="value"/>.</returns>
+        public static Vector4 Normalize(Vector4 value) => value / value.Length;
 
         /// <summary>Creates a new <see cref="Vector4" /> instance with <see cref="X" /> set to the specified value.</summary>
         /// <param name="value">The new value of the x-component.</param>

--- a/tests/Core/Vector4Tests.cs
+++ b/tests/Core/Vector4Tests.cs
@@ -6,39 +6,52 @@ namespace TerraFX.UnitTests.Numerics
     /// <summary>Unit tests for <see cref="Vector4"/>.</summary>
     public class Vector4Tests
     {
+        /// <summary>Ensures that a vector's components are equal to the parameters used to construct one.</summary>
+        [Test]
+        public static void ComponentsReturnCorrectValues(
+            [Values(1, 2, 3)] float x,
+            [Values(1, 2, 3)] float y,
+            [Values(1, 2, 3)] float z,
+            [Values(1, 2, 3)] float w)
+        {
+            var vector = new Vector4(x, y, z, w);
+
+            Assert.That(vector.X, Is.EqualTo(x));
+            Assert.That(vector.Y, Is.EqualTo(y));
+            Assert.That(vector.Z, Is.EqualTo(z));
+            Assert.That(vector.W, Is.EqualTo(w));
+        }
+
         /// <summary>Ensures that two vectors that are expected to compare equal do, in fact compare equal.</summary>
         [Test]
         public static void VectorsCompareEqual()
         {
-            Assert.True(new Vector4(0, 0, 0, 0) == new Vector4(0, 0, 0, 0));
-            Assert.False(new Vector4(0, 0, 0, 0) == new Vector4(1, 1, 1, 1));
+            Assert.That(new Vector4(0, 0, 0, 0) == new Vector4(0, 0, 0, 0), Is.True);
+            Assert.That(new Vector4(0, 0, 0, 0) == new Vector4(1, 1, 1, 1), Is.False);
         }
 
         /// <summary>Ensures that two vectors that are expected to compare not equal do, in fact compare not equal.</summary>
         [Test]
         public static void VectorsCompareNotEqual()
         {
-            Assert.False(new Vector4(0, 0, 0, 0) != new Vector4(0, 0, 0, 0));
-            Assert.True(new Vector4(0, 0, 0, 0) != new Vector4(1, 1, 1, 1));
+            Assert.That(new Vector4(0, 0, 0, 0) != new Vector4(0, 0, 0, 0), Is.False);
+            Assert.That(new Vector4(0, 0, 0, 0) != new Vector4(1, 1, 1, 1), Is.True);
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator+(Vector4)"/> returns its input unchanced.</summary>
         [Test]
         public static void UnaryPlusReturnsUnchanged()
         {
-            Assert.True(+Vector4.Zero == Vector4.Zero);
+            Assert.That(+Vector4.Zero == Vector4.Zero, Is.True);
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator-(Vector4)"/> returns the negation of its input.</summary>
         [Test]
         public static void UnaryNegationReturnsNegative()
         {
-            var minusOne = -new Vector4(1, 1, 1, 1);
+            var vector = -new Vector4(1, 1, 1, 1);
 
-            Assert.AreEqual(-1, minusOne.X);
-            Assert.AreEqual(-1, minusOne.Y);
-            Assert.AreEqual(-1, minusOne.Z);
-            Assert.AreEqual(-1, minusOne.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(-1, -1, -1, -1)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator+(Vector4,Vector4)"/> returns the vector sum of its components.</summary>
@@ -47,34 +60,25 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector4(1, 2, 3, 4) + new Vector4(1, 2, 3, 4);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(4, vector.Y);
-            Assert.AreEqual(6, vector.Z);
-            Assert.AreEqual(8, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(2, 4, 6, 8)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator-(Vector4,Vector4)"/> returns the vector difference of its components.</summary>
         [Test]
         public static void SubtractionReturnsDifferenceOfValues()
         {
-            var vector = new Vector4(3, 2, 1, 0) - new Vector4(1, 2, 3, 4);
+            var vector = new Vector4(4, 3, 2, 1) - new Vector4(1, 2, 3, 4);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(0, vector.Y);
-            Assert.AreEqual(-2, vector.Z);
-            Assert.AreEqual(-4, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(3, 1, -1, -3)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator*(Vector4,Vector4)"/> returns the vector product of its components.</summary>
         [Test]
         public static void VectorMultiplicationReturnsProductOfValues()
         {
-            var vector = new Vector4(1, 2, 3, 4) * new Vector4(3, 2, 1, 0);
+            var vector = new Vector4(1, 2, 3, 4) * new Vector4(4, 3, 2, 1);
 
-            Assert.AreEqual(3, vector.X);
-            Assert.AreEqual(4, vector.Y);
-            Assert.AreEqual(3, vector.Z);
-            Assert.AreEqual(0, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(4, 6, 6, 4)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator/(Vector4,Vector4)"/> returns the vector division of its components.</summary>
@@ -83,10 +87,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector4(6, 12, 18, 24) / new Vector4(3, 6, 9, 12);
 
-            Assert.AreEqual(2, vector.X);
-            Assert.AreEqual(2, vector.Y);
-            Assert.AreEqual(2, vector.Z);
-            Assert.AreEqual(2, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(2, 2, 2, 2)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator*(Vector4,float)"/> returns a vector with each component multiplied by the given float.</summary>
@@ -95,10 +96,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector4(1, 2, 3, 4) * 5;
 
-            Assert.AreEqual(5, vector.X);
-            Assert.AreEqual(10, vector.Y);
-            Assert.AreEqual(15, vector.Z);
-            Assert.AreEqual(20, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(5, 10, 15, 20)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.operator/(Vector4,float)"/> returns a vector with each component divided by the given float.</summary>
@@ -107,10 +105,7 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector4(5, 10, 15, 20) / 5;
 
-            Assert.AreEqual(1, vector.X);
-            Assert.AreEqual(2, vector.Y);
-            Assert.AreEqual(3, vector.Z);
-            Assert.AreEqual(4, vector.W);
+            Assert.That(vector, Is.EqualTo(new Vector4(1, 2, 3, 4)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.Dot(Vector4,Vector4)"/> returns the scalar product of both input vectors.</summary>
@@ -119,17 +114,17 @@ namespace TerraFX.UnitTests.Numerics
         {
             var product = Vector4.Dot(new Vector4(1, 0.5f, 0, 0.25f), new Vector4(2, 1, 0, 2.0f));
 
-            Assert.AreEqual(3.0f, product);
+            Assert.That(product, Is.EqualTo(3.0f));
         }
 
         /// <summary>Ensures that <see cref="Vector4.Normalize(Vector4)"/> returns a unit vector.</summary>
         [Test]
         public static void NormalizeReturnsUnitVector()
         {
-            Assert.AreEqual(new Vector4(1, 0, 0, 0), Vector4.Normalize(new Vector4(1, 0, 0, 0)));
-            Assert.AreEqual(new Vector4(0, 1, 0, 0), Vector4.Normalize(new Vector4(0, 2, 0, 0)));
-            Assert.AreEqual(new Vector4(0, 0, 1, 0), Vector4.Normalize(new Vector4(0, 0, 5, 0)));
-            Assert.AreEqual(new Vector4(0, 0, 0, 1), Vector4.Normalize(new Vector4(0, 0, 0, 8)));
+            Assert.That(Vector4.Normalize(new Vector4(1, 0, 0, 0)), Is.EqualTo(new Vector4(1, 0, 0, 0)));
+            Assert.That(Vector4.Normalize(new Vector4(0, 2, 0, 0)), Is.EqualTo(new Vector4(0, 1, 0, 0)));
+            Assert.That(Vector4.Normalize(new Vector4(0, 0, 3, 0)), Is.EqualTo(new Vector4(0, 0, 1, 0)));
+            Assert.That(Vector4.Normalize(new Vector4(0, 0, 0, 5)), Is.EqualTo(new Vector4(0, 0, 0, 1)));
         }
 
         /// <summary>Ensures that <see cref="Vector4.Length"/> and <see cref="Vector4.LengthSquared"/> return the magnitude and squared magnitude of the input vector.</summary>
@@ -138,8 +133,8 @@ namespace TerraFX.UnitTests.Numerics
         {
             var vector = new Vector4(0, 5, 0, 0);
 
-            Assert.AreEqual(5, vector.Length);
-            Assert.AreEqual(25, vector.LengthSquared);
+            Assert.That(vector.Length, Is.EqualTo(5));
+            Assert.That(vector.LengthSquared, Is.EqualTo(25));
         }
     }
 }

--- a/tests/Core/Vector4Tests.cs
+++ b/tests/Core/Vector4Tests.cs
@@ -1,0 +1,145 @@
+using NUnit.Framework;
+using TerraFX.Numerics;
+
+namespace TerraFX.UnitTests.Numerics
+{
+    /// <summary>Unit tests for <see cref="Vector4"/>.</summary>
+    public class Vector4Tests
+    {
+        /// <summary>Ensures that two vectors that are expected to compare equal do, in fact compare equal.</summary>
+        [Test]
+        public static void VectorsCompareEqual()
+        {
+            Assert.True(new Vector4(0, 0, 0, 0) == new Vector4(0, 0, 0, 0));
+            Assert.False(new Vector4(0, 0, 0, 0) == new Vector4(1, 1, 1, 1));
+        }
+
+        /// <summary>Ensures that two vectors that are expected to compare not equal do, in fact compare not equal.</summary>
+        [Test]
+        public static void VectorsCompareNotEqual()
+        {
+            Assert.False(new Vector4(0, 0, 0, 0) != new Vector4(0, 0, 0, 0));
+            Assert.True(new Vector4(0, 0, 0, 0) != new Vector4(1, 1, 1, 1));
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator+(Vector4)"/> returns its input unchanced.</summary>
+        [Test]
+        public static void UnaryPlusReturnsUnchanged()
+        {
+            Assert.True(+Vector4.Zero == Vector4.Zero);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator-(Vector4)"/> returns the negation of its input.</summary>
+        [Test]
+        public static void UnaryNegationReturnsNegative()
+        {
+            var minusOne = -new Vector4(1, 1, 1, 1);
+
+            Assert.AreEqual(-1, minusOne.X);
+            Assert.AreEqual(-1, minusOne.Y);
+            Assert.AreEqual(-1, minusOne.Z);
+            Assert.AreEqual(-1, minusOne.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator+(Vector4,Vector4)"/> returns the vector sum of its components.</summary>
+        [Test]
+        public static void AdditionReturnsSumOfValues()
+        {
+            var vector = new Vector4(1, 2, 3, 4) + new Vector4(1, 2, 3, 4);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(4, vector.Y);
+            Assert.AreEqual(6, vector.Z);
+            Assert.AreEqual(8, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator-(Vector4,Vector4)"/> returns the vector difference of its components.</summary>
+        [Test]
+        public static void SubtractionReturnsDifferenceOfValues()
+        {
+            var vector = new Vector4(3, 2, 1, 0) - new Vector4(1, 2, 3, 4);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(0, vector.Y);
+            Assert.AreEqual(-2, vector.Z);
+            Assert.AreEqual(-4, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator*(Vector4,Vector4)"/> returns the vector product of its components.</summary>
+        [Test]
+        public static void VectorMultiplicationReturnsProductOfValues()
+        {
+            var vector = new Vector4(1, 2, 3, 4) * new Vector4(3, 2, 1, 0);
+
+            Assert.AreEqual(3, vector.X);
+            Assert.AreEqual(4, vector.Y);
+            Assert.AreEqual(3, vector.Z);
+            Assert.AreEqual(0, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator/(Vector4,Vector4)"/> returns the vector division of its components.</summary>
+        [Test]
+        public static void VectorDivisionReturnsDivisionOfValues()
+        {
+            var vector = new Vector4(6, 12, 18, 24) / new Vector4(3, 6, 9, 12);
+
+            Assert.AreEqual(2, vector.X);
+            Assert.AreEqual(2, vector.Y);
+            Assert.AreEqual(2, vector.Z);
+            Assert.AreEqual(2, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator*(Vector4,float)"/> returns a vector with each component multiplied by the given float.</summary>
+        [Test]
+        public static void ScalarMultiplicationReturnValuesScaled()
+        {
+            var vector = new Vector4(1, 2, 3, 4) * 5;
+
+            Assert.AreEqual(5, vector.X);
+            Assert.AreEqual(10, vector.Y);
+            Assert.AreEqual(15, vector.Z);
+            Assert.AreEqual(20, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.operator/(Vector4,float)"/> returns a vector with each component divided by the given float.</summary>
+        [Test]
+        public static void ScalarDivisionReturnsValuesScaled()
+        {
+            var vector = new Vector4(5, 10, 15, 20) / 5;
+
+            Assert.AreEqual(1, vector.X);
+            Assert.AreEqual(2, vector.Y);
+            Assert.AreEqual(3, vector.Z);
+            Assert.AreEqual(4, vector.W);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.Dot(Vector4,Vector4)"/> returns the scalar product of both input vectors.</summary>
+        [Test]
+        public static void DotProductReturnsScalarProduct()
+        {
+            var product = Vector4.Dot(new Vector4(1, 0.5f, 0, 0.25f), new Vector4(2, 1, 0, 2.0f));
+
+            Assert.AreEqual(3.0f, product);
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.Normalize(Vector4)"/> returns a unit vector.</summary>
+        [Test]
+        public static void NormalizeReturnsUnitVector()
+        {
+            Assert.AreEqual(new Vector4(1, 0, 0, 0), Vector4.Normalize(new Vector4(1, 0, 0, 0)));
+            Assert.AreEqual(new Vector4(0, 1, 0, 0), Vector4.Normalize(new Vector4(0, 2, 0, 0)));
+            Assert.AreEqual(new Vector4(0, 0, 1, 0), Vector4.Normalize(new Vector4(0, 0, 5, 0)));
+            Assert.AreEqual(new Vector4(0, 0, 0, 1), Vector4.Normalize(new Vector4(0, 0, 0, 8)));
+        }
+
+        /// <summary>Ensures that <see cref="Vector4.Length"/> and <see cref="Vector4.LengthSquared"/> return the magnitude and squared magnitude of the input vector.</summary>
+        [Test]
+        public static void LengthReturnsMagnitudeOfVector()
+        {
+            var vector = new Vector4(0, 5, 0, 0);
+
+            Assert.AreEqual(5, vector.Length);
+            Assert.AreEqual(25, vector.LengthSquared);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #99.

Again, as with #109 and #110, this is almost a direct copy+paste of the Vector3 code but with the 'W' component added. This adds the core functionality and unit tests for Vector4.

I've left out the single-parameter constructor again, for the same reasons as Vector3 and Vector2.
