### PR TITLE
[IMPL] Sample.Timeout

### DIFF
--- a/samples/TerraFX/Audio/EnumerateAudioAdapters.cs
+++ b/samples/TerraFX/Audio/EnumerateAudioAdapters.cs
@@ -22,7 +22,7 @@ namespace TerraFX.Samples.Audio
             _provider = null;
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
             _provider = application.GetService<IAudioProvider>();
 
@@ -32,7 +32,7 @@ namespace TerraFX.Samples.Audio
                 task.AsTask().Wait();
             }
 
-            base.Initialize(application);
+            base.Initialize(application, timeout);
         }
 
         public override void Cleanup()

--- a/samples/TerraFX/Audio/PlaySampleAudio.cs
+++ b/samples/TerraFX/Audio/PlaySampleAudio.cs
@@ -30,7 +30,7 @@ namespace TerraFX.Samples.Audio
             _provider = null;
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
             _provider = application.GetService<IAudioProvider>();
 
@@ -40,7 +40,7 @@ namespace TerraFX.Samples.Audio
                 task.AsTask().Wait();
             }
 
-            base.Initialize(application);
+            base.Initialize(application, timeout);
         }
 
         public override void Cleanup()

--- a/samples/TerraFX/Graphics/HelloQuad.cs
+++ b/samples/TerraFX/Graphics/HelloQuad.cs
@@ -1,5 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
@@ -27,9 +28,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloSierpinski.cs
+++ b/samples/TerraFX/Graphics/HelloSierpinski.cs
@@ -37,9 +37,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloSmoke.cs
+++ b/samples/TerraFX/Graphics/HelloSmoke.cs
@@ -34,9 +34,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloTexture.cs
+++ b/samples/TerraFX/Graphics/HelloTexture.cs
@@ -1,5 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
@@ -25,9 +26,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloTexture3D.cs
+++ b/samples/TerraFX/Graphics/HelloTexture3D.cs
@@ -38,9 +38,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloTextureTransform.cs
+++ b/samples/TerraFX/Graphics/HelloTextureTransform.cs
@@ -35,9 +35,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloTransform.cs
+++ b/samples/TerraFX/Graphics/HelloTransform.cs
@@ -29,9 +29,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloTriangle.cs
+++ b/samples/TerraFX/Graphics/HelloTriangle.cs
@@ -1,5 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.Reflection;
 using TerraFX.ApplicationModel;
 using TerraFX.Graphics;
@@ -25,9 +26,9 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
-            base.Initialize(application);
+            base.Initialize(application, timeout);
 
             var graphicsDevice = GraphicsDevice;
             var currentGraphicsContext = graphicsDevice.CurrentContext;

--- a/samples/TerraFX/Graphics/HelloWindow.cs
+++ b/samples/TerraFX/Graphics/HelloWindow.cs
@@ -33,7 +33,7 @@ namespace TerraFX.Samples.Graphics
             base.Cleanup();
         }
 
-        public override void Initialize(Application application)
+        public override void Initialize(Application application, TimeSpan timeout)
         {
             ExceptionUtilities.ThrowIfNull(application, nameof(application));
 
@@ -48,7 +48,7 @@ namespace TerraFX.Samples.Graphics
 
             _graphicsDevice = graphicsAdapter.CreateDevice(_window, contextCount: 2);
 
-            base.Initialize(application);
+            base.Initialize(application, timeout);
         }
 
         protected virtual void Draw(GraphicsContext graphicsContext) { }
@@ -61,7 +61,7 @@ namespace TerraFX.Samples.Graphics
 
             _elapsedTime += eventArgs.Delta;
 
-            if (_elapsedTime.TotalSeconds >= 2.5)
+            if (_elapsedTime >= Timeout)
             {
                 var application = (Application)sender;
                 application.RequestExit();

--- a/samples/TerraFX/Program.cs
+++ b/samples/TerraFX/Program.cs
@@ -104,10 +104,10 @@ namespace TerraFX.Samples
             }
         }
 
-        private static void Run(Sample sample)
+        private static void Run(Sample sample, TimeSpan timeout)
         {
             using var application = new Application(sample.CompositionAssemblies);
-            sample.Initialize(application);
+            sample.Initialize(application, timeout);
 
             application.Run();
             sample.Cleanup();
@@ -119,26 +119,30 @@ namespace TerraFX.Samples
 
             if (args.Any((arg) => Matches(arg, "all")))
             {
-                foreach (var sample in s_samples)
+                var samples = s_samples;
+                foreach (var sample in samples)
                 {
                     if (IsSupported(sample))
                     {
-                        RunSample(sample);
+                        RunSample(sample, TimeSpan.FromSeconds(2.5));
                         ranAnySamples = true;
                     }
                 }
             }
-
+            else
+            {
+                var samples = s_samples;
             foreach (var arg in args)
             {
-                foreach (var sample in s_samples.Where((sample) => arg.Equals(sample.Name, StringComparison.OrdinalIgnoreCase)))
+                    foreach (var sample in samples.Where((sample) => arg.Equals(sample.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     if (IsSupported(sample))
                     {
-                        RunSample(sample);
+                            RunSample(sample, TimeSpan.MaxValue);
                         ranAnySamples = true;
                     }
                 }
+            }
             }
 
             if (ranAnySamples == false)
@@ -147,10 +151,10 @@ namespace TerraFX.Samples
             }
         }
 
-        private static void RunSample(Sample sample)
+        private static void RunSample(Sample sample, TimeSpan timeout)
         {
             Console.WriteLine($"Running: {sample.Name}");
-            var thread = new Thread(() => Run(sample));
+            var thread = new Thread(() => Run(sample, timeout));
 
             thread.Start();
             thread.Join();

--- a/samples/TerraFX/Shared/Sample.cs
+++ b/samples/TerraFX/Shared/Sample.cs
@@ -23,6 +23,7 @@ namespace TerraFX.Samples
         private readonly string _assemblyPath;
         private readonly string _name;
         private readonly Assembly[] _compositionAssemblies;
+        private TimeSpan _timeout;
 
         protected Sample(string name, Assembly[] compositionAssemblies)
         {
@@ -49,6 +50,8 @@ namespace TerraFX.Samples
 
         public string Name => _name;
 
+        public TimeSpan Timeout => _timeout;
+
         public virtual void Cleanup() { }
 
         public void Dispose()
@@ -57,7 +60,10 @@ namespace TerraFX.Samples
             GC.SuppressFinalize(this);
         }
 
-        public virtual void Initialize(Application application) => application.Idle += OnIdle;
+        public virtual void Initialize(Application application, TimeSpan timeout) {
+            _timeout = timeout;
+            application.Idle += OnIdle;
+        }
 
         protected unsafe GraphicsShader CompileShader(GraphicsDevice graphicsDevice, GraphicsShaderKind kind, string shaderName, string entryPointName)
         {


### PR DESCRIPTION
Sample.Initialize() should take a timeout as parameter, such that Program.cs can set it to 2.5s when all samples are run, and to TimeSpan.MaxValue when only one is run.