### PR TITLE
Updating how the CbvSrvUavDescriptorHeap is handled for D3D12

### DIFF
--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPipeline.cs
@@ -16,14 +16,12 @@ namespace TerraFX.Graphics.Providers.D3D12
     public sealed unsafe class D3D12GraphicsPipeline : GraphicsPipeline
     {
         private ValueLazy<Pointer<ID3D12PipelineState>> _d3d12PipelineState;
-
         private State _state;
 
         internal D3D12GraphicsPipeline(D3D12GraphicsDevice device, D3D12GraphicsPipelineSignature signature, D3D12GraphicsShader? vertexShader, D3D12GraphicsShader? pixelShader)
             : base(device, signature, vertexShader, pixelShader)
         {
             _d3d12PipelineState = new ValueLazy<Pointer<ID3D12PipelineState>>(CreateD3D12GraphicsPipelineState);
-
             _ = _state.Transition(to: Initialized);
         }
 

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPipelineSignature.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPipelineSignature.cs
@@ -76,16 +76,13 @@ namespace TerraFX.Graphics.Providers.D3D12
                 var textureShaderRegister = 0;
                 var staticSamplersIndex = 0;
 
-                if (resourcesLength != 0)
+                for (var inputIndex = 0; inputIndex < resourcesLength; inputIndex++)
                 {
-                    for (var inputIndex = 0; inputIndex < resourcesLength; inputIndex++)
-                    {
-                        rootParametersLength++;
+                    rootParametersLength++;
 
-                        if (resources[inputIndex].Kind == GraphicsPipelineResourceKind.Texture)
-                        {
-                            staticSamplersLength++;
-                        }
+                    if (resources[inputIndex].Kind == GraphicsPipelineResourceKind.Texture)
+                    {
+                        staticSamplersLength++;
                     }
                 }
 
@@ -93,45 +90,42 @@ namespace TerraFX.Graphics.Providers.D3D12
                 var staticSamplers = stackalloc D3D12_STATIC_SAMPLER_DESC[staticSamplersLength];
                 var descriptorRanges = stackalloc D3D12_DESCRIPTOR_RANGE[staticSamplersLength];
 
-                if (resourcesLength != 0)
+                for (var inputIndex = 0; inputIndex < resourcesLength; inputIndex++)
                 {
-                    for (var inputIndex = 0; inputIndex < resourcesLength; inputIndex++)
+                    var input = resources[inputIndex];
+
+                    switch (input.Kind)
                     {
-                        var input = resources[inputIndex];
-
-                        switch (input.Kind)
+                        case GraphicsPipelineResourceKind.ConstantBuffer:
                         {
-                            case GraphicsPipelineResourceKind.ConstantBuffer:
-                            {
-                                var shaderVisibility = GetD3D12ShaderVisiblity(input.ShaderVisibility);
-                                rootParameters[rootParametersIndex].InitAsConstantBufferView(unchecked((uint)constantShaderRegister), registerSpace: 0, shaderVisibility);
+                            var shaderVisibility = GetD3D12ShaderVisiblity(input.ShaderVisibility);
+                            rootParameters[rootParametersIndex].InitAsConstantBufferView(unchecked((uint)constantShaderRegister), registerSpace: 0, shaderVisibility);
 
-                                constantShaderRegister++;
-                                rootParametersIndex++;
-                                break;
-                            }
+                            constantShaderRegister++;
+                            rootParametersIndex++;
+                            break;
+                        }
 
-                            case GraphicsPipelineResourceKind.Texture:
-                            {
-                                descriptorRanges[staticSamplersIndex] = new D3D12_DESCRIPTOR_RANGE(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, numDescriptors: 1, baseShaderRegister: unchecked((uint)textureShaderRegister));
-                                var shaderVisibility = GetD3D12ShaderVisiblity(input.ShaderVisibility);
+                        case GraphicsPipelineResourceKind.Texture:
+                        {
+                            descriptorRanges[staticSamplersIndex] = new D3D12_DESCRIPTOR_RANGE(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, numDescriptors: 1, baseShaderRegister: unchecked((uint)textureShaderRegister));
+                            var shaderVisibility = GetD3D12ShaderVisiblity(input.ShaderVisibility);
 
-                                rootParameters[rootParametersIndex].InitAsDescriptorTable(1, &descriptorRanges[staticSamplersIndex], shaderVisibility);
-                                staticSamplers[staticSamplersIndex] = new D3D12_STATIC_SAMPLER_DESC(
-                                    shaderRegister: unchecked((uint)staticSamplersIndex),
-                                    shaderVisibility: shaderVisibility
-                                );
+                            rootParameters[rootParametersIndex].InitAsDescriptorTable(1, &descriptorRanges[staticSamplersIndex], shaderVisibility);
+                            staticSamplers[staticSamplersIndex] = new D3D12_STATIC_SAMPLER_DESC(
+                                shaderRegister: unchecked((uint)staticSamplersIndex),
+                                shaderVisibility: shaderVisibility
+                            );
 
-                                textureShaderRegister++;
-                                rootParametersIndex++;
-                                staticSamplersIndex++;
-                                break;
-                            }
+                            textureShaderRegister++;
+                            rootParametersIndex++;
+                            staticSamplersIndex++;
+                            break;
+                        }
 
-                            default:
-                            {
-                                break;
-                            }
+                        default:
+                        {
+                            break;
                         }
                     }
                 }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsPrimitive.cs
@@ -1,7 +1,14 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using TerraFX.Interop;
 using TerraFX.Utilities;
+using static TerraFX.Graphics.Providers.D3D12.HelperUtilities;
+using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_FLAGS;
+using static TerraFX.Interop.D3D12_DESCRIPTOR_HEAP_TYPE;
+using static TerraFX.Interop.D3D12_SRV_DIMENSION;
+using static TerraFX.Interop.DXGI_FORMAT;
+using static TerraFX.Interop.Windows;
 using static TerraFX.Utilities.State;
 
 namespace TerraFX.Graphics.Providers.D3D12
@@ -9,16 +16,22 @@ namespace TerraFX.Graphics.Providers.D3D12
     /// <inheritdoc />
     public sealed unsafe class D3D12GraphicsPrimitive : GraphicsPrimitive
     {
+        private ValueLazy<Pointer<ID3D12DescriptorHeap>> _d3d12CbvSrvUavDescriptorHeap;
         private State _state;
 
         internal D3D12GraphicsPrimitive(D3D12GraphicsDevice device, D3D12GraphicsPipeline pipeline, in GraphicsBufferView vertexBufferView, in GraphicsBufferView indexBufferView, ReadOnlySpan<GraphicsResource> inputResources)
             : base(device, pipeline, in vertexBufferView, in indexBufferView, inputResources)
         {
+            _d3d12CbvSrvUavDescriptorHeap = new ValueLazy<Pointer<ID3D12DescriptorHeap>>(CreateD3D12CbvSrvUavDescriptorHeap);
             _ = _state.Transition(to: Initialized);
         }
 
         /// <summary>Finalizes an instance of the <see cref="D3D12GraphicsPrimitive" /> class.</summary>
         ~D3D12GraphicsPrimitive() => Dispose(isDisposing: false);
+
+        /// <summary>Gets the <see cref="ID3D12DescriptorHeap" /> used by the primitive for constant buffer, shader resource, and unordered access views.</summary>
+        /// <exception cref="ObjectDisposedException">The device has been disposed.</exception>
+        public ID3D12DescriptorHeap* D3D12CbvSrvUavDescriptorHeap => _d3d12CbvSrvUavDescriptorHeap.Value;
 
         /// <inheritdoc cref="GraphicsPrimitive.Device" />
         public new D3D12GraphicsDevice Device => (D3D12GraphicsDevice)base.Device;
@@ -33,6 +46,8 @@ namespace TerraFX.Graphics.Providers.D3D12
 
             if (priorState < Disposing)
             {
+                _d3d12CbvSrvUavDescriptorHeap.Dispose(ReleaseIfNotNull);
+
                 Pipeline?.Dispose();
 
                 foreach (var inputResource in InputResources)
@@ -45,6 +60,88 @@ namespace TerraFX.Graphics.Providers.D3D12
             }
 
             _state.EndDispose();
+        }
+
+        private Pointer<ID3D12DescriptorHeap> CreateD3D12CbvSrvUavDescriptorHeap()
+        {
+            _state.ThrowIfDisposedOrDisposing();
+
+            var d3d12Device = Device.D3D12Device;
+            var inputResources = InputResources;
+            var inputResourcesLength = inputResources.Length;
+            var numCbvSrvUavDescriptors = 0u;
+
+            for (var index = 0; index < inputResourcesLength; index++)
+            {
+                var inputResource = inputResources[index];
+
+                if (inputResource is not D3D12GraphicsTexture)
+                {
+                    continue;
+                }
+
+                numCbvSrvUavDescriptors++;
+            }
+
+            ID3D12DescriptorHeap* cbvSrvUavDescriptorHeap;
+
+            var cbvSrvUavDescriptorHeapDesc = new D3D12_DESCRIPTOR_HEAP_DESC {
+                Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+                NumDescriptors = numCbvSrvUavDescriptors,
+                Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE,
+            };
+
+            var iid = IID_ID3D12DescriptorHeap;
+            ThrowExternalExceptionIfFailed(nameof(ID3D12Device.CreateDescriptorHeap), d3d12Device->CreateDescriptorHeap(&cbvSrvUavDescriptorHeapDesc, &iid, (void**)&cbvSrvUavDescriptorHeap));
+
+            var cbvSrvUavDescriptorHandleIncrementSize = Device.CbvSrvUavDescriptorHandleIncrementSize;
+            var cbvSrvUavDescriptorIndex = 0;
+
+            for (var index = 0; index < inputResourcesLength; index++)
+            {
+                var inputResource = inputResources[index];
+
+                if (inputResource is not D3D12GraphicsTexture d3d12GraphicsTexture)
+                {
+                    continue;
+                }
+
+                var shaderResourceViewDesc = new D3D12_SHADER_RESOURCE_VIEW_DESC {
+                    Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+                    ViewDimension = D3D12_SRV_DIMENSION_UNKNOWN,
+                    Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+                };
+
+                switch (d3d12GraphicsTexture.Kind)
+                {
+                    case GraphicsTextureKind.OneDimensional:
+                    {
+                        shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
+                        shaderResourceViewDesc.Texture1D.MipLevels = 1;
+                        break;
+                    }
+
+                    case GraphicsTextureKind.TwoDimensional:
+                    {
+                        shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+                        shaderResourceViewDesc.Texture2D.MipLevels = 1;
+                        break;
+                    }
+
+                    case GraphicsTextureKind.ThreeDimensional:
+                    {
+                        shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
+                        shaderResourceViewDesc.Texture3D.MipLevels = 1;
+                        break;
+                    }
+                }
+
+                var cpuDescriptorHandleForHeapStart = cbvSrvUavDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
+                d3d12Device->CreateShaderResourceView(d3d12GraphicsTexture.D3D12Resource, &shaderResourceViewDesc, cpuDescriptorHandleForHeapStart.Offset(cbvSrvUavDescriptorIndex, cbvSrvUavDescriptorHandleIncrementSize));
+                cbvSrvUavDescriptorIndex++;
+            }
+
+            return cbvSrvUavDescriptorHeap;
         }
     }
 }

--- a/sources/Providers/Graphics/D3D12/D3D12GraphicsTexture.cs
+++ b/sources/Providers/Graphics/D3D12/D3D12GraphicsTexture.cs
@@ -114,38 +114,6 @@ namespace TerraFX.Graphics.Providers.D3D12
                 (void**)&d3d12Resource
             ));
 
-            var shaderResourceViewDesc = new D3D12_SHADER_RESOURCE_VIEW_DESC {
-                Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-                ViewDimension = D3D12_SRV_DIMENSION_UNKNOWN,
-                Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-            };
-
-            switch(Kind)
-            {
-                case GraphicsTextureKind.OneDimensional:
-                {
-                    shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
-                    shaderResourceViewDesc.Texture1D.MipLevels = 1;
-                    break;
-                }
-
-                case GraphicsTextureKind.TwoDimensional:
-                {
-                    shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-                    shaderResourceViewDesc.Texture2D.MipLevels = 1;
-                    break;
-                }
-
-                case GraphicsTextureKind.ThreeDimensional:
-                {
-                    shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
-                    shaderResourceViewDesc.Texture3D.MipLevels = 1;
-                    break;
-                }
-            }
-
-            d3d12Device->CreateShaderResourceView(d3d12Resource, &shaderResourceViewDesc, device.D3D12ShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart());
-
             return d3d12Resource;
         }
 


### PR DESCRIPTION
This updates how the `CbvSrvUavDescriptorHeap` is handled for D3D12. Previously, this heap was set per device but this greatly limits its reusability and will ultimately cause resources to overwrite eachother.

This PR changes it to be tracked per primitive instead so that resources don't overlap and the state can be tracked correctly for each shader. While still not an ideal setup and while it won't work quite correctly with instancing, it is a step in the right direction for now.