### PR TITLE
Updating Win32Window to cache the window size after creation

### DIFF
--- a/sources/Providers/UI/Win32/Win32Window.cs
+++ b/sources/Providers/UI/Win32/Win32Window.cs
@@ -406,6 +406,28 @@ namespace TerraFX.UI.Providers.Win32
             }
             ThrowExternalExceptionIfZero(hWnd, nameof(CreateWindowExW));
 
+            // Set the initial bounds so that resizing and relocating before showing work as expected
+
+            RECT rect;
+
+            ThrowExternalExceptionIfFalse(GetClientRect(hWnd, &rect), nameof(GetClientRect));
+
+            _clientBounds = new Rectangle(
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top
+            );
+
+            ThrowExternalExceptionIfFalse(AdjustWindowRectEx(&rect, _style, FALSE, _extendedStyle), nameof(AdjustWindowRectEx));
+
+            _bounds = new Rectangle(
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top
+            );
+
             return hWnd;
         }
 


### PR DESCRIPTION
This ensures resize and relocate can run successfully even before the first show and without computing the other at an incorrect location.