### PR TITLE
Ensure textures are created on the non RT/DS heap by default

### DIFF
--- a/sources/Providers/Graphics/D3D12/Memory/D3D12GraphicsMemoryAllocator.cs
+++ b/sources/Providers/Graphics/D3D12/Memory/D3D12GraphicsMemoryAllocator.cs
@@ -95,7 +95,7 @@ namespace TerraFX.Graphics.Providers.D3D12
         /// <inheritdoc />
         public override D3D12GraphicsTexture CreateTexture(GraphicsTextureKind kind, GraphicsResourceCpuAccess cpuAccess, uint width, uint height = 1, ushort depth = 1, ulong alignment = 0, GraphicsMemoryAllocationFlags allocationFlags = GraphicsMemoryAllocationFlags.None)
         {
-            var index = GetBlockCollectionIndex(cpuAccess, 2);
+            var index = GetBlockCollectionIndex(cpuAccess, 1);
 
             var resourceDesc = kind switch {
                 GraphicsTextureKind.OneDimensional => D3D12_RESOURCE_DESC.Tex1D(DXGI_FORMAT_R8G8B8A8_UNORM, width, mipLevels: 1, alignment: alignment),


### PR DESCRIPTION
Textures were being created on the RT/DS heap which was causing issues on older GPUs without resource heap tier 2 support.