### PR TITLE
Upgrading to .NET 5 RC2

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,17 +24,17 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200812-03" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200921-01" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Update="System.Composition" Version="5.0.0-preview.8.20407.11" />
-    <PackageReference Update="System.IO.Pipelines" Version="5.0.0-preview.8.20407.11" />
-    <PackageReference Update="TerraFX.Interop.Libc" Version="1.2017.0-alpha-258283270" />
-    <PackageReference Update="TerraFX.Interop.PulseAudio" Version="13.0.0-alpha-258313922" />
-    <PackageReference Update="TerraFX.Interop.Vulkan" Version="1.2.135-alpha-257883922" />
-    <PackageReference Update="TerraFX.Interop.Windows" Version="10.0.19041-alpha-257883804" />
-    <PackageReference Update="TerraFX.Interop.Xlib" Version="6.3.0-alpha-258281612" />
+    <PackageReference Update="System.Composition" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Update="System.IO.Pipelines" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Update="TerraFX.Interop.Libc" Version="1.2017.0-alpha-306791429" />
+    <PackageReference Update="TerraFX.Interop.PulseAudio" Version="13.0.0-alpha-306791545" />
+    <PackageReference Update="TerraFX.Interop.Vulkan" Version="1.2.135-alpha-306791632" />
+    <PackageReference Update="TerraFX.Interop.Windows" Version="10.0.19041-alpha-306793647" />
+    <PackageReference Update="TerraFX.Interop.Xlib" Version="6.3.0-alpha-306791182" />
   </ItemGroup>
 
 </Project>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,7 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel master -Version 5.0.100-rc.1.20452.10 -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel master -Version 5.0.100-rc.2.20479.15 -InstallDir $DotNetInstallDirectory -Architecture $architecture
 
     $env:PATH="$DotNetInstallDirectory;$env:PATH"
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,7 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel master --version 5.0.100-rc.1.20452.10 --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel master --version 5.0.100-rc.2.20479.15 --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
 
   PATH="$DotNetInstallDirectory:$PATH:"
 fi

--- a/sources/Core/Collections/NotifyCollectionChangedEventArgs`1.cs
+++ b/sources/Core/Collections/NotifyCollectionChangedEventArgs`1.cs
@@ -13,9 +13,9 @@ namespace TerraFX.Collections
         private static readonly NotifyCollectionChangedEventArgs<T> Reset = new NotifyCollectionChangedEventArgs<T>(NotifyCollectionChangedAction.Reset);
 
         private readonly NotifyCollectionChangedAction _action;
-        private readonly T _value;
+        private readonly T? _value;
 
-        private NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, T value = default)
+        private NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, T? value = default)
         {
             Debug.Assert(Enum.IsDefined(typeof(NotifyCollectionChangedAction), action));
 
@@ -28,7 +28,7 @@ namespace TerraFX.Collections
 
         /// <summary>Gets the value of the item that caused the event.</summary>
         /// <exception cref="InvalidOperationException"><see cref="Action" /> is not <see cref="NotifyDictionaryChangedAction.Add" /> or <see cref="NotifyDictionaryChangedAction.Remove" />.</exception>
-        public T Value
+        public T? Value
         {
             get
             {

--- a/sources/Core/Collections/NotifyDictionaryChangedEventArgs`2.cs
+++ b/sources/Core/Collections/NotifyDictionaryChangedEventArgs`2.cs
@@ -14,11 +14,11 @@ namespace TerraFX.Collections
         private static readonly NotifyDictionaryChangedEventArgs<TKey, TValue> Reset = new NotifyDictionaryChangedEventArgs<TKey, TValue>(NotifyDictionaryChangedAction.Reset);
 
         private readonly NotifyDictionaryChangedAction _action;
-        private readonly TKey _key;
-        private readonly TValue _oldValue;
-        private readonly TValue _newValue;
+        private readonly TKey? _key;
+        private readonly TValue? _oldValue;
+        private readonly TValue? _newValue;
 
-        private NotifyDictionaryChangedEventArgs(NotifyDictionaryChangedAction action, TKey key = default, TValue oldValue = default, TValue newValue = default)
+        private NotifyDictionaryChangedEventArgs(NotifyDictionaryChangedAction action, TKey? key = default, TValue? oldValue = default, TValue? newValue = default)
         {
             Debug.Assert(Enum.IsDefined(typeof(NotifyDictionaryChangedAction), action));
 
@@ -33,7 +33,7 @@ namespace TerraFX.Collections
 
         /// <summary>Gets the key of the item that caused the event.</summary>
         /// <exception cref="InvalidOperationException"><see cref="Action" /> is not <see cref="NotifyDictionaryChangedAction.Add" />, <see cref="NotifyDictionaryChangedAction.Remove" />, or <see cref="NotifyDictionaryChangedAction.ValueChanged" />.</exception>
-        public TKey Key
+        public TKey? Key
         {
             get
             {
@@ -48,7 +48,7 @@ namespace TerraFX.Collections
 
         /// <summary>Gets the old value of the item that caused the event.</summary>
         /// <exception cref="InvalidOperationException"><see cref="Action" /> is not <see cref="NotifyDictionaryChangedAction.ValueChanged" />.</exception>
-        public TValue OldValue
+        public TValue? OldValue
         {
             get
             {
@@ -63,7 +63,7 @@ namespace TerraFX.Collections
 
         /// <summary>Gets the new value of the item that caused the event.</summary>
         /// <exception cref="InvalidOperationException"><see cref="Action" /> is not <see cref="NotifyDictionaryChangedAction.ValueChanged" />.</exception>
-        public TValue NewValue
+        public TValue? NewValue
         {
             get
             {

--- a/sources/Providers/Audio/PulseAudio/AudioProvider.cs
+++ b/sources/Providers/Audio/PulseAudio/AudioProvider.cs
@@ -238,7 +238,7 @@ namespace TerraFX.Audio.Providers.PulseAudio
             var userdata = (void*)GCHandle.ToIntPtr(handle);
             ref var helper = ref Unsafe.Unbox<AudioDeviceEnumeratorHelper>(handle.Target!);
 
-            helper.Enumerable = new PulseAudioAdapterEnumerable(_mainLoopThread!, (delegate* unmanaged<IntPtr, pa_source_info*, int, void*, void>)(delegate*<IntPtr, pa_source_info*, int, void*, void>)&AddSourceDevice, (delegate* unmanaged<IntPtr, pa_sink_info*, int, void*, void>)(delegate*<IntPtr, pa_sink_info*, int, void*, void>)&AddSinkDevice);
+            helper.Enumerable = new PulseAudioAdapterEnumerable(_mainLoopThread!, &AddSourceDevice, &AddSinkDevice);
             helper.SourceOp = pa_context_get_source_info_list(Context, helper.Enumerable.SourceCallback, userdata);
             helper.SinkOp = pa_context_get_sink_info_list(Context, helper.Enumerable.SinkCallback, userdata);
 

--- a/sources/Providers/Audio/PulseAudio/PulseAudioPlaybackDevice.cs
+++ b/sources/Providers/Audio/PulseAudio/PulseAudioPlaybackDevice.cs
@@ -61,7 +61,7 @@ namespace TerraFX.Audio.Providers.PulseAudio
             _sampleDataPipe = new Pipe();
             _stream = new Lazy<IntPtr>(CreateStream, isThreadSafe: true);
             _writeDelegateHandle = new ValueLazy<GCHandle>(CreateHandle);
-            _writeDelegate = (delegate* unmanaged<IntPtr, nuint, void*, void>)(delegate*<IntPtr, nuint, void*, void>)&WriteCallback;
+            _writeDelegate = &WriteCallback;
             _writeRequest = new ManualResetValueTaskSource<int>() {
                 RunContinuationsAsynchronously = true
             };

--- a/sources/Providers/UI/Win32/Win32WindowProvider.cs
+++ b/sources/Providers/UI/Win32/Win32WindowProvider.cs
@@ -215,13 +215,10 @@ namespace TerraFX.UI.Providers.Win32
 
                 fixed (char* lpszClassName = className)
                 {
-                    // Requires an explicit cast until C# handles UnmanagedCallersOnly
-                    var wndProc = (delegate* unmanaged<IntPtr, uint, nuint, nint, nint>)(delegate*<IntPtr, uint, nuint, nint, nint>)&ForwardWindowMessage;
-
                     var wndClassEx = new WNDCLASSEXW {
                         cbSize = SizeOf<WNDCLASSEXW>(),
                         style = CS_VREDRAW | CS_HREDRAW | CS_DBLCLKS,
-                        lpfnWndProc = wndProc,
+                        lpfnWndProc = &ForwardWindowMessage,
                         cbClsExtra = 0,
                         cbWndExtra = 0,
                         hInstance = EntryPointModule,


### PR DESCRIPTION
This upgrades the repo to .NET 5 RC2. This allows us to simplify the `UnmanagedCallersOnly` usage sites by removing unnecessary casts and required some additional nullability annotations.