### PR TITLE
Ensure we validate the memory type is compatible with the VkMemoryRequirements

### DIFF
--- a/sources/Providers/Graphics/Vulkan/Memory/VulkanGraphicsMemoryAllocator.cs
+++ b/sources/Providers/Graphics/Vulkan/Memory/VulkanGraphicsMemoryAllocator.cs
@@ -186,6 +186,11 @@ namespace TerraFX.Graphics.Providers.Vulkan
 
             for (var i = 0; i < _blockCollections.Length; i++)
             {
+                if ((memoryTypeBits & (1 << i)) == 0)
+                {
+                    continue;
+                }
+
                 var memoryPropertyFlags = memoryProperties.memoryTypes[i].propertyFlags;
 
                 if (((uint)requiredMemoryPropertyFlags & ~memoryPropertyFlags) != 0)


### PR DESCRIPTION
This ensures Vulkan works with a card that only supports "resource tier 1" for DirectX