### PR TITLE
Removing the check enforcing the GPU support Resource Heap Tier 2

### DIFF
--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsDevice.cs
@@ -235,13 +235,6 @@ namespace TerraFX.Graphics.Providers.D3D12
             var iid = IID_ID3D12Device;
             ThrowExternalExceptionIfFailed(nameof(D3D12CreateDevice), D3D12CreateDevice((IUnknown*)Adapter.DxgiAdapter, D3D_FEATURE_LEVEL_11_0, &iid, (void**)&d3d12Device));
 
-            D3D12_FEATURE_DATA_D3D12_OPTIONS d3d12Options;
-            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CheckFeatureSupport), d3d12Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &d3d12Options, SizeOf<D3D12_FEATURE_DATA_D3D12_OPTIONS>()));
-
-            if (d3d12Options.ResourceHeapTier != D3D12_RESOURCE_HEAP_TIER_2)
-            {
-                throw new NotSupportedException("TerraFX currently requires a device that supports Resource Heap Tier 2");
-            }
             return d3d12Device;
         }
 


### PR DESCRIPTION
This should have been removed with #91 but was missed.