### PR TITLE
Adding a number of basic collection types.

### DIFF
--- a/sources/Core/Collections/UnmanagedValueList`1.DebugView.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.DebugView.cs
@@ -1,0 +1,41 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX.Collections
+{
+    public partial struct UnmanagedValueList<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly UnmanagedValueList<T> _list;
+
+            public DebugView(UnmanagedValueList<T> list)
+            {
+                _list = list;
+            }
+
+            public nuint Count => _list.Count;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public unsafe T[] Items
+            {
+                get
+                {
+                    var count = Max(_list.Count, s_maxArrayLength);
+                    var items = GC.AllocateUninitializedArray<T>((int)count);
+
+                    fixed (T* pItems = items)
+                    {
+                        var span = new UnmanagedSpan<T>(pItems, count);
+                        _list.CopyTo(span);
+                    }
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/UnmanagedValueList`1.DebugView.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.DebugView.cs
@@ -25,7 +25,7 @@ namespace TerraFX.Collections
             {
                 get
                 {
-                    var count = Max(_list.Count, s_maxArrayLength);
+                    var count = Min(_list.Count, s_maxArrayLength);
                     var items = GC.AllocateUninitializedArray<T>((int)count);
 
                     fixed (T* pItems = items)

--- a/sources/Core/Collections/UnmanagedValueList`1.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.cs
@@ -15,8 +15,8 @@ namespace TerraFX.Collections
     /// <summary>Represents a list of unmanaged items that can be accessed by index.</summary>
     /// <typeparam name="T">The type of the unmanaged items contained in the list.</typeparam>
     /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
-    [DebuggerDisplay("Count = {Count}")]
-    // [DebuggerTypeProxy(typeof(UnmanagedValueList<>.DebugView))]
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
+    [DebuggerTypeProxy(typeof(UnmanagedValueList<>.DebugView))]
     public partial struct UnmanagedValueList<T> : IDisposable
         where  T : unmanaged
     {

--- a/sources/Core/Collections/UnmanagedValueList`1.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.cs
@@ -1,0 +1,299 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the List<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+using static TerraFX.Utilities.MemoryUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a list of unmanaged items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the unmanaged items contained in the list.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Count = {Count}")]
+    // [DebuggerTypeProxy(typeof(UnmanagedValueList<>.DebugView))]
+    public partial struct UnmanagedValueList<T> : IDisposable
+        where  T : unmanaged
+    {
+        private UnmanagedArray<T> _items;
+        private nuint _count;
+        private nuint _version;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueList{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the list.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the list or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public UnmanagedValueList(nuint capacity, nuint alignment = 0)
+        {
+            if (capacity != 0)
+            {
+                _items = new UnmanagedArray<T>(capacity, alignment, zero: false);
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueList{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the list.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the list or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public unsafe UnmanagedValueList(UnmanagedReadOnlySpan<T> span, nuint alignment = 0)
+        {
+            if (span.Length != 0)
+            {
+                var items = new UnmanagedArray<T>(span.Length, alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), span.GetPointerUnsafe(0), span.Length);
+                _items = items;
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = span.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueList{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the list.</param>
+        /// <param name="takeOwnership"><c>true</c> if the list should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public unsafe UnmanagedValueList(UnmanagedArray<T> array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = new UnmanagedArray<T>(array.Length, array.Alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), array.GetPointerUnsafe(0), array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the list without being resized.</summary>
+        public readonly nuint Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (!items.IsNull)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the list.</summary>
+        public readonly nuint Count => _count;
+
+        /// <summary>Gets or sets the item at the specified index in the list.</summary>
+        /// <param name="index">The index of the item to get or set.</param>
+        /// <returns>The item that exists at <paramref name="index" /> in the list.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Count" />.</exception>
+        public T this[nuint index]
+        {
+            readonly get
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                return _items[index];
+            }
+
+            set
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                _version++;
+
+                _items[index] = value;
+            }
+        }
+
+        /// <summary>Adds an item to the list.</summary>
+        /// <param name="item">The item to add to the list.</param>
+        public void Add(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount < Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            _count = newCount;
+            _items[count] = item;
+        }
+
+        /// <summary>Removes all items from the list.</summary>
+        public void Clear()
+        {
+            _version++;
+            _count = 0;
+        }
+
+        /// <summary>Checks whether the list contains a specified item.</summary>
+        /// <param name="item">The item to check for in the list.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the list; otherwise, <c>false</c>.</returns>
+        public readonly bool Contains(T item) => TryGetIndexOf(item, out _);
+
+        /// <summary>Copies the items of the list to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly unsafe void CopyTo(UnmanagedSpan<T> destination)
+        {
+            var count = Count;
+
+            if (count != 0)
+            {
+                ThrowIfNotInInsertBounds(count, destination.Length, nameof(Count), nameof(destination));
+                CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), _items.GetPointerUnsafe(0), count);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => _items.Dispose();
+
+        /// <summary>Ensures the capacity of the list is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the list should support.</param>
+        public unsafe void EnsureCapacity(nuint capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var items = _items;
+
+                var newCapacity = Max(capacity, currentCapacity * 2);
+                var alignment = !items.IsNull ? items.Alignment : 0;
+
+                var newItems = new UnmanagedArray<T>(newCapacity, alignment, zero: false);
+
+                if (!items.IsNull)
+                {
+                    CopyArrayUnsafe<T>(newItems.GetPointerUnsafe(0), items.GetPointer(0), Count);
+                    items.Dispose();
+                }
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
+        /// <summary>Inserts an item into list at the specified index.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="item" /> is inserted.</param>
+        /// <param name="item">The item to insert into the list.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is negative or greater than <see cref="Count" />.</exception>
+        public void Insert(nuint index, T item)
+        {
+            var count = Count;
+            ThrowIfNotInInsertBounds(index, count, nameof(index), nameof(Count));
+
+            if (index != count)
+            {
+                _version++;
+            }
+            else
+            {
+                var newCount = count + 1;
+                EnsureCapacity(newCount);
+                _count = newCount;
+            }
+
+            _items[index] = item;
+        }
+
+        /// <summary>Removes the first occurence of an item from the list.</summary>
+        /// <param name="item">The item to remove from the list.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was removed from the list; otherwise, <c>false</c>.</returns>
+        public bool Remove(T item)
+        {
+            if (TryGetIndexOf(item, out var index))
+            {
+                RemoveAt(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Removes the item at the specified index from the list.</summary>
+        /// <param name="index">The zero-based index of the item to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.</exception>
+        public unsafe void RemoveAt(nuint index)
+        {
+            var count = Count;
+            ThrowIfNotInBounds(index, count, nameof(index), nameof(Count));
+
+            var newCount = count - 1;
+            var items = _items;
+
+            _version++;
+
+            if (index < newCount)
+            {
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(index), items.GetPointerUnsafe(index + 1), newCount - index);
+            }
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                items[newCount] = default!;
+            }
+
+            _count = newCount;
+        }
+
+        /// <summary>Tries to get the index of a given item in the list.</summary>
+        /// <param name="item">The item for which to get its index..</param>
+        /// <param name="index">When <c>true</c> is returned, this contains the index of <paramref name="item" />.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the list; otherwise, <c>false</c>.</returns>
+        public readonly unsafe bool TryGetIndexOf(T item, out nuint index)
+        {
+            var items = _items;
+
+            if (!items.IsNull)
+            {
+                return TryGetIndexOfUnsafe(items.GetPointerUnsafe(0), Count, item, out index);
+            }
+            else
+            {
+                index = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/UnmanagedValueList`1.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.cs
@@ -144,7 +144,7 @@ namespace TerraFX.Collections
             var count = Count;
             var newCount = count + 1;
 
-            if (newCount < Capacity)
+            if (newCount <= Capacity)
             {
                 _version++;
             }
@@ -201,11 +201,8 @@ namespace TerraFX.Collections
 
                 var newItems = new UnmanagedArray<T>(newCapacity, alignment, zero: false);
 
-                if (!items.IsNull)
-                {
-                    CopyArrayUnsafe<T>(newItems.GetPointerUnsafe(0), items.GetPointer(0), Count);
-                    items.Dispose();
-                }
+                CopyTo(newItems);
+                items.Dispose();
 
                 _version++;
                 _items = newItems;

--- a/sources/Core/Collections/UnmanagedValueList`1.cs
+++ b/sources/Core/Collections/UnmanagedValueList`1.cs
@@ -274,6 +274,29 @@ namespace TerraFX.Collections
             _count = newCount;
         }
 
+        /// <summary>Trims any excess capacity, up to a given threshold, from the list.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (nuint)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var items = _items;
+
+                var alignment = !items.IsNull ? items.Alignment : 0;
+                var newItems = new UnmanagedArray<T>(count, alignment, zero: false);
+
+                CopyTo(newItems);
+                items.Dispose();
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
         /// <summary>Tries to get the index of a given item in the list.</summary>
         /// <param name="item">The item for which to get its index..</param>
         /// <param name="index">When <c>true</c> is returned, this contains the index of <paramref name="item" />.</param>

--- a/sources/Core/Collections/UnmanagedValueQueue`1.DebugView.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.DebugView.cs
@@ -1,0 +1,41 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX.Collections
+{
+    public partial struct UnmanagedValueQueue<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly UnmanagedValueQueue<T> _list;
+
+            public DebugView(UnmanagedValueQueue<T> list)
+            {
+                _list = list;
+            }
+
+            public nuint Count => _list.Count;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public unsafe T[] Items
+            {
+                get
+                {
+                    var count = Max(_list.Count, s_maxArrayLength);
+                    var items = GC.AllocateUninitializedArray<T>((int)count);
+
+                    fixed (T* pItems = items)
+                    {
+                        var span = new UnmanagedSpan<T>(pItems, count);
+                        _list.CopyTo(span);
+                    }
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/UnmanagedValueQueue`1.DebugView.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.DebugView.cs
@@ -11,27 +11,27 @@ namespace TerraFX.Collections
     {
         internal sealed class DebugView
         {
-            private readonly UnmanagedValueQueue<T> _list;
+            private readonly UnmanagedValueQueue<T> _queue;
 
-            public DebugView(UnmanagedValueQueue<T> list)
+            public DebugView(UnmanagedValueQueue<T> queue)
             {
-                _list = list;
+                _queue = queue;
             }
 
-            public nuint Count => _list.Count;
+            public nuint Count => _queue.Count;
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
             public unsafe T[] Items
             {
                 get
                 {
-                    var count = Max(_list.Count, s_maxArrayLength);
+                    var count = Min(_queue.Count, s_maxArrayLength);
                     var items = GC.AllocateUninitializedArray<T>((int)count);
 
                     fixed (T* pItems = items)
                     {
                         var span = new UnmanagedSpan<T>(pItems, count);
-                        _list.CopyTo(span);
+                        _queue.CopyTo(span);
                     }
                     return items;
                 }

--- a/sources/Core/Collections/UnmanagedValueQueue`1.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.cs
@@ -285,6 +285,32 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Trims any excess capacity, up to a given threshold, from the queue.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (nuint)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var items = _items;
+
+                var alignment = !items.IsNull ? items.Alignment : 0;
+                var newItems = new UnmanagedArray<T>(count, alignment, zero: false);
+
+                CopyTo(newItems);
+                items.Dispose();
+
+                _version++;
+                _items = newItems;
+
+                _head = 0;
+                _tail = count;
+            }
+        }
+
         /// <summary>Tries to dequeue an item from the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>

--- a/sources/Core/Collections/UnmanagedValueQueue`1.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.cs
@@ -1,0 +1,330 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the List<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+using static TerraFX.Utilities.MemoryUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a queue of unmanaged items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the unmanaged items contained in the queue.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
+    [DebuggerTypeProxy(typeof(UnmanagedValueQueue<>.DebugView))]
+    public partial struct UnmanagedValueQueue<T> : IDisposable
+        where  T : unmanaged
+    {
+        private UnmanagedArray<T> _items;
+        private nuint _count;
+        private nuint _head;
+        private nuint _tail;
+        private nuint _version;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueQueue{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the queue.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the queue or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public UnmanagedValueQueue(nuint capacity, nuint alignment = 0)
+        {
+            if (capacity != 0)
+            {
+                _items = new UnmanagedArray<T>(capacity, alignment, zero: false);
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = 0;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueQueue{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the queue.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the queue or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public unsafe UnmanagedValueQueue(UnmanagedReadOnlySpan<T> span, nuint alignment = 0)
+        {
+            if (span.Length != 0)
+            {
+                var items = new UnmanagedArray<T>(span.Length, alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), span.GetPointerUnsafe(0), span.Length);
+                _items = items;
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = span.Length;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueQueue{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the queue.</param>
+        /// <param name="takeOwnership"><c>true</c> if the queue should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public unsafe UnmanagedValueQueue(UnmanagedArray<T> array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = new UnmanagedArray<T>(array.Length, array.Alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), array.GetPointerUnsafe(0), array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the queue without being resized.</summary>
+        public readonly nuint Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (!items.IsNull)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the queue.</summary>
+        public readonly nuint Count => _count;
+
+        /// <summary>Removes all items from the queue.</summary>
+        public void Clear()
+        {
+            _version++;
+            _count = 0;
+
+            _head = 0;
+            _tail = 0;
+        }
+
+        /// <summary>Checks whether the queue contains a specified item.</summary>
+        /// <param name="item">The item to check for in the queue.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the queue; otherwise, <c>false</c>.</returns>
+        public readonly unsafe bool Contains(T item)
+        {
+            var items = _items;
+
+            if (!items.IsNull)
+            {
+                var head = _head;
+                var tail = _tail;
+
+                if ((head < tail) || (tail == 0))
+                {
+                    return TryGetIndexOfUnsafe(items.GetPointerUnsafe(head), Count, item, out _);
+                }
+                else
+                {
+                    return TryGetIndexOfUnsafe(items.GetPointerUnsafe(head), Count - head, item, out _)
+                        || TryGetIndexOfUnsafe(items.GetPointerUnsafe(0), tail, item, out _);
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Copies the items of the queue to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly unsafe void CopyTo(UnmanagedSpan<T> destination)
+        {
+            var count = Count;
+
+            if (count != 0)
+            {
+                ThrowIfNotInInsertBounds(count, destination.Length, nameof(Count), nameof(destination));
+
+                var head = _head;
+                var tail = _tail;
+
+                if ((head < tail) || (tail == 0))
+                {
+                    CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), _items.GetPointerUnsafe(head), count);
+                }
+                else
+                {
+                    var headLength = count - head;
+                    CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), _items.GetPointerUnsafe(head), headLength);
+                    CopyArrayUnsafe<T>(destination.GetPointerUnsafe(headLength), _items.GetPointerUnsafe(0), tail);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => _items.Dispose();
+
+        /// <summary>Dequeues the item from the head of the queue.</summary>
+        /// <returns>The item at the head of the queue.</returns>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        public T Dequeue()
+        {
+            if (!TryDequeue(out var item))
+            {
+                ThrowForEmptyQueue();
+            }
+            return item;
+        }
+
+        /// <summary>Enqueues an item to the tail of the queue.</summary>
+        /// <param name="item">The item to enqueue to the tail of the queue.</param>
+        public void Enqueue(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount <= Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            var tail = _tail;
+            var newTail = tail + 1;
+
+            _count = newCount;
+            _items[tail] = item;
+
+            if (newTail == Capacity)
+            {
+                newTail = 0;
+            }
+            _tail = newTail;
+        }
+
+        /// <summary>Ensures the capacity of the queue is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the queue should support.</param>
+        public unsafe void EnsureCapacity(nuint capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var items = _items;
+
+                var newCapacity = Max(capacity, currentCapacity * 2);
+                var alignment = !items.IsNull ? items.Alignment : 0;
+
+                var newItems = new UnmanagedArray<T>(newCapacity, alignment, zero: false);
+
+                CopyTo(newItems);
+                items.Dispose();
+
+                _version++;
+                _items = newItems;
+
+                _head = 0;
+                _tail = Count;
+            }
+        }
+
+        /// <summary>Peeks the item at the head of the queue.</summary>
+        /// <returns>The item at the head of the queue.</returns>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        public readonly T Peek()
+        {
+            if (!TryPeek(out var item))
+            {
+                ThrowForEmptyQueue();
+            }
+            return item;
+        }
+
+        /// <summary>Tries to dequeue an item from the head of the queue.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
+        public bool TryDequeue([MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+            var newCount = unchecked(count - 1);
+
+            if (count == 0)
+            {
+                item = default!;
+                return false;
+            }
+
+            _version++;
+
+            var head = _head;
+            var newHead = head + 1;
+
+            _count = newCount;
+
+            if (newHead == Capacity)
+            {
+                newHead = 0;
+            }
+            _head = newHead;
+
+            var items = _items;
+            item = items[head];
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                items[head] = default!;
+            }
+
+            return true;
+        }
+
+        /// <summary>Tries to peek the item at the head of the queue.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek([MaybeNullWhen(false)] out T item)
+        {
+            if (Count != 0)
+            {
+                item = _items[_head];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/UnmanagedValueQueue`1.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.cs
@@ -1,11 +1,10 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// This file includes code based on the List<T> class from https://github.com/dotnet/runtime/
+// This file includes code based on the Queue<T> class from https://github.com/dotnet/runtime/
 // The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.MathUtilities;
@@ -260,7 +259,7 @@ namespace TerraFX.Collections
             }
         }
 
-        /// <summary>Peeks the item at the head of the queue.</summary>
+        /// <summary>Peeks at item at the head of the queue.</summary>
         /// <returns>The item at the head of the queue.</returns>
         /// <exception cref="InvalidOperationException">The queue is empty.</exception>
         public readonly T Peek()
@@ -275,7 +274,7 @@ namespace TerraFX.Collections
         /// <summary>Tries to dequeue an item from the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
-        public bool TryDequeue([MaybeNullWhen(false)] out T item)
+        public bool TryDequeue(out T item)
         {
             var count = Count;
             var newCount = unchecked(count - 1);
@@ -302,18 +301,13 @@ namespace TerraFX.Collections
             var items = _items;
             item = items[head];
 
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                items[head] = default!;
-            }
-
             return true;
         }
 
-        /// <summary>Tries to peek the item at the head of the queue.</summary>
+        /// <summary>Tries to peek at the item at the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
-        public readonly bool TryPeek([MaybeNullWhen(false)] out T item)
+        public readonly bool TryPeek(out T item)
         {
             if (Count != 0)
             {

--- a/sources/Core/Collections/UnmanagedValueQueue`1.cs
+++ b/sources/Core/Collections/UnmanagedValueQueue`1.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.MathUtilities;
 using static TerraFX.Utilities.MemoryUtilities;
@@ -271,6 +271,20 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Peeks at item at the specified index of the queue.</summary>
+        /// <param name="index">The index from the head of the queue of the item at which to peek.</param>
+        /// <returns>The item at the specified index of the queue.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Count" />.</exception>
+        public readonly T Peek(nuint index)
+        {
+            if (!TryPeek(index, out var item))
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                Fail();
+            }
+            return item;
+        }
+
         /// <summary>Tries to dequeue an item from the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
@@ -312,6 +326,35 @@ namespace TerraFX.Collections
             if (Count != 0)
             {
                 item = _items[_head];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to peek at the item at the head of the queue.</summary>
+        /// <param name="index">The index from the head of the queue of the item at which to peek.</param>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty and <paramref name="index" /> is less than <see cref="Count" />; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek(nuint index, out T item)
+        {
+            var count = Count;
+
+            if (index < count)
+            {
+                var head = _head;
+
+                if ((head < _tail) || (index < (count - head)))
+                {
+                    item = _items[head + index];
+                }
+                else
+                {
+                    item = _items[index];
+                }
                 return true;
             }
             else

--- a/sources/Core/Collections/UnmanagedValueStack`1.DebugView.cs
+++ b/sources/Core/Collections/UnmanagedValueStack`1.DebugView.cs
@@ -5,35 +5,33 @@ using System.Diagnostics;
 using static TerraFX.Runtime.Configuration;
 using static TerraFX.Utilities.MathUtilities;
 
-namespace TerraFX
+namespace TerraFX.Collections
 {
-    public readonly partial struct UnmanagedSpan<T>
+    public partial struct UnmanagedValueStack<T>
     {
         internal sealed class DebugView
         {
-            private readonly UnmanagedSpan<T> _span;
+            private readonly UnmanagedValueStack<T> _stack;
 
-            public DebugView(UnmanagedSpan<T> span)
+            public DebugView(UnmanagedValueStack<T> stack)
             {
-                _span = span;
+                _stack = stack;
             }
 
-            public bool IsEmpty => _span.IsEmpty;
-
-            public nuint Length => _span.Length;
+            public nuint Count => _stack.Count;
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
             public unsafe T[] Items
             {
                 get
                 {
-                    var count = Min(_span.Length, s_maxArrayLength);
+                    var count = Min(_stack.Count, s_maxArrayLength);
                     var items = GC.AllocateUninitializedArray<T>((int)count);
 
                     fixed (T* pItems = items)
                     {
                         var span = new UnmanagedSpan<T>(pItems, count);
-                        _span.CopyTo(span);
+                        _stack.CopyTo(span);
                     }
                     return items;
                 }

--- a/sources/Core/Collections/UnmanagedValueStack`1.cs
+++ b/sources/Core/Collections/UnmanagedValueStack`1.cs
@@ -1,0 +1,269 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the Stack<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+using static TerraFX.Utilities.MemoryUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a stack of unmanaged items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the unmanaged items contained in the stack.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
+    [DebuggerTypeProxy(typeof(UnmanagedValueStack<>.DebugView))]
+    public partial struct UnmanagedValueStack<T> : IDisposable
+        where  T : unmanaged
+    {
+        private UnmanagedArray<T> _items;
+        private nuint _count;
+        private nuint _version;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueStack{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the stack.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the stack or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public UnmanagedValueStack(nuint capacity, nuint alignment = 0)
+        {
+            if (capacity != 0)
+            {
+                _items = new UnmanagedArray<T>(capacity, alignment, zero: false);
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueStack{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the stack.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the stack or <c>zero</c> to use the system default.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not a <c>power of two</c>.</exception>
+        public unsafe UnmanagedValueStack(UnmanagedReadOnlySpan<T> span, nuint alignment = 0)
+        {
+            if (span.Length != 0)
+            {
+                var items = new UnmanagedArray<T>(span.Length, alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), span.GetPointerUnsafe(0), span.Length);
+                _items = items;
+            }
+            else
+            {
+                if (alignment != 0)
+                {
+                    ThrowIfNotPow2(alignment, nameof(alignment));
+                }
+                _items = UnmanagedArray<T>.Empty;
+            }
+
+            _count = span.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedValueStack{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the stack.</param>
+        /// <param name="takeOwnership"><c>true</c> if the stack should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public unsafe UnmanagedValueStack(UnmanagedArray<T> array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = new UnmanagedArray<T>(array.Length, array.Alignment, zero: false);
+                CopyArrayUnsafe<T>(items.GetPointerUnsafe(0), array.GetPointerUnsafe(0), array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the stack without being resized.</summary>
+        public readonly nuint Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (!items.IsNull)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the stack.</summary>
+        public readonly nuint Count => _count;
+
+        /// <summary>Removes all items from the stack.</summary>
+        public void Clear()
+        {
+            _version++;
+            _count = 0;
+        }
+
+        /// <summary>Checks whether the stack contains a specified item.</summary>
+        /// <param name="item">The item to check for in the stack.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the stack; otherwise, <c>false</c>.</returns>
+        public readonly unsafe bool Contains(T item)
+        {
+            var items = _items;
+
+            if (!items.IsNull)
+            {
+                return TryGetLastIndexOfUnsafe(items.GetPointerUnsafe(0), Count, item, out _);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Copies the items of the stack to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly unsafe void CopyTo(UnmanagedSpan<T> destination)
+        {
+            var count = Count;
+
+            if (count != 0)
+            {
+                ThrowIfNotInInsertBounds(count, destination.Length, nameof(Count), nameof(destination));
+                CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), _items.GetPointerUnsafe(0), count);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => _items.Dispose();
+
+        /// <summary>Ensures the capacity of the stack is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the stack should support.</param>
+        public unsafe void EnsureCapacity(nuint capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var items = _items;
+
+                var newCapacity = Max(capacity, currentCapacity * 2);
+                var alignment = !items.IsNull ? items.Alignment : 0;
+
+                var newItems = new UnmanagedArray<T>(newCapacity, alignment, zero: false);
+
+                CopyTo(newItems);
+                items.Dispose();
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
+        /// <summary>Peeks at the item at the top of the stack.</summary>
+        /// <returns>The item at the top of the stack.</returns>
+        /// <exception cref="InvalidOperationException">The stack is empty.</exception>
+        public readonly T Peek()
+        {
+            if (!TryPeek(out var item))
+            {
+                ThrowForEmptyStack();
+            }
+            return item;
+        }
+
+        /// <summary>Pops the item from the top of the stack.</summary>
+        /// <returns>The item at the top of the stack.</returns>
+        /// <exception cref="InvalidOperationException">The stack is empty.</exception>
+        public T Pop()
+        {
+            if (!TryPop(out var item))
+            {
+                ThrowForEmptyStack();
+            }
+            return item;
+        }
+
+        /// <summary>Pushes an item to the top of the stack.</summary>
+        /// <param name="item">The item to push to the top of the stack.</param>
+        public void Push(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount <= Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            _count = newCount;
+            _items[count] = item;
+        }
+
+        /// <summary>Tries to peek the item at the head of the stack.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek(out T item)
+        {
+            var count = Count;
+
+            if (count != 0)
+            {
+                item = _items[count - 1];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to pop an item from the top of the stack.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item from the top of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>
+        public bool TryPop(out T item)
+        {
+            var count = Count;
+            var newCount = unchecked(count - 1);
+
+            if (count == 0)
+            {
+                item = default!;
+                return false;
+            }
+
+            _version++;
+            _count = newCount;
+
+            var items = _items;
+            item = items[newCount];
+
+            return true;
+        }
+    }
+}

--- a/sources/Core/Collections/UnmanagedValueStack`1.cs
+++ b/sources/Core/Collections/UnmanagedValueStack`1.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.MathUtilities;
 using static TerraFX.Utilities.MemoryUtilities;
@@ -192,6 +192,20 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Peeks at item at the specified index of the stack.</summary>
+        /// <param name="index">The index from the top of the stack of the item at which to peek.</param>
+        /// <returns>The item at the specified index of the stack.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Count" />.</exception>
+        public readonly T Peek(nuint index)
+        {
+            if (!TryPeek(index, out var item))
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                Fail();
+            }
+            return item;
+        }
+
         /// <summary>Pops the item from the top of the stack.</summary>
         /// <returns>The item at the top of the stack.</returns>
         /// <exception cref="InvalidOperationException">The stack is empty.</exception>
@@ -234,6 +248,26 @@ namespace TerraFX.Collections
             if (count != 0)
             {
                 item = _items[count - 1];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to peek the item at the head of the stack.</summary>
+        /// <param name="index">The index from the top of the stack of the item at which to peek.</param>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty and <paramref name="index" /> is less than <see cref="Count" />; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek(nuint index, out T item)
+        {
+            var count = Count;
+
+            if (index < count)
+            {
+                item = _items[count - (index + 1)];
                 return true;
             }
             else

--- a/sources/Core/Collections/UnmanagedValueStack`1.cs
+++ b/sources/Core/Collections/UnmanagedValueStack`1.cs
@@ -238,6 +238,29 @@ namespace TerraFX.Collections
             _items[count] = item;
         }
 
+        /// <summary>Trims any excess capacity, up to a given threshold, from the stack.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (nuint)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var items = _items;
+
+                var alignment = !items.IsNull ? items.Alignment : 0;
+                var newItems = new UnmanagedArray<T>(count, alignment, zero: false);
+
+                CopyTo(newItems);
+                items.Dispose();
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
         /// <summary>Tries to peek the item at the head of the stack.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the stack.</param>
         /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>

--- a/sources/Core/Collections/ValueList`1.DebugView.cs
+++ b/sources/Core/Collections/ValueList`1.DebugView.cs
@@ -3,6 +3,7 @@
 // This file includes code based on the ICollectionDebugView<T> class from https://github.com/dotnet/runtime/
 // The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
 
+using System;
 using System.Diagnostics;
 
 namespace TerraFX.Collections
@@ -18,12 +19,16 @@ namespace TerraFX.Collections
                 _list = list;
             }
 
+            public int Capacity => _list.Capacity;
+
+            public int Count => _list.Count;
+
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
             public T[] Items
             {
                 get
                 {
-                    var items = new T[_list.Count];
+                    var items = GC.AllocateUninitializedArray<T>(_list.Count);
                     _list.CopyTo(items);
                     return items;
                 }

--- a/sources/Core/Collections/ValueList`1.DebugView.cs
+++ b/sources/Core/Collections/ValueList`1.DebugView.cs
@@ -1,0 +1,33 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the ICollectionDebugView<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System.Diagnostics;
+
+namespace TerraFX.Collections
+{
+    public partial struct ValueList<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly ValueList<T> _list;
+
+            public DebugView(ValueList<T> list)
+            {
+                _list = list;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public T[] Items
+            {
+                get
+                {
+                    var items = new T[_list.Count];
+                    _list.CopyTo(items);
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/ValueList`1.cs
+++ b/sources/Core/Collections/ValueList`1.cs
@@ -147,7 +147,7 @@ namespace TerraFX.Collections
             var count = Count;
             var newCount = count + 1;
 
-            if (newCount < Capacity)
+            if (newCount <= Capacity)
             {
                 _version++;
             }
@@ -193,14 +193,9 @@ namespace TerraFX.Collections
             if (capacity > currentCapacity)
             {
                 var newCapacity = Max(capacity, currentCapacity * 2);
-
                 var newItems = GC.AllocateUninitializedArray<T>(newCapacity);
-                var items = _items;
 
-                if (items is not null)
-                {
-                    Array.Copy(items, newItems, currentCapacity);
-                }
+                CopyTo(newItems);
 
                 _version++;
                 _items = newItems;

--- a/sources/Core/Collections/ValueList`1.cs
+++ b/sources/Core/Collections/ValueList`1.cs
@@ -285,5 +285,23 @@ namespace TerraFX.Collections
 
             _count = newCount;
         }
+
+        /// <summary>Trims any excess capacity, up to a given threshold, from the list.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (int)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var newItems = GC.AllocateUninitializedArray<T>(count);
+                CopyTo(newItems);
+
+                _version++;
+                _items = newItems;
+            }
+        }
     }
 }

--- a/sources/Core/Collections/ValueList`1.cs
+++ b/sources/Core/Collections/ValueList`1.cs
@@ -16,7 +16,7 @@ namespace TerraFX.Collections
     /// <summary>Represents a list of items that can be accessed by index.</summary>
     /// <typeparam name="T">The type of the items contained in the list.</typeparam>
     /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
-    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
     [DebuggerTypeProxy(typeof(ValueList<>.DebugView))]
     public partial struct ValueList<T>
     {

--- a/sources/Core/Collections/ValueList`1.cs
+++ b/sources/Core/Collections/ValueList`1.cs
@@ -1,0 +1,294 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the List<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a list of items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the items contained in the list.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(ValueList<>.DebugView))]
+    public partial struct ValueList<T>
+    {
+        private T[] _items;
+        private int _count;
+        private int _version;
+
+        /// <summary>Initializes a new instance of the <see cref="ValueList{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the list.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is <c>negative</c>.</exception>
+        public ValueList(int capacity)
+        {
+            ThrowIfNegative(capacity, nameof(capacity));
+
+            if (capacity != 0)
+            {
+                _items = GC.AllocateUninitializedArray<T>(capacity);
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueList{T}" /> struct.</summary>
+        /// <param name="source">The enumerable that is used to populate the list.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c>.</exception>
+        public ValueList(IEnumerable<T> source)
+        {
+            // This is an extension method and throws ArgumentNullException if null
+            _items = source.ToArray();
+
+            _count = _items.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueList{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the list.</param>
+        public ValueList(ReadOnlySpan<T> span)
+        {
+            if (span.Length != 0)
+            {
+                var items = GC.AllocateUninitializedArray<T>(span.Length);
+                span.CopyTo(items);
+                _items = items;
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = span.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueList{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the list.</param>
+        /// <param name="takeOwnership"><c>true</c> if the list should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public ValueList(T[] array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = GC.AllocateUninitializedArray<T>(array.Length);
+                Array.Copy(array, items, array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the list without being resized.</summary>
+        public readonly int Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (items is not null)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the list.</summary>
+        public readonly int Count => _count;
+
+        /// <summary>Gets or sets the item at the specified index in the list.</summary>
+        /// <param name="index">The index of the item to get or set.</param>
+        /// <returns>The item that exists at <paramref name="index" /> in the list.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.</exception>
+        public T this[int index]
+        {
+            readonly get
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                return _items[index];
+            }
+
+            set
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                _version++;
+
+                _items[index] = value;
+            }
+        }
+
+        /// <summary>Adds an item to the list.</summary>
+        /// <param name="item">The item to add to the list.</param>
+        public void Add(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount < Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            _count = newCount;
+            _items[count] = item;
+        }
+
+        /// <summary>Removes all items from the list.</summary>
+        public void Clear()
+        {
+            _version++;
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Array.Clear(_items, 0, Count);
+            }
+
+            _count = 0;
+        }
+
+        /// <summary>Checks whether the list contains a specified item.</summary>
+        /// <param name="item">The item to check for in the list.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the list; otherwise, <c>false</c>.</returns>
+        public readonly bool Contains(T item) => IndexOf(item) != -1;
+
+        /// <summary>Copies the items of the list to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly void CopyTo(Span<T> destination) => _items.AsSpan(0, Count).CopyTo(destination);
+
+        /// <summary>Ensures the capacity of the list is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the list should support.</param>
+        /// <remarks>This method does not throw if <paramref name="capacity" /> is negative and is instead does nothing.</remarks>
+        public void EnsureCapacity(int capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var newCapacity = Max(capacity, currentCapacity * 2);
+
+                var newItems = GC.AllocateUninitializedArray<T>(newCapacity);
+                var items = _items;
+
+                if (items is not null)
+                {
+                    Array.Copy(items, newItems, currentCapacity);
+                }
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
+        /// <summary>Gets the index of the first occurence of an item in the list.</summary>
+        /// <param name="item">The item to find in the list.</param>
+        /// <returns>The index of <paramref name="item" /> if it was found in the list; otherwise, <c>-1</c>.</returns>
+        public readonly int IndexOf(T item)
+        {
+            var items = _items;
+
+            if (items is not null)
+            {
+                return Array.IndexOf(items, item, 0, Count);
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>Inserts an item into list at the specified index.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="item" /> is inserted.</param>
+        /// <param name="item">The item to insert into the list.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is negative or greater than <see cref="Count" />.</exception>
+        public void Insert(int index, T item)
+        {
+            var count = Count;
+            ThrowIfNotInInsertBounds(index, count, nameof(index), nameof(Count));
+
+            if (index != count)
+            {
+                _version++;
+            }
+            else
+            {
+                var newCount = count + 1;
+                EnsureCapacity(newCount);
+                _count = newCount;
+            }
+
+            _items[index] = item;
+        }
+
+        /// <summary>Removes the first occurence of an item from the list.</summary>
+        /// <param name="item">The item to remove from the list.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was removed from the list; otherwise, <c>false</c>.</returns>
+        public bool Remove(T item)
+        {
+            var index = IndexOf(item);
+
+            if (index >= 0)
+            {
+                RemoveAt(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Removes the item at the specified index from the list.</summary>
+        /// <param name="index">The zero-based index of the item to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.</exception>
+        public void RemoveAt(int index)
+        {
+            var count = Count;
+            ThrowIfNotInBounds(index, count, nameof(index), nameof(Count));
+
+            var newCount = count - 1;
+            var items = _items;
+
+            _version++;
+
+            if (index < newCount)
+            {
+                Array.Copy(items, index + 1, items, index, newCount - index);
+            }
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                items[newCount] = default!;
+            }
+
+            _count = newCount;
+        }
+    }
+}

--- a/sources/Core/Collections/ValueQueue`1.DebugView.cs
+++ b/sources/Core/Collections/ValueQueue`1.DebugView.cs
@@ -1,0 +1,38 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the ICollectionDebugView<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Diagnostics;
+
+namespace TerraFX.Collections
+{
+    public partial struct ValueQueue<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly ValueQueue<T> _queue;
+
+            public DebugView(ValueQueue<T> queue)
+            {
+                _queue = queue;
+            }
+
+            public int Capacity => _queue.Capacity;
+
+            public int Count => _queue.Count;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public T[] Items
+            {
+                get
+                {
+                    var items = GC.AllocateUninitializedArray<T>(_queue.Count);
+                    _queue.CopyTo(items);
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/ValueQueue`1.cs
+++ b/sources/Core/Collections/ValueQueue`1.cs
@@ -297,6 +297,27 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Trims any excess capacity, up to a given threshold, from the queue.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (int)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var newItems = GC.AllocateUninitializedArray<T>(count);
+                CopyTo(newItems);
+
+                _version++;
+                _items = newItems;
+
+                _head = 0;
+                _tail = count;
+            }
+        }
+
         /// <summary>Tries to dequeue an item from the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>

--- a/sources/Core/Collections/ValueQueue`1.cs
+++ b/sources/Core/Collections/ValueQueue`1.cs
@@ -1,0 +1,340 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the Queue<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a queue of items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the items contained in the queue.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
+    [DebuggerTypeProxy(typeof(ValueQueue<>.DebugView))]
+    public partial struct ValueQueue<T>
+    {
+        private T[] _items;
+        private int _count;
+        private int _head;
+        private int _tail;
+        private int _version;
+
+        /// <summary>Initializes a new instance of the <see cref="ValueQueue{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the queue.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is <c>negative</c>.</exception>
+        public ValueQueue(int capacity)
+        {
+            ThrowIfNegative(capacity, nameof(capacity));
+
+            if (capacity != 0)
+            {
+                _items = GC.AllocateUninitializedArray<T>(capacity);
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = 0;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueQueue{T}" /> struct.</summary>
+        /// <param name="source">The enumerable that is used to populate the queue.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c>.</exception>
+        public ValueQueue(IEnumerable<T> source)
+        {
+            // This is an extension method and throws ArgumentNullException if null
+            _items = source.ToArray();
+
+            _count = _items.Length;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueQueue{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the queue.</param>
+        public ValueQueue(ReadOnlySpan<T> span)
+        {
+            if (span.Length != 0)
+            {
+                var items = GC.AllocateUninitializedArray<T>(span.Length);
+                span.CopyTo(items);
+                _items = items;
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = span.Length;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueQueue{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the queue.</param>
+        /// <param name="takeOwnership"><c>true</c> if the queue should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public ValueQueue(T[] array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = GC.AllocateUninitializedArray<T>(array.Length);
+                Array.Copy(array, items, array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _head = 0;
+            _tail = 0;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the queue without being resized.</summary>
+        public readonly int Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (items is not null)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the queue.</summary>
+        public readonly int Count => _count;
+
+        /// <summary>Removes all items from the queue.</summary>
+        public void Clear()
+        {
+            _version++;
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                var head = _head;
+                var tail = _tail;
+
+                if ((head < tail) || (tail == 0))
+                {
+                    Array.Clear(_items, head, Count);
+                }
+                else
+                {
+                    Array.Clear(_items, head, Count - head);
+                    Array.Clear(_items, 0, tail);
+                }
+            }
+
+            _count = 0;
+            _head = 0;
+            _tail = 0;
+        }
+
+        /// <summary>Checks whether the queue contains a specified item.</summary>
+        /// <param name="item">The item to check for in the queue.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the queue; otherwise, <c>false</c>.</returns>
+        public readonly bool Contains(T item)
+        {
+            var items = _items;
+
+            if (items is not null)
+            {
+                var head = _head;
+                var tail = _tail;
+
+                if ((head < tail) || (tail == 0))
+                {
+                    return Array.IndexOf(items, item, head, Count) != -1;
+                }
+                else
+                {
+                    return (Array.IndexOf(items, item, head, Count - head) != -1)
+                        || (Array.IndexOf(items, item, 0, tail) != -1);
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Copies the items of the queue to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly void CopyTo(Span<T> destination)
+        {
+            var count = _count;
+            var items = _items;
+
+            var head = _head;
+            var tail = _tail;
+
+            if ((head < tail) || (tail == 0))
+            {
+                items.AsSpan(head, count).CopyTo(destination);
+            }
+            else
+            {
+                var headLength = count - head;
+                items.AsSpan(head, headLength).CopyTo(destination);
+                items.AsSpan(0, tail).CopyTo(destination[headLength..]);
+            }
+        }
+
+        /// <summary>Dequeues the item from the head of the queue.</summary>
+        /// <returns>The item at the head of the queue.</returns>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        public T Dequeue()
+        {
+            if (!TryDequeue(out var item))
+            {
+                ThrowForEmptyQueue();
+            }
+            return item;
+        }
+
+        /// <summary>Enqueues an item to the tail of the queue.</summary>
+        /// <param name="item">The item to enqueue to the tail of the queue.</param>
+        public void Enqueue(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount <= Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            var tail = _tail;
+            var newTail = tail + 1;
+
+            _count = newCount;
+            _items[tail] = item;
+
+            if (newTail == Capacity)
+            {
+                newTail = 0;
+            }
+            _tail = newTail;
+        }
+
+        /// <summary>Ensures the capacity of the queue is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the queue should support.</param>
+        /// <remarks>This method does not throw if <paramref name="capacity" /> is negative and is instead does nothing.</remarks>
+        public void EnsureCapacity(int capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var newCapacity = Max(capacity, currentCapacity * 2);
+                var newItems = GC.AllocateUninitializedArray<T>(newCapacity);
+
+                CopyTo(newItems);
+
+                _version++;
+                _items = newItems;
+
+                _head = 0;
+                _tail = Count;
+            }
+        }
+
+        /// <summary>Peeks the item at the head of the queue.</summary>
+        /// <returns>The item at the head of the queue.</returns>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        public readonly T Peek()
+        {
+            if (!TryPeek(out var item))
+            {
+                ThrowForEmptyQueue();
+            }
+            return item;
+        }
+
+        /// <summary>Tries to dequeue an item from the head of the queue.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
+        public bool TryDequeue([MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+            var newCount = count - 1;
+
+            if (count == 0)
+            {
+                item = default!;
+                return false;
+            }
+
+            _version++;
+
+            var head = _head;
+            var newHead = head + 1;
+
+            _count = newCount;
+
+            if (newHead == Capacity)
+            {
+                newHead = 0;
+            }
+            _head = newHead;
+
+            var items = _items;
+            item = items[head];
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                items[head] = default!;
+            }
+
+            return true;
+        }
+
+        /// <summary>Tries to peek the item at the head of the queue.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek([MaybeNullWhen(false)] out T item)
+        {
+            if (Count != 0)
+            {
+                item = _items[_head];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/ValueQueue`1.cs
+++ b/sources/Core/Collections/ValueQueue`1.cs
@@ -270,7 +270,7 @@ namespace TerraFX.Collections
             }
         }
 
-        /// <summary>Peeks the item at the head of the queue.</summary>
+        /// <summary>Peeks at item at the head of the queue.</summary>
         /// <returns>The item at the head of the queue.</returns>
         /// <exception cref="InvalidOperationException">The queue is empty.</exception>
         public readonly T Peek()
@@ -320,7 +320,7 @@ namespace TerraFX.Collections
             return true;
         }
 
-        /// <summary>Tries to peek the item at the head of the queue.</summary>
+        /// <summary>Tries to peek at the item at the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
         public readonly bool TryPeek([MaybeNullWhen(false)] out T item)

--- a/sources/Core/Collections/ValueQueue`1.cs
+++ b/sources/Core/Collections/ValueQueue`1.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.MathUtilities;
 
@@ -282,6 +283,20 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Peeks at item at the specified index of the queue.</summary>
+        /// <param name="index">The index from the head of the queue of the item at which to peek.</param>
+        /// <returns>The item at the specified index of the queue.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is <c>negative</c> or greater than or equal to <see cref="Count" />.</exception>
+        public readonly T Peek(int index)
+        {
+            if (!TryPeek(index, out var item))
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                Fail();
+            }
+            return item;
+        }
+
         /// <summary>Tries to dequeue an item from the head of the queue.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item from the head of the queue.</param>
         /// <returns><c>true</c> if the queue was not empty; otherwise, <c>false</c>.</returns>
@@ -328,6 +343,35 @@ namespace TerraFX.Collections
             if (Count != 0)
             {
                 item = _items[_head];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to peek at the item at the head of the queue.</summary>
+        /// <param name="index">The index from the head of the queue of the item at which to peek.</param>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the head of the queue.</param>
+        /// <returns><c>true</c> if the queue was not empty and <paramref name="index" /> is less than <see cref="Count" />; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek(int index, [MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+
+            if (unchecked((uint)index < count))
+            {
+                var head = _head;
+
+                if ((head < _tail) || (index < (count - head)))
+                {
+                    item = _items[head + index];
+                }
+                else
+                {
+                    item = _items[index];
+                }
                 return true;
             }
             else

--- a/sources/Core/Collections/ValueStack`1.DebugView.cs
+++ b/sources/Core/Collections/ValueStack`1.DebugView.cs
@@ -1,0 +1,38 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the ICollectionDebugView<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Diagnostics;
+
+namespace TerraFX.Collections
+{
+    public partial struct ValueStack<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly ValueStack<T> _stack;
+
+            public DebugView(ValueStack<T> stack)
+            {
+                _stack = stack;
+            }
+
+            public int Capacity => _stack.Capacity;
+
+            public int Count => _stack.Count;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public T[] Items
+            {
+                get
+                {
+                    var items = GC.AllocateUninitializedArray<T>(_stack.Count);
+                    _stack.CopyTo(items);
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/Collections/ValueStack`1.cs
+++ b/sources/Core/Collections/ValueStack`1.cs
@@ -1,0 +1,269 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// This file includes code based on the Stack<T> class from https://github.com/dotnet/runtime/
+// The original code is Copyright © .NET Foundation and Contributors. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX.Collections
+{
+    /// <summary>Represents a stack of items that can be accessed by index.</summary>
+    /// <typeparam name="T">The type of the items contained in the stack.</typeparam>
+    /// <remarks>This type is meant to be used as an implementation detail of another type and should not be part of your public surface area.</remarks>
+    [DebuggerDisplay("Capacity = {Capacity}; Count = {Count}")]
+    [DebuggerTypeProxy(typeof(ValueStack<>.DebugView))]
+    public partial struct ValueStack<T>
+    {
+        private T[] _items;
+        private int _count;
+        private int _version;
+
+        /// <summary>Initializes a new instance of the <see cref="ValueStack{T}" /> struct.</summary>
+        /// <param name="capacity">The initial capacity of the stack.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is <c>negative</c>.</exception>
+        public ValueStack(int capacity)
+        {
+            ThrowIfNegative(capacity, nameof(capacity));
+
+            if (capacity != 0)
+            {
+                _items = GC.AllocateUninitializedArray<T>(capacity);
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = 0;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueStack{T}" /> struct.</summary>
+        /// <param name="source">The enumerable that is used to populate the stack.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c>.</exception>
+        public ValueStack(IEnumerable<T> source)
+        {
+            // This is an extension method and throws ArgumentNullException if null
+            _items = source.ToArray();
+
+            _count = _items.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueStack{T}" /> struct.</summary>
+        /// <param name="span">The span that is used to populate the stack.</param>
+        public ValueStack(ReadOnlySpan<T> span)
+        {
+            if (span.Length != 0)
+            {
+                var items = GC.AllocateUninitializedArray<T>(span.Length);
+                span.CopyTo(items);
+                _items = items;
+            }
+            else
+            {
+                _items = Array.Empty<T>();
+            }
+
+            _count = span.Length;
+            _version = 0;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ValueStack{T}" /> struct.</summary>
+        /// <param name="array">The array that is used to populate the stack.</param>
+        /// <param name="takeOwnership"><c>true</c> if the stack should take ownership of the array; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        public ValueStack(T[] array, bool takeOwnership = false)
+        {
+            ThrowIfNull(array, nameof(array));
+
+            if (takeOwnership)
+            {
+                _items = array;
+            }
+            else
+            {
+                var items = GC.AllocateUninitializedArray<T>(array.Length);
+                Array.Copy(array, items, array.Length);
+                _items = items;
+            }
+
+            _count = array.Length;
+            _version = 0;
+        }
+
+        /// <summary>Gets the number of items that can be contained by the stack without being resized.</summary>
+        public readonly int Capacity
+        {
+            get
+            {
+                var items = _items;
+
+                if (items is not null)
+                {
+                    return _items.Length;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <summary>Gets the number of items contained in the stack.</summary>
+        public readonly int Count => _count;
+
+        /// <summary>Removes all items from the stack.</summary>
+        public void Clear()
+        {
+            _version++;
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Array.Clear(_items, 0, Count);
+            }
+
+            _count = 0;
+        }
+
+        /// <summary>Checks whether the stack contains a specified item.</summary>
+        /// <param name="item">The item to check for in the stack.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in the stack; otherwise, <c>false</c>.</returns>
+        public readonly bool Contains(T item)
+        {
+            var items = _items;
+
+            if (items is not null)
+            {
+                var count = Count;
+                return (count != 0) && Array.LastIndexOf(items, item, count - 1) != -1;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Copies the items of the stack to a span.</summary>
+        /// <param name="destination">The span to which the items will be copied.</param>
+        /// <exception cref="ArgumentException"><see cref="Count" /> is greater than the length of <paramref name="destination" />.</exception>
+        public readonly void CopyTo(Span<T> destination) => _items.AsSpan(0, Count).CopyTo(destination);
+
+        /// <summary>Ensures the capacity of the stack is at least the specified value.</summary>
+        /// <param name="capacity">The minimum capacity the stack should support.</param>
+        /// <remarks>This method does not throw if <paramref name="capacity" /> is negative and is instead does nothing.</remarks>
+        public void EnsureCapacity(int capacity)
+        {
+            var currentCapacity = Capacity;
+
+            if (capacity > currentCapacity)
+            {
+                var newCapacity = Max(capacity, currentCapacity * 2);
+                var newItems = GC.AllocateUninitializedArray<T>(newCapacity);
+
+                CopyTo(newItems);
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
+        /// <summary>Peeks at the item at the top of the stack.</summary>
+        /// <returns>The item at the top of the stack.</returns>
+        /// <exception cref="InvalidOperationException">The stack is empty.</exception>
+        public readonly T Peek()
+        {
+            if (!TryPeek(out var item))
+            {
+                ThrowForEmptyStack();
+            }
+            return item;
+        }
+
+        /// <summary>Pops the item from the top of the stack.</summary>
+        /// <returns>The item at the top of the stack.</returns>
+        /// <exception cref="InvalidOperationException">The stack is empty.</exception>
+        public T Pop()
+        {
+            if (!TryPop(out var item))
+            {
+                ThrowForEmptyStack();
+            }
+            return item;
+        }
+
+        /// <summary>Pushes an item to the top of the stack.</summary>
+        /// <param name="item">The item to push to the top of the stack.</param>
+        public void Push(T item)
+        {
+            var count = Count;
+            var newCount = count + 1;
+
+            if (newCount <= Capacity)
+            {
+                _version++;
+            }
+            else
+            {
+                EnsureCapacity(count + 1);
+            }
+
+            _count = newCount;
+            _items[count] = item;
+        }
+
+        /// <summary>Tries to peek the item at the top of the stack.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the top of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek([MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+
+            if (count != 0)
+            {
+                item = _items[count - 1];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to pop an item from the top of the stack.</summary>
+        /// <param name="item">When <c>true</c> is returned, this contains the item from the top of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>
+        public bool TryPop([MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+            var newCount = count - 1;
+
+            if (count == 0)
+            {
+                item = default!;
+                return false;
+            }
+
+            _version++;
+            _count = newCount;
+
+            var items = _items;
+            item = items[newCount];
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                items[newCount] = default!;
+            }
+
+            return true;
+        }
+    }
+}

--- a/sources/Core/Collections/ValueStack`1.cs
+++ b/sources/Core/Collections/ValueStack`1.cs
@@ -234,6 +234,24 @@ namespace TerraFX.Collections
             _items[count] = item;
         }
 
+        /// <summary>Trims any excess capacity, up to a given threshold, from the stack.</summary>
+        /// <param name="threshold">A percentage, between <c>zero</c> and <c>one</c>, under which any exceess will not be trimmed.</param>
+        /// <remarks>This methods clamps <paramref name="threshold" /> to between <c>zero</c> and <c>one</c>, inclusive.</remarks>
+        public void TrimExcess(float threshold = 1.0f)
+        {
+            var count = Count;
+            var minCount = (int)(Capacity * Clamp(threshold, 0.0f, 1.0f));
+
+            if (count < minCount)
+            {
+                var newItems = GC.AllocateUninitializedArray<T>(count);
+                CopyTo(newItems);
+
+                _version++;
+                _items = newItems;
+            }
+        }
+
         /// <summary>Tries to peek the item at the top of the stack.</summary>
         /// <param name="item">When <c>true</c> is returned, this contains the item at the top of the stack.</param>
         /// <returns><c>true</c> if the stack was not empty; otherwise, <c>false</c>.</returns>

--- a/sources/Core/Collections/ValueStack`1.cs
+++ b/sources/Core/Collections/ValueStack`1.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.MathUtilities;
 
@@ -187,6 +188,20 @@ namespace TerraFX.Collections
             return item;
         }
 
+        /// <summary>Peeks at item at the specified index of the stack.</summary>
+        /// <param name="index">The index from the top of the stack of the item at which to peek.</param>
+        /// <returns>The item at the specified index of the stack.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is <c>negative</c> or greater than or equal to <see cref="Count" />.</exception>
+        public readonly T Peek(int index)
+        {
+            if (!TryPeek(index, out var item))
+            {
+                ThrowIfNotInBounds(index, Count, nameof(index), nameof(Count));
+                Fail();
+            }
+            return item;
+        }
+
         /// <summary>Pops the item from the top of the stack.</summary>
         /// <returns>The item at the top of the stack.</returns>
         /// <exception cref="InvalidOperationException">The stack is empty.</exception>
@@ -229,6 +244,26 @@ namespace TerraFX.Collections
             if (count != 0)
             {
                 item = _items[count - 1];
+                return true;
+            }
+            else
+            {
+                item = default!;
+                return false;
+            }
+        }
+
+        /// <summary>Tries to peek the item at the top of the stack.</summary>
+        /// <param name="index">The index from the top of the stack of the item at which to peek.</param>
+        /// <param name="item">When <c>true</c> is returned, this contains the item at the top of the stack.</param>
+        /// <returns><c>true</c> if the stack was not empty and <paramref name="index" /> is less than <see cref="Count" />; otherwise, <c>false</c>.</returns>
+        public readonly bool TryPeek(int index, [MaybeNullWhen(false)] out T item)
+        {
+            var count = Count;
+
+            if (unchecked((uint)index < count))
+            {
+                item = _items[count - (index + 1)];
                 return true;
             }
             else

--- a/sources/Core/Runtime/Configuration.cs
+++ b/sources/Core/Runtime/Configuration.cs
@@ -56,6 +56,16 @@ namespace TerraFX.Runtime
             defaultValue: IsDebug
         );
 
+        /// <summary><c>true</c> if TerraFX should break on a failed assert; otherwise, <c>false</c>.</summary>
+        /// <remarks>
+        ///     <para>This defaults to <c>true</c> in debug builds of TerraFX; otherwise, it defaults to <c>false</c>.</para>
+        ///     <para>Users can enable this via an <see cref="AppContext" /> switch to get additional validation in their own assemblies.</para>
+        /// </remarks>
+        public static readonly nuint DefaultAlignment = GetAppContextData(
+            $"{typeof(Configuration).FullName}.{nameof(DefaultAlignment)}",
+            defaultValue: 16
+        );
+
         /// <summary><c>true</c> if TerraFX should use <see cref="CultureInfo.InvariantCulture" /> when resolving resources; otherwise, <c>false</c>.</summary>
         /// <remarks>
         ///     <para>This defaults to <c>false</c>.</para>

--- a/sources/Core/Runtime/Configuration.cs
+++ b/sources/Core/Runtime/Configuration.cs
@@ -63,7 +63,7 @@ namespace TerraFX.Runtime
         /// </remarks>
         public static readonly nuint DefaultAlignment = GetAppContextData(
             $"{typeof(Configuration).FullName}.{nameof(DefaultAlignment)}",
-            defaultValue: 16
+            defaultValue: (nuint)16
         );
 
         /// <summary><c>true</c> if TerraFX should use <see cref="CultureInfo.InvariantCulture" /> when resolving resources; otherwise, <c>false</c>.</summary>

--- a/sources/Core/Runtime/Configuration.cs
+++ b/sources/Core/Runtime/Configuration.cs
@@ -36,6 +36,10 @@ namespace TerraFX.Runtime
         /// <remarks>This value is not configurable via an <see cref="AppContext" /> switch.</remarks>
         public static readonly bool IsWindows = OperatingSystem.IsWindows();
 
+        internal static readonly nuint s_maxArrayLength = 0X7FEFFFFF;
+
+        internal static readonly nuint s_maxByteArrayLength = 0x7FFFFFC7;
+
         /// <summary><c>true</c> if TerraFX based assertions are enabled; otherwise, <c>false</c>.</summary>
         /// <remarks>
         ///     <para>This defaults to <c>true</c> in debug builds of TerraFX; otherwise, it defaults to <c>false</c>.</para>

--- a/sources/Core/Runtime/Resources.Strings.cs
+++ b/sources/Core/Runtime/Resources.Strings.cs
@@ -80,6 +80,9 @@ namespace TerraFX.Runtime
         /// <summary>Gets a localized string similar to <c>'{0}' is not a power of two</c>.</summary>
         public static string ValueIsNotPow2Message => GetString(nameof(ValueIsNotPow2Message));
 
+        /// <summary>Gets a localized string similar to <c>'{0}' is not zero</c>.</summary>
+        public static string ValueIsNotZeroMessage => GetString(nameof(ValueIsNotZeroMessage));
+
         /// <summary>Gets a localized string similar to <c>'{0}' is null</c>.</summary>
         public static string ValueIsNullMessage => GetString(nameof(ValueIsNullMessage));
 

--- a/sources/Core/Runtime/Resources.Strings.cs
+++ b/sources/Core/Runtime/Resources.Strings.cs
@@ -14,6 +14,9 @@ namespace TerraFX.Runtime
         /// <summary>Gets a localized string similar to <c>The queue is empty</c>.</summary>
         public static string EmptyQueueMessage => GetString(nameof(EmptyQueueMessage));
 
+        /// <summary>Gets a localized string similar to <c>The stack is empty</c>.</summary>
+        public static string EmptyStackMessage => GetString(nameof(EmptyStackMessage));
+
         /// <summary>Gets a localized string similar to <c>'{0}' has an invalid flag combination</c>.</summary>
         public static string InvalidFlagCombinationMessage => GetString(nameof(InvalidFlagCombinationMessage));
 

--- a/sources/Core/Runtime/Resources.Strings.cs
+++ b/sources/Core/Runtime/Resources.Strings.cs
@@ -71,6 +71,12 @@ namespace TerraFX.Runtime
         /// <summary>Gets a localized string similar to <c>'{0}' is negative or greater than '{1}'</c>.</summary>
         public static string ValueIsNotInSignedInsertBoundsMessage => GetString(nameof(ValueIsNotInSignedInsertBoundsMessage));
 
+        /// <summary>Gets a localized string similar to <c>'{0}' is greater than or equal to '{1}'</c>.</summary>
+        public static string ValueIsNotInUnsignedBoundsMessage => GetString(nameof(ValueIsNotInUnsignedBoundsMessage));
+
+        /// <summary>Gets a localized string similar to <c>'{0}' is greater than '{1}'</c>.</summary>
+        public static string ValueIsNotInUnsignedInsertBoundsMessage => GetString(nameof(ValueIsNotInUnsignedInsertBoundsMessage));
+
         /// <summary>Gets a localized string similar to <c>'{0}' is not a power of two</c>.</summary>
         public static string ValueIsNotPow2Message => GetString(nameof(ValueIsNotPow2Message));
 

--- a/sources/Core/Runtime/Resources.Strings.cs
+++ b/sources/Core/Runtime/Resources.Strings.cs
@@ -65,6 +65,12 @@ namespace TerraFX.Runtime
         /// <summary>Gets a localized string similar to <c>'{0}' is negative</c>.</summary>
         public static string ValueIsNegativeMessage => GetString(nameof(ValueIsNegativeMessage));
 
+        /// <summary>Gets a localized string similar to <c>'{0}' is negative or greater than or equal to '{1}'</c>.</summary>
+        public static string ValueIsNotInSignedBoundsMessage => GetString(nameof(ValueIsNotInSignedBoundsMessage));
+
+        /// <summary>Gets a localized string similar to <c>'{0}' is negative or greater than '{1}'</c>.</summary>
+        public static string ValueIsNotInSignedInsertBoundsMessage => GetString(nameof(ValueIsNotInSignedInsertBoundsMessage));
+
         /// <summary>Gets a localized string similar to <c>'{0}' is not a power of two</c>.</summary>
         public static string ValueIsNotPow2Message => GetString(nameof(ValueIsNotPow2Message));
 

--- a/sources/Core/Runtime/Resources.Strings.cs
+++ b/sources/Core/Runtime/Resources.Strings.cs
@@ -11,7 +11,10 @@ namespace TerraFX.Runtime
         /// <summary>Gets a localized string similar to <c>The allocation of '{0}x{1}' bytes failed</c>.</summary>
         public static string ArrayAllocationFailedMessage => GetString(nameof(ArrayAllocationFailedMessage));
 
-        /// <summary>Gets a localized string similar to <c>'{0}' has an invalid flag combination</c>c>.</summary>
+        /// <summary>Gets a localized string similar to <c>The queue is empty</c>.</summary>
+        public static string EmptyQueueMessage => GetString(nameof(EmptyQueueMessage));
+
+        /// <summary>Gets a localized string similar to <c>'{0}' has an invalid flag combination</c>.</summary>
         public static string InvalidFlagCombinationMessage => GetString(nameof(InvalidFlagCombinationMessage));
 
         /// <summary>Gets a localized string similar to <c>'{0}' is not a valid key to '{1}'</c>.</summary>

--- a/sources/Core/Runtime/Resources.resx
+++ b/sources/Core/Runtime/Resources.resx
@@ -192,6 +192,9 @@
   <data name="ValueIsNotPow2Message" xml:space="preserve">
     <value>'{0}' is not a power of two</value>
   </data>
+  <data name="ValueIsNotZeroMessage" xml:space="preserve">
+    <value>'{0}' is not zero</value>
+  </data>
   <data name="ValueIsNullMessage" xml:space="preserve">
     <value>'{0}' is null</value>
   </data>

--- a/sources/Core/Runtime/Resources.resx
+++ b/sources/Core/Runtime/Resources.resx
@@ -126,6 +126,9 @@
   <data name="EmptyQueueMessage" xml:space="preserve">
     <value>The queue is empty</value>
   </data>
+  <data name="EmptyStackMessage" xml:space="preserve">
+    <value>The stack is empty</value>
+  </data>
   <data name="InvalidFlagCombinationMessage" xml:space="preserve">
     <value>'{0}' has an invalid flag combination</value>
   </data>

--- a/sources/Core/Runtime/Resources.resx
+++ b/sources/Core/Runtime/Resources.resx
@@ -123,6 +123,9 @@
   <data name="ArrayAllocationFailedMessage" xml:space="preserve">
     <value>The allocation of '{0}x{1}' bytes failed</value>
   </data>
+  <data name="EmptyQueueMessage" xml:space="preserve">
+    <value>The queue is empty</value>
+  </data>
   <data name="InvalidFlagCombinationMessage" xml:space="preserve">
     <value>'{0}' has an invalid flag combination</value>
   </data>

--- a/sources/Core/Runtime/Resources.resx
+++ b/sources/Core/Runtime/Resources.resx
@@ -183,6 +183,12 @@
   <data name="ValueIsNotInSignedInsertBoundsMessage" xml:space="preserve">
     <value>'{0}' is negative or greater than '{1}'</value>
   </data>
+  <data name="ValueIsNotInUnsignedBoundsMessage" xml:space="preserve">
+    <value>'{0}' is greater than or equal to '{1}'</value>
+  </data>
+  <data name="ValueIsNotInUnsignedInsertBoundsMessage" xml:space="preserve">
+    <value>'{0}' is greater than '{1}'</value>
+  </data>
   <data name="ValueIsNotPow2Message" xml:space="preserve">
     <value>'{0}' is not a power of two</value>
   </data>

--- a/sources/Core/Runtime/Resources.resx
+++ b/sources/Core/Runtime/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -177,11 +177,17 @@
   <data name="ValueIsNegativeMessage" xml:space="preserve">
     <value>'{0}' is negative</value>
   </data>
-  <data name="ValueIsNullMessage" xml:space="preserve">
-    <value>'{0}' is null</value>
+  <data name="ValueIsNotInSignedBoundsMessage" xml:space="preserve">
+    <value>'{0}' is negative or greater than or equal to '{1}'</value>
+  </data>
+  <data name="ValueIsNotInSignedInsertBoundsMessage" xml:space="preserve">
+    <value>'{0}' is negative or greater than '{1}'</value>
   </data>
   <data name="ValueIsNotPow2Message" xml:space="preserve">
     <value>'{0}' is not a power of two</value>
+  </data>
+  <data name="ValueIsNullMessage" xml:space="preserve">
+    <value>'{0}' is null</value>
   </data>
   <data name="ValueIsZeroMessage" xml:space="preserve">
     <value>'{0}' is zero</value>

--- a/sources/Core/UnmanagedArray`1.DebugView.cs
+++ b/sources/Core/UnmanagedArray`1.DebugView.cs
@@ -29,7 +29,7 @@ namespace TerraFX
             {
                 get
                 {
-                    var count = Max(_array.Length, s_maxArrayLength);
+                    var count = Min(_array.Length, s_maxArrayLength);
                     var items = GC.AllocateUninitializedArray<T>((int)count);
 
                     fixed (T* pItems = items)

--- a/sources/Core/UnmanagedArray`1.DebugView.cs
+++ b/sources/Core/UnmanagedArray`1.DebugView.cs
@@ -1,0 +1,45 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX
+{
+    public readonly partial struct UnmanagedArray<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly UnmanagedArray<T> _array;
+
+            public DebugView(UnmanagedArray<T> array)
+            {
+                _array = array;
+            }
+
+            public nuint Alignment => _array.Alignment;
+
+            public bool IsNull => _array.IsNull;
+
+            public nuint Length => _array.Length;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public unsafe T[] Items
+            {
+                get
+                {
+                    var count = Max(_array.Length, s_maxArrayLength);
+                    var items = GC.AllocateUninitializedArray<T>((int)count);
+
+                    fixed (T* pItems = items)
+                    {
+                        var span = new UnmanagedSpan<T>(pItems, count);
+                        _array.CopyTo(span);
+                    }
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/UnmanagedArray`1.Metadata.cs
+++ b/sources/Core/UnmanagedArray`1.Metadata.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX
+{
+    public readonly partial struct UnmanagedArray<T>
+    {
+        private struct Metadata
+        {
+            public nuint Length;
+            public nuint Alignment;
+            public T Item;
+        }
+    }
+}

--- a/sources/Core/UnmanagedArray`1.cs
+++ b/sources/Core/UnmanagedArray`1.cs
@@ -192,7 +192,7 @@ namespace TerraFX
         public T* GetPointerUnsafe(nuint index)
         {
             AssertNotNull(this);
-            Assert(AssertionsEnabled && (index < Length));
+            Assert(AssertionsEnabled && (index <= Length));
 
             var items = &_data->Item;
             return items + index;

--- a/sources/Core/UnmanagedArray`1.cs
+++ b/sources/Core/UnmanagedArray`1.cs
@@ -1,6 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using static TerraFX.Runtime.Configuration;
 using static TerraFX.Utilities.AssertionUtilities;
@@ -12,6 +13,8 @@ namespace TerraFX
 {
     /// <summary></summary>
     /// <typeparam name="T"></typeparam>
+    [DebuggerDisplay("Alignment = {Alignment}; IsNull = {IsNull}; Length = {Length}")]
+    [DebuggerTypeProxy(typeof(UnmanagedArray<>.DebugView))]
     public readonly unsafe partial struct UnmanagedArray<T> : IDisposable
         where T : unmanaged
     {

--- a/sources/Core/UnmanagedArray`1.cs
+++ b/sources/Core/UnmanagedArray`1.cs
@@ -106,7 +106,13 @@ namespace TerraFX
             => new UnmanagedReadOnlySpan<T>(array);
 
         /// <inheritdoc />
-        public void Dispose() => Free(_data);
+        public void Dispose()
+        {
+            if (_data != Empty._data)
+            {
+                Free(_data);
+            }
+        }
 
         /// <summary>Converts the array to a span.</summary>
         /// <returns>A span that covers the array.</returns>
@@ -131,7 +137,7 @@ namespace TerraFX
             var items = &_data->Item;
             var length = _data->Length;
 
-            ClearUnsafe(items, length);
+            ClearArrayUnsafe<T>(items, length);
         }
 
         /// <summary>Copies the items in the array to a given destination.</summary>
@@ -148,7 +154,7 @@ namespace TerraFX
             ThrowIfNull(destination, nameof(destination));
             ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
 
-            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+            CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), items, length);
         }
 
         /// <summary>Copies the items in the array to a given destination.</summary>
@@ -163,7 +169,7 @@ namespace TerraFX
 
             ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
 
-            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+            CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), items, length);
         }
 
         /// <summary>Gets a pointer to the item at the specified index of the array.</summary>

--- a/sources/Core/UnmanagedArray`1.cs
+++ b/sources/Core/UnmanagedArray`1.cs
@@ -1,0 +1,199 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.AssertionUtilities;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MemoryUtilities;
+using static TerraFX.Utilities.UnsafeUtilities;
+
+namespace TerraFX
+{
+    /// <summary></summary>
+    /// <typeparam name="T"></typeparam>
+    public readonly unsafe partial struct UnmanagedArray<T> : IDisposable
+        where T : unmanaged
+    {
+        /// <summary>An empty array.</summary>
+        public static readonly UnmanagedArray<T> Empty = new UnmanagedArray<T>(
+            (Metadata*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UnmanagedArray<T>), sizeof(Metadata))
+        );
+
+        private readonly Metadata* _data;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedArray{T}" /> struct.</summary>
+        /// <param name="length">The length, in items, of the array.</param>
+        /// <param name="alignment">The alignment, in bytes, of the items in the array or <c>zero</c> to use the system default.</param>
+        /// <param name="zero"><c>true</c> if the items in the array should be zeroed; otherwise, <c>false</c>.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="alignment" /> is not zero or a <c>power of two</c>.</exception>
+        public UnmanagedArray(nuint length, nuint alignment = 0, bool zero = true)
+        {
+            var actualAlignment = (alignment != 0) ? alignment : DefaultAlignment;
+            ThrowIfNotPow2(actualAlignment, nameof(alignment));
+
+            Metadata* data;
+
+            if (length != 0)
+            {
+                // This allocates one more item than necessary, but this can be used to help detect buffer
+                // overruns and ensures that get a ref to an empty array isn't "undefined behavior".
+
+                data = (Metadata*)Allocate(
+                    SizeOf<Metadata>() + (length * SizeOf<T>()),
+                    actualAlignment,
+                    offset: SizeOf<nuint>(),
+                    zero
+                );
+
+                data->Alignment = alignment;
+                data->Length = length;
+            }
+            else
+            {
+                data = Empty._data;
+            }
+
+            _data = data;
+        }
+
+        private UnmanagedArray(Metadata* data)
+        {
+            AssertNotNull(data);
+            _data = data;
+        }
+
+        /// <summary>Gets the alignment, in bytes, of the items in the array or <c>zero</c> which indicates the system default.</summary>
+        public nuint Alignment
+        {
+            get
+            {
+                AssertNotNull(this);
+                return _data->Alignment;
+            }
+        }
+
+        /// <summary><c>true</c> if the array is <c>null</c>; otherwise, <c>false</c>.</summary>
+        public bool IsNull => _data == null;
+
+        /// <summary>Gets the length, in items, of the array.</summary>
+        public nuint Length
+        {
+            get
+            {
+                AssertNotNull(this);
+                return _data->Length;
+            }
+        }
+
+        /// <summary>Gets a reference to the item at the specified index of the array.</summary>
+        /// <param name="index">The index of the item to get or set.</param>
+        /// <returns>The item that exists at <paramref name="index" /> in the array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Length" />.</exception>
+        public ref T this[nuint index]
+            => ref AsRef<T>(GetPointer(index));
+
+        /// <summary>Implicitly converts the array to a span.</summary>
+        /// <param name="array">The array to convert.</param>
+        /// <returns>A span that covers the same memory as <paramref name="array" />.</returns>
+        public static implicit operator UnmanagedSpan<T>(UnmanagedArray<T> array)
+            => new UnmanagedSpan<T>(array);
+
+        /// <summary>Implicitly converts the array to a readonly span.</summary>
+        /// <param name="array">The array to convert.</param>
+        /// <returns>A readonly span that covers the same memory as <paramref name="array" />.</returns>
+        public static implicit operator UnmanagedReadOnlySpan<T>(UnmanagedArray<T> array)
+            => new UnmanagedReadOnlySpan<T>(array);
+
+        /// <inheritdoc />
+        public void Dispose() => Free(_data);
+
+        /// <summary>Converts the array to a span.</summary>
+        /// <returns>A span that covers the array.</returns>
+        public UnmanagedSpan<T> AsSpan() => new UnmanagedSpan<T>(this);
+
+        /// <summary>Converts the array to a span starting at the specified index.</summary>
+        /// <param name="start">The index of the array at which the span should start.</param>
+        /// <returns>A span that covers the array beginning at <paramref name="start" />.</returns>
+        public UnmanagedSpan<T> AsSpan(nuint start) => new UnmanagedSpan<T>(this, start);
+
+        /// <summary>Converts the array to a span starting at the specified index and continuing for the specified number of items.</summary>
+        /// <param name="start">The index of the array at which the span should start.</param>
+        /// <param name="length">The length, in items, of the span.</param>
+        /// <returns>A span that covers the array beginning at <paramref name="start" /> and continuing for <paramref name="length" /> items.</returns>
+        public UnmanagedSpan<T> AsSpan(nuint start, nuint length) => new UnmanagedSpan<T>(this, start, length);
+
+        /// <summary>Clears all items in the array to <c>zero</c>.</summary>
+        public void Clear()
+        {
+            AssertNotNull(this);
+
+            var items = &_data->Item;
+            var length = _data->Length;
+
+            ClearUnsafe(items, length);
+        }
+
+        /// <summary>Copies the items in the array to a given destination.</summary>
+        /// <param name="destination">The destination array where the items should be copied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Length" /> is greater than <paramref name="destination" />.</exception>
+        public void CopyTo(UnmanagedArray<T> destination)
+        {
+            AssertNotNull(this);
+
+            var items = &_data->Item;
+            var length = _data->Length;
+
+            ThrowIfNull(destination, nameof(destination));
+            ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
+
+            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+        }
+
+        /// <summary>Copies the items in the array to a given destination.</summary>
+        /// <param name="destination">The destination span where the items should be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Length" /> is greater than <paramref name="destination" />.</exception>
+        public void CopyTo(UnmanagedSpan<T> destination)
+        {
+            AssertNotNull(this);
+
+            var items = &_data->Item;
+            var length = _data->Length;
+
+            ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
+
+            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+        }
+
+        /// <summary>Gets a pointer to the item at the specified index of the array.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A pointer to the item that exists at <paramref name="index" /> in the array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Length" />.</exception>
+        public T* GetPointer(nuint index)
+        {
+            ThrowIfNotInBounds(index, Length, nameof(index), nameof(Length));
+            return GetPointerUnsafe(index);
+        }
+
+        /// <summary>Gets a pointer to the item at the specified index of the array.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A pointer to the item that exists at <paramref name="index" /> in the array.</returns>
+        /// <remarks>This method is unsafe because it does not validated that <paramref name="index" /> is less than <see cref="Length" />.</remarks>
+        public T* GetPointerUnsafe(nuint index)
+        {
+            AssertNotNull(this);
+            Assert(AssertionsEnabled && (index < Length));
+
+            var items = &_data->Item;
+            return items + index;
+        }
+
+        /// <summary>Gets a reference to the item at the specified index of the array.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A reference to the item that exists at <paramref name="index" /> in the array.</returns>
+        /// <remarks>This method is unsafe because it does not validated that <paramref name="index" /> is less than <see cref="Length" />.</remarks>
+        public ref T GetReferenceUnsafe(nuint index)
+            => ref AsRef<T>(GetPointerUnsafe(index));
+    }
+}

--- a/sources/Core/UnmanagedReadOnlySpan`1.DebugView.cs
+++ b/sources/Core/UnmanagedReadOnlySpan`1.DebugView.cs
@@ -1,0 +1,43 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX
+{
+    public partial struct UnmanagedReadOnlySpan<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly UnmanagedReadOnlySpan<T> _span;
+
+            public DebugView(UnmanagedReadOnlySpan<T> span)
+            {
+                _span = span;
+            }
+
+            public bool IsEmpty => _span.IsEmpty;
+
+            public nuint Length => _span.Length;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public unsafe T[] Items
+            {
+                get
+                {
+                    var count = Max(_span.Length, s_maxArrayLength);
+                    var items = GC.AllocateUninitializedArray<T>((int)count);
+
+                    fixed (T* pItems = items)
+                    {
+                        var span = new UnmanagedSpan<T>(pItems, count);
+                        _span.CopyTo(span);
+                    }
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/UnmanagedReadOnlySpan`1.DebugView.cs
+++ b/sources/Core/UnmanagedReadOnlySpan`1.DebugView.cs
@@ -27,7 +27,7 @@ namespace TerraFX
             {
                 get
                 {
-                    var count = Max(_span.Length, s_maxArrayLength);
+                    var count = Min(_span.Length, s_maxArrayLength);
                     var items = GC.AllocateUninitializedArray<T>((int)count);
 
                     fixed (T* pItems = items)

--- a/sources/Core/UnmanagedReadOnlySpan`1.cs
+++ b/sources/Core/UnmanagedReadOnlySpan`1.cs
@@ -1,0 +1,80 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace TerraFX
+{
+    /// <summary>Represents a type and memory safe way to read a contiguous region of unmanaged memory.</summary>
+    /// <typeparam name="T">The type of items contained in the span.</typeparam>
+    public readonly unsafe partial struct UnmanagedReadOnlySpan<T>
+        where T : unmanaged
+    {
+        /// <summary>An empty span.</summary>
+        public static readonly UnmanagedReadOnlySpan<T> Empty = new UnmanagedReadOnlySpan<T>();
+
+        private readonly UnmanagedSpan<T> _span;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedReadOnlySpan{T}" /> struct.</summary>
+        /// <inheritdoc cref="UnmanagedSpan{T}.UnmanagedSpan(UnmanagedArray{T})" />
+        public UnmanagedReadOnlySpan(UnmanagedArray<T> array)
+            : this(new UnmanagedSpan<T>(array)) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedReadOnlySpan{T}" /> struct.</summary>
+        /// <inheritdoc cref="UnmanagedSpan{T}.UnmanagedSpan(UnmanagedArray{T}, nuint)" />
+        public UnmanagedReadOnlySpan(UnmanagedArray<T> array, nuint start)
+            : this(new UnmanagedSpan<T>(array, start)) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedReadOnlySpan{T}" /> struct.</summary>
+        /// <inheritdoc cref="UnmanagedSpan{T}.UnmanagedSpan(UnmanagedArray{T}, nuint, nuint)" />
+        public UnmanagedReadOnlySpan(UnmanagedArray<T> array, nuint start, nuint length)
+            : this(new UnmanagedSpan<T>(array, start, length)) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedReadOnlySpan{T}" /> struct.</summary>
+        /// <inheritdoc cref="UnmanagedSpan{T}.UnmanagedSpan(T*, nuint)" />
+        public UnmanagedReadOnlySpan(T* pointer, nuint length)
+            : this(new UnmanagedSpan<T>(pointer, length)) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedReadOnlySpan{T}" /> struct.</summary>
+        /// <param name="span">The underlying span for the readonly span.</param>
+        public UnmanagedReadOnlySpan(UnmanagedSpan<T> span)
+        {
+            _span = span;
+        }
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.IsEmpty" />
+        public bool IsEmpty => _span.IsEmpty;
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.Length" />
+        public nuint Length => _span.Length;
+
+        /// <summary>Gets or sets the item at the specified index of the span.</summary>
+        /// <param name="index">The index of the item to get or set.</param>
+        /// <returns>The item that exists at <paramref name="index" /> in the span.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Length" />.</exception>
+        public ref T this[nuint index] => ref _span[index];
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.Clear()" />
+        public void Clear() => _span.Clear();
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.CopyTo(UnmanagedArray{T})" />
+        public void CopyTo(UnmanagedArray<T> destination) => _span.CopyTo(destination);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.CopyTo(UnmanagedSpan{T})" />
+        public void CopyTo(UnmanagedSpan<T> destination) => _span.CopyTo(destination);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.GetPointer(nuint)" />
+        public T* GetPointer(nuint index) => _span.GetPointer(index);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.GetPointerUnsafe(nuint)" />
+        public T* GetPointerUnsafe(nuint index) => _span.GetPointerUnsafe(index);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.GetReferenceUnsafe(nuint)" />
+        public ref T GetReferenceUnsafe(nuint index) => ref _span.GetReferenceUnsafe(index);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.Slice(nuint)" />
+        public UnmanagedReadOnlySpan<T> Slice(nuint start) => _span.Slice(start);
+
+        /// <inheritdoc cref="UnmanagedSpan{T}.Slice(nuint, nuint)" />
+        public UnmanagedReadOnlySpan<T> Slice(nuint start, nuint length) => _span.Slice(start, length);
+    }
+}

--- a/sources/Core/UnmanagedReadOnlySpan`1.cs
+++ b/sources/Core/UnmanagedReadOnlySpan`1.cs
@@ -1,11 +1,14 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Diagnostics;
 
 namespace TerraFX
 {
     /// <summary>Represents a type and memory safe way to read a contiguous region of unmanaged memory.</summary>
     /// <typeparam name="T">The type of items contained in the span.</typeparam>
+    [DebuggerDisplay("IsEmpty = {IsEmpty}; Length = {Length}")]
+    [DebuggerTypeProxy(typeof(UnmanagedReadOnlySpan<>.DebugView))]
     public readonly unsafe partial struct UnmanagedReadOnlySpan<T>
         where T : unmanaged
     {

--- a/sources/Core/UnmanagedSpan`1.DebugView.cs
+++ b/sources/Core/UnmanagedSpan`1.DebugView.cs
@@ -1,0 +1,43 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.MathUtilities;
+
+namespace TerraFX
+{
+    public readonly partial struct UnmanagedSpan<T>
+    {
+        internal sealed class DebugView
+        {
+            private readonly UnmanagedSpan<T> _span;
+
+            public DebugView(UnmanagedSpan<T> span)
+            {
+                _span = span;
+            }
+
+            public bool IsEmpty => _span.IsEmpty;
+
+            public nuint Length => _span.Length;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public unsafe T[] Items
+            {
+                get
+                {
+                    var count = Max(_span.Length, s_maxArrayLength);
+                    var items = GC.AllocateUninitializedArray<T>((int)count);
+
+                    fixed (T* pItems = items)
+                    {
+                        var span = new UnmanagedSpan<T>(pItems, count);
+                        _span.CopyTo(span);
+                    }
+                    return items;
+                }
+            }
+        }
+    }
+}

--- a/sources/Core/UnmanagedSpan`1.cs
+++ b/sources/Core/UnmanagedSpan`1.cs
@@ -1,6 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Diagnostics;
 using static TerraFX.Runtime.Configuration;
 using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
@@ -11,6 +12,8 @@ namespace TerraFX
 {
     /// <summary>Represents a type and memory safe way to read and write a contiguous region of unmanaged memory.</summary>
     /// <typeparam name="T">The type of items contained in the span.</typeparam>
+    [DebuggerDisplay("IsEmpty = {IsEmpty}; Length = {Length}")]
+    [DebuggerTypeProxy(typeof(UnmanagedSpan<>.DebugView))]
     public readonly unsafe partial struct UnmanagedSpan<T>
         where T : unmanaged
     {

--- a/sources/Core/UnmanagedSpan`1.cs
+++ b/sources/Core/UnmanagedSpan`1.cs
@@ -117,7 +117,7 @@ namespace TerraFX
             => new UnmanagedReadOnlySpan<T>(span);
 
         /// <summary>Clears all items in the span to <c>zero</c>.</summary>
-        public void Clear() => ClearUnsafe(_items, _length);
+        public void Clear() => ClearArrayUnsafe<T>(_items, _length);
 
         /// <summary>Copies the items in the span to a given destination.</summary>
         /// <param name="destination">The destination array where the items should be copied.</param>
@@ -131,7 +131,7 @@ namespace TerraFX
             ThrowIfNull(destination, nameof(destination));
             ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
 
-            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+            CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), items, length);
         }
 
         /// <summary>Copies the items in the array to a given destination.</summary>
@@ -144,7 +144,7 @@ namespace TerraFX
 
             ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
 
-            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+            CopyArrayUnsafe<T>(destination.GetPointerUnsafe(0), items, length);
         }
 
         /// <summary>Gets a pointer to the item at the specified index of the span.</summary>

--- a/sources/Core/UnmanagedSpan`1.cs
+++ b/sources/Core/UnmanagedSpan`1.cs
@@ -1,0 +1,197 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.AssertionUtilities;
+using static TerraFX.Utilities.ExceptionUtilities;
+using static TerraFX.Utilities.MemoryUtilities;
+using static TerraFX.Utilities.UnsafeUtilities;
+
+namespace TerraFX
+{
+    /// <summary>Represents a type and memory safe way to read and write a contiguous region of unmanaged memory.</summary>
+    /// <typeparam name="T">The type of items contained in the span.</typeparam>
+    public readonly unsafe partial struct UnmanagedSpan<T>
+        where T : unmanaged
+    {
+        /// <summary>An empty span.</summary>
+        public static readonly UnmanagedSpan<T> Empty = new UnmanagedSpan<T>();
+
+        private readonly nuint _length;
+        private readonly T* _items;
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedSpan{T}" /> struct.</summary>
+        /// <param name="array">The array to create the span for.</param>
+        public UnmanagedSpan(UnmanagedArray<T> array)
+        {
+            if (!array.IsNull)
+            {
+                _length = array.Length;
+                _items = array.GetPointerUnsafe(0);
+            }
+            else
+            {
+                this = Empty;
+            }
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedSpan{T}" /> struct.</summary>
+        /// <param name="array">The array to create the span for.</param>
+        /// <param name="start">The index of <paramref name="array" /> at which the span should start.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="start" /> is greater than or equal to the length of <paramref name="array" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="array" /> is null and <paramref name="start" /> is not <c>zero</c>.</exception>
+        public UnmanagedSpan(UnmanagedArray<T> array, nuint start)
+        {
+            if (!array.IsNull)
+            {
+                ThrowIfNotInBounds(start, array.Length, nameof(start), nameof(array.Length));
+
+                _length = array.Length - start;
+                _items = array.GetPointerUnsafe(start);
+            }
+            else
+            {
+                ThrowIfNotZero(start, nameof(start));
+                this = Empty;
+            }
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedSpan{T}" /> struct.</summary>
+        /// <param name="array">The array to create the span for.</param>
+        /// <param name="start">The index of <paramref name="array" /> at which the span should start.</param>
+        /// <param name="length">The length, in items, of the span beginning at <paramref name="start" />.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="start" /> is greater than or equal to the length of <paramref name="array" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="start" /> plus <paramref name="length" /> is greater than or equal to the length of <paramref name="array" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="array" /> is null and <paramref name="start" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="array" /> is null and <paramref name="length" /> is not <c>zero</c>.</exception>
+        public UnmanagedSpan(UnmanagedArray<T> array, nuint start, nuint length)
+        {
+            if (!array.IsNull)
+            {
+                ThrowIfNotInBounds(start, array.Length, nameof(start), nameof(array.Length));
+                ThrowIfNotInBounds(start + length, array.Length, nameof(length), nameof(array.Length));
+
+                _length = length;
+                _items = array.GetPointerUnsafe(start);
+            }
+            else
+            {
+                ThrowIfNotZero(start, nameof(start));
+                ThrowIfNotZero(length, nameof(length));
+                this = Empty;
+            }
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="UnmanagedSpan{T}" /> struct.</summary>
+        /// <param name="pointer">A pointer to the first item the span will contain.</param>
+        /// <param name="length">The length, in items, of the span.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="pointer" /> is null and <paramref name="length" /> is not <c>zero</c>.</exception>
+        public UnmanagedSpan(T* pointer, nuint length)
+        {
+            if (pointer == null)
+            {
+                ThrowForLastErrorIfNotZero(length, nameof(length));
+            }
+
+            _length = length;
+            _items = pointer;
+        }
+
+        /// <summary><c>true</c> if the span is empty; otherwise, <c>false</c>.</summary>
+        public bool IsEmpty => _length == 0;
+
+        /// <summary>Gets the length, in items, of the span.</summary>
+        public nuint Length => _length;
+
+        /// <summary>Gets or sets the item at the specified index of the span.</summary>
+        /// <param name="index">The index of the item to get or set.</param>
+        /// <returns>The item that exists at <paramref name="index" /> in the span.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Length" />.</exception>
+        public ref T this[nuint index]
+            => ref AsRef<T>(GetPointer(index));
+
+        /// <summary>Implicitly converts the span to a readonly span.</summary>
+        /// <param name="span">The span to convert.</param>
+        /// <returns>A readonly span that covers the same memory as <paramref name="span" />.</returns>
+        public static implicit operator UnmanagedReadOnlySpan<T>(UnmanagedSpan<T> span)
+            => new UnmanagedReadOnlySpan<T>(span);
+
+        /// <summary>Clears all items in the span to <c>zero</c>.</summary>
+        public void Clear() => ClearUnsafe(_items, _length);
+
+        /// <summary>Copies the items in the span to a given destination.</summary>
+        /// <param name="destination">The destination array where the items should be copied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Length" /> is greater than <paramref name="destination" />.</exception>
+        public void CopyTo(UnmanagedArray<T> destination)
+        {
+            var items = _items;
+            var length = _length;
+
+            ThrowIfNull(destination, nameof(destination));
+            ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
+
+            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+        }
+
+        /// <summary>Copies the items in the array to a given destination.</summary>
+        /// <param name="destination">The destination span where the items should be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Length" /> is greater than <paramref name="destination" />.</exception>
+        public void CopyTo(UnmanagedSpan<T> destination)
+        {
+            var items = _items;
+            var length = _length;
+
+            ThrowIfNotInInsertBounds(length, destination.Length, nameof(Length), nameof(destination));
+
+            CopyUnsafe(destination.GetPointerUnsafe(0), items, length);
+        }
+
+        /// <summary>Gets a pointer to the item at the specified index of the span.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A pointer to the item that exists at <paramref name="index" /> in the span.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is greater than or equal to <see cref="Length" />.</exception>
+        public T* GetPointer(nuint index)
+        {
+            ThrowIfNotInBounds(index, Length, nameof(index), nameof(Length));
+            return GetPointerUnsafe(index);
+        }
+
+        /// <summary>Gets a pointer to the item at the specified index of the span.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A pointer to the item that exists at <paramref name="index" /> in the span.</returns>
+        /// <remarks>This method is unsafe because it does not validated that <paramref name="index" /> is less than <see cref="Length" />.</remarks>
+        public T* GetPointerUnsafe(nuint index)
+        {
+            Assert(AssertionsEnabled && (index < Length));
+            return _items + index;
+        }
+
+        /// <summary>Gets a reference to the item at the specified index of the span.</summary>
+        /// <param name="index">The index of the item to get a pointer to.</param>
+        /// <returns>A reference to the item that exists at <paramref name="index" /> in the span.</returns>
+        /// <remarks>This method is unsafe because it does not validated that <paramref name="index" /> is less than <see cref="Length" />.</remarks>
+        public ref T GetReferenceUnsafe(nuint index)
+            => ref AsRef<T>(GetPointerUnsafe(index));
+
+        /// <summary>Slices the span so that it begins at the specified index.</summary>
+        /// <param name="start">The index at which the span should start.</param>
+        /// <returns>A span that covers the same memory as the current span beginning at <paramref name="start" />.</returns>
+        public UnmanagedSpan<T> Slice(nuint start)
+        {
+            ThrowIfNotInBounds(start, Length, nameof(start), nameof(Length));
+            return new UnmanagedSpan<T>(_items + start, Length - start);
+        }
+
+        /// <summary>Slices the span so that it begins at the specified index and continuing for the specified number of items.</summary>
+        /// <param name="start">The index at which the span should start.</param>
+        /// <param name="length">The length, in items, of the span.</param>
+        /// <returns>A span that covers the same memory as the current span beginning at <paramref name="start" /> and continuing for <paramref name="length" /> items.</returns>
+        public UnmanagedSpan<T> Slice(nuint start, nuint length)
+        {
+            ThrowIfNotInBounds(start, Length, nameof(start), nameof(Length));
+            ThrowIfNotInBounds(start + length, Length, nameof(length), nameof(Length));
+            return new UnmanagedSpan<T>(_items + start, length);
+        }
+    }
+}

--- a/sources/Core/Utilities/AssertionUtilities.cs
+++ b/sources/Core/Utilities/AssertionUtilities.cs
@@ -49,6 +49,13 @@ namespace TerraFX.Utilities
         public static void AssertNotNull<T>([NotNull] T? value)
             where T : class => Assert(AssertionsEnabled && (value is not null));
 
+        /// <summary>Asserts that <paramref name="array" /> is not <c>null</c>.</summary>
+        /// <typeparam name="T">The type of items in <paramref name="array" />.</typeparam>
+        /// <param name="array">The array to assert is not <c>null</c>.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AssertNotNull<T>(UnmanagedArray<T> array)
+            where T : unmanaged => Assert(AssertionsEnabled && !array.IsNull);
+
         /// <summary>Asserts that <paramref name="value" /> is not <c>null</c>.</summary>
         /// <param name="value">The value to assert is not <c>null</c>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -63,6 +63,15 @@ namespace TerraFX.Utilities
             ThrowInvalidOperationException(message);
         }
 
+        /// <summary>Throws an <see cref="InvalidOperationException" /> for an empty stack.</summary>
+        /// <exception cref="InvalidOperationException">The stack is empty.</exception>
+        [DoesNotReturn]
+        public static void ThrowForEmptyStack()
+        {
+            var message = Resources.EmptyStackMessage;
+            ThrowInvalidOperationException(message);
+        }
+
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> for an invalid flags enum combination.</summary>
         /// <param name="value">The value that caused the exception.va</param>
         /// <param name="valueName">The name of the value that caused the exception.</param>

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -348,6 +348,102 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(int index, int length, string indexName, string lengthName)
+        {
+            if ((uint)index >= (uint)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(long index, long length, string indexName, string lengthName)
+        {
+            if ((ulong)index >= (ulong)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(nint index, nint length, string indexName, string lengthName)
+        {
+            if ((nuint)index >= (nuint)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(int index, int length, string indexName, string lengthName)
+        {
+            if ((uint)index > (uint)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(long index, long length, string indexName, string lengthName)
+        {
+            if ((ulong)index > (ulong)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is <c>negative</c> or greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(nint index, nint length, string indexName, string lengthName)
+        {
+            if ((nuint)index > (nuint)length)
+            {
+                var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not a <c>power of two</c>.</summary>
         /// <param name="value">The value to check.</param>
         /// <param name="valueName">The name of <paramref name="value" />.</param>

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -595,6 +595,90 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(int value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(long value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(nint value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(uint value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(ulong value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not <c>zero</c>.</summary>
+        /// <param name="value">The value to be checked if it is not <c>zero</c>.</param>
+        /// <param name="valueName">The name of the value being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotZero(nuint value, string valueName)
+        {
+            if (value != 0)
+            {
+                var message = string.Format(Resources.ValueIsNotZeroMessage, valueName);
+                ThrowArgumentOutOfRangeException(message, value, valueName);
+            }
+        }
+
         /// <summary>Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <c>null</c>.</summary>
         /// <typeparam name="T">The type of <paramref name="value" />.</typeparam>
         /// <param name="value">The value to be checked for <c>null</c>.</param>

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -694,6 +694,21 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Throws an <see cref="ArgumentNullException" /> if <paramref name="array" /> is <c>null</c>.</summary>
+        /// <typeparam name="T">The type of items in <paramref name="array" />.</typeparam>
+        /// <param name="array">The array to be checked for <c>null</c>.</param>
+        /// <param name="arrayName">The name of the array being checked.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array" /> is <c>null</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>(UnmanagedArray<T> array, string arrayName)
+            where T : unmanaged
+        {
+            if (array.IsNull)
+            {
+                ThrowArgumentNullException(arrayName);
+            }
+        }
+
         /// <summary>Throws a <see cref="ArgumentNullException" /> if <paramref name="value" /> is <c>null</c>.</summary>
         /// <param name="value">The value to be checked for <c>null</c>.</param>
         /// <param name="valueName">The name of the value being checked.</param>

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -54,6 +54,15 @@ namespace TerraFX.Utilities
             throw new ExternalException(message, errorCode);
         }
 
+        /// <summary>Throws an <see cref="InvalidOperationException" /> for an empty queue.</summary>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        [DoesNotReturn]
+        public static void ThrowForEmptyQueue()
+        {
+            var message = Resources.EmptyQueueMessage;
+            ThrowInvalidOperationException(message);
+        }
+
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> for an invalid flags enum combination.</summary>
         /// <param name="value">The value that caused the exception.va</param>
         /// <param name="valueName">The name of the value that caused the exception.</param>
@@ -357,7 +366,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInBounds(int index, int length, string indexName, string lengthName)
         {
-            if ((uint)index >= (uint)length)
+            if (unchecked((uint)index >= (uint)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
@@ -373,7 +382,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInBounds(long index, long length, string indexName, string lengthName)
         {
-            if ((ulong)index >= (ulong)length)
+            if (unchecked((ulong)index >= (ulong)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
@@ -389,7 +398,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInBounds(nint index, nint length, string indexName, string lengthName)
         {
-            if ((nuint)index >= (nuint)length)
+            if (unchecked((nuint)index >= (nuint)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
@@ -453,7 +462,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInInsertBounds(int index, int length, string indexName, string lengthName)
         {
-            if ((uint)index > (uint)length)
+            if (unchecked((uint)index > (uint)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
@@ -469,7 +478,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInInsertBounds(long index, long length, string indexName, string lengthName)
         {
-            if ((ulong)index > (ulong)length)
+            if (unchecked((ulong)index > (ulong)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
@@ -485,7 +494,7 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotInInsertBounds(nint index, nint length, string indexName, string lengthName)
         {
-            if ((nuint)index > (nuint)length)
+            if (unchecked((nuint)index > (nuint)length))
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);

--- a/sources/Core/Utilities/ExceptionUtilities.cs
+++ b/sources/Core/Utilities/ExceptionUtilities.cs
@@ -396,6 +396,54 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(uint index, uint length, string indexName, string lengthName)
+        {
+            if (index >= length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(ulong index, ulong length, string indexName, string lengthName)
+        {
+            if (index >= length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than or equal to <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than or equal to <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInBounds(nuint index, nuint length, string indexName, string lengthName)
+        {
+            if (index >= length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is <c>negative</c> or greater than <paramref name="length" />.</summary>
         /// <param name="index">The index to check.</param>
         /// <param name="length">The length of the collection being indexed.</param>
@@ -440,6 +488,54 @@ namespace TerraFX.Utilities
             if ((nuint)index > (nuint)length)
             {
                 var message = string.Format(Resources.ValueIsNotInSignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(uint index, uint length, string indexName, string lengthName)
+        {
+            if (index > length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(ulong index, ulong length, string indexName, string lengthName)
+        {
+            if (index > length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
+                ThrowArgumentOutOfRangeException(message, index, indexName);
+            }
+        }
+
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is greater than <paramref name="length" />.</summary>
+        /// <param name="index">The index to check.</param>
+        /// <param name="length">The length of the collection being indexed.</param>
+        /// <param name="indexName">The name of the index being checked.</param>
+        /// <param name="lengthName">The name of the length being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="indexName" /> is greater than <paramref name="lengthName" />.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNotInInsertBounds(nuint index, nuint length, string indexName, string lengthName)
+        {
+            if (index > length)
+            {
+                var message = string.Format(Resources.ValueIsNotInUnsignedBoundsMessage, indexName, lengthName);
                 ThrowArgumentOutOfRangeException(message, index, indexName);
             }
         }

--- a/sources/Core/Utilities/MathUtilities.cs
+++ b/sources/Core/Utilities/MathUtilities.cs
@@ -98,9 +98,17 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool EqualsEstimate(this float left, float right, float epsilon) => Abs(right - left) < epsilon;
 
+        /// <inheritdoc cref="Math.Max(int, int)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Max(int left, int right) => Math.Max(left, right);
+
         /// <inheritdoc cref="MathF.Max(float, float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Max(float left, float right) => MathF.Max(left, right);
+
+        /// <inheritdoc cref="Math.Min(int, int)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Min(int left, int right) => Math.Min(left, right);
 
         /// <inheritdoc cref="MathF.Max(float, float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sources/Core/Utilities/MathUtilities.cs
+++ b/sources/Core/Utilities/MathUtilities.cs
@@ -11,7 +11,63 @@ namespace TerraFX.Utilities
     /// <summary>Provides a set of methods to supplement or replace <see cref="Math" /> and <see cref="MathF" />.</summary>
     public static class MathUtilities
     {
-        /// <inheritdoc cref="MathF.Abs(float)" />
+        /// <summary>Computes the absolute value of a given 16-bit signed integer.</summary>
+        /// <param name="value">The integer for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
+        /// <remarks>This method does not account for <see cref="short.MinValue" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short Abs(short value)
+        {
+            Assert(AssertionsEnabled && (value != short.MinValue));
+            var mask = value >> ((sizeof(short) * 8) - 1);
+            return (short)((value + mask) ^ mask);
+        }
+
+        /// <summary>Computes the absolute value of a given 32-bit signed integer.</summary>
+        /// <param name="value">The integer for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
+        /// <remarks>This method does not account for <see cref="int.MinValue" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Abs(int value)
+        {
+            Assert(AssertionsEnabled && (value != int.MinValue));
+            var mask = value >> ((sizeof(int) * 8) - 1);
+            return (value + mask) ^ mask;
+        }
+
+        /// <summary>Computes the absolute value of a given signed native integer.</summary>
+        /// <param name="value">The integer for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
+        /// <remarks>This method does not account for <see cref="nint.MinValue" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe nint Abs(nint value)
+        {
+            Assert(AssertionsEnabled && (value != nint.MinValue));
+            var mask = value >> ((sizeof(nint) * 8) - 1);
+            return (value + mask) ^ mask;
+        }
+
+        /// <summary>Computes the absolute value of a given 64-bit float.</summary>
+        /// <param name="value">The float for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Abs(double value) => Math.Abs(value);
+
+        /// <summary>Computes the absolute value of a given 8-bit signed integer.</summary>
+        /// <param name="value">The integer for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
+        /// <remarks>This method does not account for <see cref="sbyte.MinValue" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte Abs(sbyte value)
+        {
+            Assert(AssertionsEnabled && (value != sbyte.MinValue));
+            var mask = value >> ((sizeof(int) * 8) - 1);
+            return (sbyte)((value + mask) ^ mask);
+        }
+
+        /// <summary>Computes the absolute value of a given 32-bit float.</summary>
+        /// <param name="value">The float for which to compute its absolute.</param>
+        /// <returns>The absolute value of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Abs(float value) => MathF.Abs(value);
 
@@ -19,6 +75,7 @@ namespace TerraFX.Utilities
         /// <param name="address">The address to be aligned.</param>
         /// <param name="alignment">The target alignment, which should be a power of two.</param>
         /// <returns><paramref name="address" /> rounded up to the specified <paramref name="alignment" />.</returns>
+        /// <remarks>This method does not account for an <paramref name="alignment" /> which is not a <c>power of two</c>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint AlignUp(uint address, uint alignment)
         {
@@ -30,6 +87,7 @@ namespace TerraFX.Utilities
         /// <param name="address">The address to be aligned.</param>
         /// <param name="alignment">The target alignment, which should be a power of two.</param>
         /// <returns><paramref name="address" /> rounded up to the specified <paramref name="alignment" />.</returns>
+        /// <remarks>This method does not account for an <paramref name="alignment" /> which is not a <c>power of two</c>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong AlignUp(ulong address, ulong alignment)
         {
@@ -41,6 +99,7 @@ namespace TerraFX.Utilities
         /// <param name="address">The address to be aligned.</param>
         /// <param name="alignment">The target alignment, which should be a power of two.</param>
         /// <returns><paramref name="address" /> rounded up to the specified <paramref name="alignment" />.</returns>
+        /// <remarks>This method does not account for an <paramref name="alignment" /> which is not a <c>power of two</c>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint AlignUp(nuint address, nuint alignment)
         {
@@ -48,71 +107,624 @@ namespace TerraFX.Utilities
             return (address + (alignment - 1)) & ~(alignment - 1);
         }
 
-        /// <summary>Clamps a <see cref="float" /> value to be between a minimum and maximum value.</summary>
+        /// <summary>Clamps an 8-bit unsigned integer to be between a minimum and maximum value.</summary>
         /// <param name="value">The value to restrict.</param>
         /// <param name="min">The minimum value (inclusive).</param>
         /// <param name="max">The maximum value (inclusive).</param>
         /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Clamp(float value, float min, float max)
+        public static byte Clamp(byte value, byte min, byte max)
         {
+            Assert(AssertionsEnabled && (min <= max));
+
             // The compare order here is important.
             // It ensures we match HLSL behavior for the scenario where min is larger than max.
 
             var result = value;
 
-            result = (result > max) ? max : result;
-            result = (result < min) ? min : result;
+            result = Max(result, min);
+            result = Min(result, max);
 
             return result;
         }
 
-        /// <inheritdoc cref="MathF.Cos(float)" />
+        /// <summary>Clamps a 64-bit float to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp(double value, double min, double max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 16-bit signed integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short Clamp(short value, short min, short max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 32-bit signed integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Clamp(int value, int min, int max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 64-bit signed integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Clamp(long value, long min, long max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a signed native integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nint Clamp(nint value, nint min, nint max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps an 8-bit signed integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte Clamp(sbyte value, sbyte min, sbyte max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 32-bit float to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Clamp(float value, float min, float max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 16-bit unsigned integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort Clamp(ushort value, ushort min, ushort max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 32-bit unsigned integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Clamp(uint value, uint min, uint max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps a 64-bit unsigned integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not account for <paramref name="min" /> being greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Clamp(ulong value, ulong min, ulong max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Clamps an unsigned native integer to be between a minimum and maximum value.</summary>
+        /// <param name="value">The value to restrict.</param>
+        /// <param name="min">The minimum value (inclusive).</param>
+        /// <param name="max">The maximum value (inclusive).</param>
+        /// <returns><paramref name="value" /> clamped to be between <paramref name="min" /> and <paramref name="max" />.</returns>
+        /// <remarks>This method does not throw if <paramref name="min" /> is greater than <paramref name="max" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nuint Clamp(nuint value, nuint min, nuint max)
+        {
+            Assert(AssertionsEnabled && (min <= max));
+
+            // The compare order here is important.
+            // It ensures we match HLSL behavior for the scenario where min is larger than max.
+
+            var result = value;
+
+            result = Max(result, min);
+            result = Min(result, max);
+
+            return result;
+        }
+
+        /// <summary>Computes the cosine for a given 64-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the cosine.</param>
+        /// <returns>The cosine of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Cos(double value) => Math.Cos(value);
+
+        /// <summary>Computes the cosine for a given 32-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the cosine.</param>
+        /// <returns>The cosine of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Cos(float value) => MathF.Cos(value);
 
-        /// <summary>Computes <paramref name="dividend" /> / <paramref name="divisor" /> but rounds the result up, rather than down.</summary>
+        /// <summary>Computes the quotient of two 32-bit unsigned integers but rounds the result up, rather than down.</summary>
         /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
         /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
         /// <returns>The quotient of <paramref name="dividend" /> / <paramref name="divisor" />, rounded up.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint DivideRoundingUp(uint dividend, uint divisor) => (dividend + divisor - 1) / divisor;
+        public static uint DivideRoundingUp(uint dividend, uint divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            return (dividend + divisor - 1) / divisor;
+        }
 
-        /// <summary>Computes the quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</summary>
+        /// <summary>Computes the quotient of two 64-bit unsigned integers but rounds the result up, rather than down.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient of <paramref name="dividend" /> / <paramref name="divisor" />, rounded up.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong DivideRoundingUp(ulong dividend, ulong divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            return (dividend + divisor - 1) / divisor;
+        }
+
+        /// <summary>Computes the quotient of two unsigned native integers but rounds the result up, rather than down.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient of <paramref name="dividend" /> / <paramref name="divisor" />, rounded up.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nuint DivideRoundingUp(nuint dividend, nuint divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            return (dividend + divisor - 1) / divisor;
+        }
+
+        /// <summary>Computes the quotient and remainder of two 32-bit signed integers.</summary>
         /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
         /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
         /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (nuint quotient, nuint remainder) DivRem(nuint dividend, nuint divisor)
+        public static (int quotient, int remainder) DivRem(int dividend, int divisor)
+
         {
+            Assert(AssertionsEnabled && (divisor != 0));
             var quotient = dividend / divisor;
+
             var remainder = dividend - (quotient * divisor);
             return (quotient, remainder);
         }
 
-        /// <summary>Compares two floats to determine if they are approximately equal.</summary>
+        /// <summary>Computes the quotient and remainder of two 64-bit signed  integers.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (long quotient, long remainder) DivRem(long dividend, long divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            var quotient = dividend / divisor;
+
+            var remainder = dividend - (quotient * divisor);
+            return (quotient, remainder);
+        }
+
+        /// <summary>Computes the quotient and remainder of two signed native integers.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (nint quotient, nint remainder) DivRem(nint dividend, nint divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            var quotient = dividend / divisor;
+
+            var remainder = dividend - (quotient * divisor);
+            return (quotient, remainder);
+        }
+
+        /// <summary>Computes the quotient and remainder of two 32-bit unsigned integers.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (uint quotient, uint remainder) DivRem(uint dividend, uint divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            var quotient = dividend / divisor;
+
+            var remainder = dividend - (quotient * divisor);
+            return (quotient, remainder);
+        }
+
+        /// <summary>Computes the quotient and remainder of two 64-bit unsigned  integers.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (ulong quotient, ulong remainder) DivRem(ulong dividend, ulong divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            var quotient = dividend / divisor;
+
+            var remainder = dividend - (quotient * divisor);
+            return (quotient, remainder);
+        }
+
+        /// <summary>Computes the quotient and remainder of two unsigned native integers.</summary>
+        /// <param name="dividend">The value being divided by <paramref name="divisor" />.</param>
+        /// <param name="divisor">The value that is used to divide <paramref name="dividend" />.</param>
+        /// <returns>The quotient and remainder of <paramref name="dividend" /> / <paramref name="divisor" />.</returns>
+        /// <remarks>This method does not account for <paramref name="divisor" /> being <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (nuint quotient, nuint remainder) DivRem(nuint dividend, nuint divisor)
+        {
+            Assert(AssertionsEnabled && (divisor != 0));
+            var quotient = dividend / divisor;
+
+            var remainder = dividend - (quotient * divisor);
+            return (quotient, remainder);
+        }
+
+        /// <summary>Compares two 64-bit floats to determine approximate equality.</summary>
         /// <param name="left">The float to compare with <paramref name="right" />.</param>
         /// <param name="right">The float to compare with <paramref name="left" />.</param>
         /// <param name="epsilon">The maximum (exclusive) difference between <paramref name="left" /> and <paramref name="right" /> for which they should be considered equivalent.</param>
         /// <returns><c>true</c> if <paramref name="left" /> and <paramref name="right" /> differ by no more than <paramref name="epsilon" />; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EqualsEstimate(this float left, float right, float epsilon) => Abs(right - left) < epsilon;
+        public static bool EqualsEstimate(double left, double right, double epsilon) => Abs(right - left) < epsilon;
 
-        /// <inheritdoc cref="Math.Max(int, int)" />
+        /// <summary>Compares two 32-bit floats to determine approximate equality.</summary>
+        /// <param name="left">The float to compare with <paramref name="right" />.</param>
+        /// <param name="right">The float to compare with <paramref name="left" />.</param>
+        /// <param name="epsilon">The maximum (exclusive) difference between <paramref name="left" /> and <paramref name="right" /> for which they should be considered equivalent.</param>
+        /// <returns><c>true</c> if <paramref name="left" /> and <paramref name="right" /> differ by no more than <paramref name="epsilon" />; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Max(int left, int right) => Math.Max(left, right);
+        public static bool EqualsEstimate(float left, float right, float epsilon) => Abs(right - left) < epsilon;
 
-        /// <inheritdoc cref="MathF.Max(float, float)" />
+        /// <summary>Computes the maximum of two 32-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Max(float left, float right) => MathF.Max(left, right);
+        public static byte Max(byte left, byte right) => (left > right) ? left : right;
 
-        /// <inheritdoc cref="Math.Min(int, int)" />
+        /// <summary>Computes the maximum of two 64-bit floats.</summary>
+        /// <param name="left">The float to compare with <paramref name="right" />.</param>
+        /// <param name="right">The float to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        /// <remarks>This method does not account for <c>negative zero</c> and returns the other parameter if one is <see cref="double.NaN" />.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Min(int left, int right) => Math.Min(left, right);
+        public static double Max(double left, double right)
+        {
+            if (double.IsNaN(right))
+            {
+                return left;
+            }
+            return (left >= right) ? left : right;
+        }
 
-        /// <inheritdoc cref="MathF.Max(float, float)" />
+        /// <summary>Computes the maximum of two 16-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Min(float left, float right) => MathF.Min(left, right);
+        public static short Max(short left, short right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 32-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Max(int left, int right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 64-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Max(long left, long right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two signed native integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nint Max(nint left, nint right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 8-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte Max(sbyte left, sbyte right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 32-bit floats.</summary>
+        /// <param name="left">The float to compare with <paramref name="right" />.</param>
+        /// <param name="right">The float to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        /// <remarks>This method does not account for <c>negative zero</c> and returns the other parameter if one is <see cref="double.NaN" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Max(float left, float right)
+        {
+            if (float.IsNaN(right))
+            {
+                return left;
+            }
+            return (left >= right) ? left : right;
+        }
+
+        /// <summary>Computes the maximum of two 16-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort Max(ushort left, ushort right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 32-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Max(uint left, uint right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two 64-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Max(ulong left, ulong right) => (left > right) ? left : right;
+
+        /// <summary>Computes the maximum of two unsigned native integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The maximum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nuint Max(nuint left, nuint right) => (left > right) ? left : right;
+
+        /// <summary>Computes the minimum of two 8-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte Min(byte left, byte right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 64-bit floats.</summary>
+        /// <param name="left">The float to compare with <paramref name="right" />.</param>
+        /// <param name="right">The float to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        /// <remarks>This method does not account for <c>negative zero</c> and returns the other parameter if one is <see cref="double.NaN" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Min(double left, double right)
+        {
+            if (double.IsNaN(right))
+            {
+                return left;
+            }
+            return (left < right) ? left : right;
+        }
+
+        /// <summary>Computes the minimum of two 16-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short Min(short left, short right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 32-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Min(int left, int right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 64-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Min(long left, long right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two signed native integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nint Min(nint left, nint right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 8-bit signed integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte Min(sbyte left, sbyte right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 32-bit floats.</summary>
+        /// <param name="left">The float to compare with <paramref name="right" />.</param>
+        /// <param name="right">The float to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        /// <remarks>This method does not account for <c>negative zero</c> and returns the other parameter if one is <see cref="double.NaN" />.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Min(float left, float right)
+        {
+            if (float.IsNaN(right))
+            {
+                return left;
+            }
+            return (left < right) ? left : right;
+        }
+
+        /// <summary>Computes the minimum of two 16-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort Min(ushort left, ushort right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 32-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Min(uint left, uint right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two 64-bit unsigned integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Min(ulong left, ulong right) => (left < right) ? left : right;
+
+        /// <summary>Computes the minimum of two unsigned native integers.</summary>
+        /// <param name="left">The integer to compare with <paramref name="right" />.</param>
+        /// <param name="right">The integer to compare with <paramref name="left" />.</param>
+        /// <returns>The minimum of <paramref name="left" /> and <paramref name="right" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nuint Min(nuint left, nuint right) => (left < right) ? left : right;
 
         /// <summary>Determines whether a given value is a power of two.</summary>
         /// <param name="value">The value to check.</param>
@@ -162,21 +774,51 @@ namespace TerraFX.Utilities
             }
         }
 
-        /// <inheritdoc cref="MathF.Sin(float)" />
+        /// <summary>Computes the sine for a given 64-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the sine.</param>
+        /// <returns>The sine of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sin(double value) => Math.Sin(value);
+
+        /// <summary>Computes the sine for a given 32-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the sine.</param>
+        /// <returns>The sine of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sin(float value) => MathF.Sin(value);
 
-        /// <summary>Returns the sine and cosine of the specified angle.</summary>
-        /// <param name="value">The angle for which to get the sine and cosine.</param>
+        /// <summary>Computes the sine and cosine for a given 64-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the sine and cosine.</param>
         /// <returns>The sine and cosine of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (float Sin, float Cos) SinCos(float value) => (MathF.Sin(value), MathF.Cos(value));
+        public static (double Sin, double Cos) SinCos(double value) => (Sin(value), Cos(value));
 
-        /// <inheritdoc cref="MathF.Sqrt(float)" />
+        /// <summary>Computes the sine and cosine for a given 32-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the sine and cosine.</param>
+        /// <returns>The sine and cosine of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (float Sin, float Cos) SinCos(float value) => (Sin(value), Cos(value));
+
+        /// <summary>Computes the square root of a given 64-bit float.</summary>
+        /// <param name="value">The float for which to compute the square root.</param>
+        /// <returns>The square root of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sqrt(double value) => Math.Sqrt(value);
+
+        /// <summary>Computes the square root of a given 32-bit float.</summary>
+        /// <param name="value">The float for which to compute the square root.</param>
+        /// <returns>The square root of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sqrt(float value) => MathF.Sqrt(value);
 
-        /// <inheritdoc cref="MathF.Tan(float)" />
+        /// <summary>Computes the tangent for a given 64-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the tangent.</param>
+        /// <returns>The tangent of <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Tan(double value) => Math.Tan(value);
+
+        /// <summary>Computes the tangent for a given 32-bit float.</summary>
+        /// <param name="value">The float, in radians, for which to compute the tangent.</param>
+        /// <returns>The tangent of <paramref name="value" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Tan(float value) => MathF.Tan(value);
     }

--- a/sources/Core/Utilities/MemoryUtilities.cs
+++ b/sources/Core/Utilities/MemoryUtilities.cs
@@ -1239,6 +1239,47 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Tries to get the last index of a given item in the specified buffer.</summary>
+        /// <typeparam name="T">The type of the item to try and get the index for.</typeparam>
+        /// <param name="items">The items to search for <paramref name="item" />.</param>
+        /// <param name="length">The length, in items, of <paramref name="items" />.</param>
+        /// <param name="item">The item to try and get the last index for.</param>
+        /// <param name="index">When <c>true</c> is returned, this contains the last index of <paramref name="item" />.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in <paramref name="items" />; otherwise, <c>false</c>.</returns>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="items" /> is not <c>null</c> if <paramref name="length" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetLastIndexOfUnsafe<T>(T* items, nuint length, T item, out nuint index)
+            where T : unmanaged
+        {
+            return SoftwareFallback(items, length, item, out index);
+
+            static bool SoftwareFallback(T* items, nuint length, T item, out nuint index)
+            {
+                var equalityComparer = EqualityComparer<T>.Default;
+
+                if (length != 0)
+                {
+                    for (var i = length - 1; i > 0; i--)
+                    {
+                        if (equalityComparer.Equals(items[i], item))
+                        {
+                            index = i;
+                            return true;
+                        }
+                    }
+
+                    if (equalityComparer.Equals(items[0], item))
+                    {
+                        index = 0;
+                        return true;
+                    }
+                }
+
+                index = 0;
+                return false;
+            }
+        }
+
         /// <summary>Tries to reallocate a chunk of unmanaged memory.</summary>
         /// <param name="address">The address of an allocated chunk of memory to reallocate</param>
         /// <param name="newSize">The new size, in bytes, of the allocation.</param>

--- a/sources/Core/Utilities/MemoryUtilities.cs
+++ b/sources/Core/Utilities/MemoryUtilities.cs
@@ -1,7 +1,12 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using static TerraFX.Interop.Mimalloc;
+using static TerraFX.Runtime.Configuration;
+using static TerraFX.Utilities.AssertionUtilities;
 using static TerraFX.Utilities.ExceptionUtilities;
 using static TerraFX.Utilities.UnsafeUtilities;
 
@@ -224,6 +229,528 @@ namespace TerraFX.Utilities
                 ThrowOutOfMemoryException(count, SizeOf<T>());
             }
             return result;
+        }
+
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <param name="length">The length, in bytes, of <paramref name="destination" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
+        public static void Clear(void* destination, nuint length)
+        {
+            if (length == 0)
+            {
+                return;
+            }
+            ThrowIfNull(destination, nameof(destination));
+
+            ClearUnsafe(destination, length);
+        }
+
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <param name="length">The length, in bytes, of <paramref name="destination" />.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> is not <c>null</c> if <paramref name="length" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ClearUnsafe(void* destination, nuint length)
+        {
+            Assert(AssertionsEnabled && ((destination != null) || (length == 0)));
+
+            if (length <= 32)
+            {
+                SmallClear(destination, length);
+            }
+            else
+            {
+                LargeClear(destination, length);
+            }
+
+            static void LargeClear(void* destination, nuint length)
+            {
+                Assert(AssertionsEnabled && (length > 32));
+                var blocks = length / 128;
+
+                length -= blocks * 128;
+                Assert(AssertionsEnabled && (length < 128));
+
+                for (nuint block = 0; block < blocks; block++)
+                {
+                    // Bytes 0-31
+
+                    WriteUnaligned<Vector128<byte>>(destination, default);
+                    WriteUnaligned<Vector128<byte>>(destination, 16, default);
+
+                    // Bytes 32-63
+
+                    WriteUnaligned<Vector128<byte>>(destination, 32, default);
+                    WriteUnaligned<Vector128<byte>>(destination, 48, default);
+
+                    // Bytes 64-95
+
+                    WriteUnaligned<Vector128<byte>>(destination, 64, default);
+                    WriteUnaligned<Vector128<byte>>(destination, 80, default);
+
+                    // Bytes 96-127
+
+                    WriteUnaligned<Vector128<byte>>(destination, 96, default);
+                    WriteUnaligned<Vector128<byte>>(destination, 112, default);
+
+                    destination = (void*)((nuint)destination + 128);
+                }
+
+                blocks = length / 32;
+                Assert(AssertionsEnabled && (blocks <= 3));
+
+                length -= blocks * 32;
+                Assert(AssertionsEnabled && (length < 32));
+
+                switch (blocks)
+                {
+                    case 3:
+                    {
+                        WriteUnaligned<Vector128<byte>>(destination, 64, default);
+                        WriteUnaligned<Vector128<byte>>(destination, 80, default);
+
+                        goto case 2;
+                    }
+
+                    case 2:
+                    {
+                        WriteUnaligned<Vector128<byte>>(destination, 32, default);
+                        WriteUnaligned<Vector128<byte>>(destination, 48, default);
+
+                        goto case 1;
+                    }
+
+                    case 1:
+                    {
+                        WriteUnaligned<Vector128<byte>>(destination, default);
+                        WriteUnaligned<Vector128<byte>>(destination, 16, default);
+
+                        goto case 0;
+                    }
+
+                    case 0:
+                    {
+                        SmallClear(destination, length);
+                        break;
+                    }
+                }
+            }
+
+            static void SmallClear(void* destination, nuint length)
+            {
+                Assert(AssertionsEnabled && (length <= 32));
+
+                switch (length)
+                {
+                    case 32:
+                    case 31:
+                    case 30:
+                    case 29:
+                    case 28:
+                    case 27:
+                    case 26:
+                    case 25:
+                    case 24:
+                    case 23:
+                    case 22:
+                    case 21:
+                    case 20:
+                    case 19:
+                    case 18:
+                    case 17:
+                    {
+                        WriteUnaligned<Vector128<byte>>(destination, default);
+                        WriteUnaligned<Vector128<byte>>(destination, length - 16, default);
+                        break;
+                    }
+
+                    case 16:
+                    {
+                        WriteUnaligned<Vector128<byte>>(destination, default);
+                        break;
+                    }
+
+                    case 15:
+                    case 14:
+                    case 13:
+                    case 12:
+                    case 11:
+                    case 10:
+                    case 09:
+                    {
+                        WriteUnaligned<ulong>(destination, default);
+                        WriteUnaligned<ulong>(destination, length - 8, default);
+                        break;
+                    }
+
+                    case 8:
+                    {
+                        WriteUnaligned<ulong>(destination, default);
+                        break;
+                    }
+
+                    case 7:
+                    case 6:
+                    case 5:
+                    {
+                        WriteUnaligned<uint>(destination, default);
+                        WriteUnaligned<uint>(destination, length - 4, default);
+                        break;
+                    }
+
+                    case 4:
+                    {
+                        WriteUnaligned<uint>(destination, default);
+                        break;
+                    }
+
+                    case 3:
+                    {
+                        WriteUnaligned<ushort>(destination, default);
+                        WriteUnaligned<ushort>(destination, length - 2, default);
+                        break;
+                    }
+
+                    case 2:
+                    {
+                        WriteUnaligned<ushort>(destination, default);
+                        break;
+                    }
+
+                    case 1:
+                    {
+                        WriteUnaligned<byte>(destination, default);
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="length">The length, in bytes, to be copied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
+        public static void Copy(void* destination, void* source, nuint length)
+        {
+            if (length == 0)
+            {
+                return;
+            }
+
+            ThrowIfNull(source, nameof(source));
+            ThrowIfNull(destination, nameof(destination));
+
+            CopyUnsafe(destination, source, length);
+        }
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="destinationLength">The length, in bytes, of <paramref name="destination" />.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="sourceLength">The length, in bytes, of <paramref name="source" />.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="sourceLength" /> is greater than <paramref name="destinationLength" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="sourceLength" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="destinationLength" /> is not <c>zero</c>.</exception>
+        public static void Copy(void* destination, nuint destinationLength, void* source, nuint sourceLength)
+        {
+            ThrowIfNotInInsertBounds(sourceLength, destinationLength, nameof(sourceLength), nameof(destinationLength));
+            Copy(destination, source, sourceLength);
+        }
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="length">The length, in bytes, to be copied.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> and <paramref name="source" /> are not <c>null</c> if <paramref name="length" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyUnsafe(void* destination, void* source, nuint length)
+        {
+            Assert(AssertionsEnabled && ((destination != null) || (length == 0)));
+            Assert(AssertionsEnabled && ((source != null) || (length == 0)));
+            Assert(AssertionsEnabled && (destination != source));
+            
+            if (length <= 32)
+            {
+                SmallCopy(destination, source, length);
+            }
+            else if ((source >= destination) || (((nuint)source + length) <= (nuint)destination))
+            {
+                NonOverlappingCopy(destination, source, length);
+            }
+            else
+            {
+                OverlappingCopy(destination, source, length);
+            }
+
+            static void NonOverlappingCopy(void* destination, void* source, nuint length)
+            {
+                Assert(AssertionsEnabled && (length > 32));
+                var blocks = length / 128;
+
+                length -= blocks * 128;
+                Assert(AssertionsEnabled && (length < 128));
+
+                for (nuint block = 0; block < blocks; block++)
+                {
+                    // Bytes 0-31
+
+                    var lower = ReadUnaligned<Vector128<byte>>(source);
+                    var upper = ReadUnaligned<Vector128<byte>>(source, 16);
+
+                    WriteUnaligned(destination, lower);
+                    WriteUnaligned(destination, 16, upper);
+
+                    // Bytes 32-63
+
+                    lower = ReadUnaligned<Vector128<byte>>(source, 32);
+                    upper = ReadUnaligned<Vector128<byte>>(source, 48);
+
+                    WriteUnaligned(destination, 32, lower);
+                    WriteUnaligned(destination, 48, upper);
+
+                    // Bytes 64-95
+
+                    lower = ReadUnaligned<Vector128<byte>>(source, 64);
+                    upper = ReadUnaligned<Vector128<byte>>(source, 80);
+
+                    WriteUnaligned(destination, 64, lower);
+                    WriteUnaligned(destination, 80, upper);
+
+                    // Bytes 96-127
+
+                    lower = ReadUnaligned<Vector128<byte>>(source, 96);
+                    upper = ReadUnaligned<Vector128<byte>>(source, 112);
+
+                    WriteUnaligned(destination, 96, lower);
+                    WriteUnaligned(destination, 112, upper);
+
+                    source = (void*)((nuint)source + 128);
+                    destination = (void*)((nuint)destination + 128);
+                }
+
+                TrailingCopy(destination, source, length);
+            }
+
+            static void OverlappingCopy(void* destination, void* source, nuint length)
+            {
+                Assert(AssertionsEnabled && (source < destination));
+                Assert(AssertionsEnabled && (((nuint)source + length) > (nuint)destination));
+
+                source = (void*)((nuint)source + length);
+                destination = (void*)((nuint)destination + length);
+
+                // This is basically the same as the non-overlapping copy but does
+                // everything in reverse, from back to front. Since we know source
+                // is less than destination and that there is some overlap this ensures
+                // we are only overwriting bytes that have already been read.
+
+                Assert(AssertionsEnabled && (length > 32));
+                var blocks = length / 128;
+
+                length -= blocks * 128;
+                Assert(AssertionsEnabled && (length < 128));
+
+                for (nuint block = 0; block < blocks; block++)
+                {
+                    // Bytes 127-96
+
+                    var upper = ReadUnaligned<Vector128<byte>>(source, 112);
+                    var lower = ReadUnaligned<Vector128<byte>>(source, 96);
+
+                    WriteUnaligned(destination, 112, upper);
+                    WriteUnaligned(destination, 96, lower);
+
+                    // Bytes 95-64
+
+                    upper = ReadUnaligned<Vector128<byte>>(source, 80);
+                    lower = ReadUnaligned<Vector128<byte>>(source, 64);
+
+                    WriteUnaligned(destination, 80, upper);
+                    WriteUnaligned(destination, 64, lower);
+
+                    // Bytes 63-32
+
+                    upper = ReadUnaligned<Vector128<byte>>(source, 48);
+                    lower = ReadUnaligned<Vector128<byte>>(source, 32);
+
+                    WriteUnaligned(destination, 48, upper);
+                    WriteUnaligned(destination, 32, lower);
+
+                    // Bytes 31-0
+
+                    upper = ReadUnaligned<Vector128<byte>>(source, 16);
+                    lower = ReadUnaligned<Vector128<byte>>(source);
+
+                    WriteUnaligned(destination, 16, upper);
+                    WriteUnaligned(destination, lower);
+
+                    source = (void*)((nuint)source - 128);
+                    destination = (void*)((nuint)destination - 128);
+                }
+
+                TrailingCopy(destination, source, length);
+            }
+
+            static void SmallCopy(void* destination, void* source, nuint length)
+            {
+                Assert(AssertionsEnabled && (length <= 32));
+
+                switch (length)
+                {
+                    case 32:
+                    case 31:
+                    case 30:
+                    case 29:
+                    case 28:
+                    case 27:
+                    case 26:
+                    case 25:
+                    case 24:
+                    case 23:
+                    case 22:
+                    case 21:
+                    case 20:
+                    case 19:
+                    case 18:
+                    case 17:
+                    {
+                        var lower = ReadUnaligned<Vector128<byte>>(source);
+                        var upper = ReadUnaligned<Vector128<byte>>(source, length - 16);
+
+                        WriteUnaligned(destination, lower);
+                        WriteUnaligned(destination, length - 16, upper);
+                        break;
+                    }
+
+                    case 16:
+                    {
+                        var value = ReadUnaligned<Vector128<byte>>(source);
+                        WriteUnaligned(destination, value);
+                        break;
+                    }
+
+                    case 15:
+                    case 14:
+                    case 13:
+                    case 12:
+                    case 11:
+                    case 10:
+                    case 09:
+                    {
+                        var lower = ReadUnaligned<ulong>(source);
+                        var upper = ReadUnaligned<ulong>(source, length - 8);
+
+                        WriteUnaligned(destination, lower);
+                        WriteUnaligned(destination, length - 8, upper);
+                        break;
+                    }
+
+                    case 8:
+                    {
+                        var value = ReadUnaligned<ulong>(source);
+                        WriteUnaligned(destination, value);
+                        break;
+                    }
+
+                    case 7:
+                    case 6:
+                    case 5:
+                    {
+                        var lower = ReadUnaligned<uint>(source);
+                        var upper = ReadUnaligned<uint>(source, length - 4);
+
+                        WriteUnaligned(destination, lower);
+                        WriteUnaligned(destination, length - 4, upper);
+                        break;
+                    }
+
+                    case 4:
+                    {
+                        var value = ReadUnaligned<uint>(source);
+                        WriteUnaligned(destination, value);
+                        break;
+                    }
+
+                    case 3:
+                    {
+                        var lower = ReadUnaligned<ushort>(source);
+                        var upper = ReadUnaligned<ushort>(source, length - 2);
+
+                        WriteUnaligned(destination, lower);
+                        WriteUnaligned(destination, length - 2, upper);
+                        break;
+                    }
+
+                    case 2:
+                    {
+                        var value = ReadUnaligned<ushort>(source);
+                        WriteUnaligned(destination, value);
+                        break;
+                    }
+
+                    case 1:
+                    {
+                        var value = ReadUnaligned<byte>(source);
+                        WriteUnaligned(destination, value);
+                        break;
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static void TrailingCopy(void* destination, void* source, nuint length)
+            {
+                var blocks = length / 32;
+                Assert(AssertionsEnabled && (blocks <= 3));
+
+                length -= blocks * 32;
+                Assert(AssertionsEnabled && (length < 32));
+
+                switch (blocks)
+                {
+                    case 3:
+                    {
+                        var lower = ReadUnaligned<Vector128<byte>>(source, 64);
+                        var upper = ReadUnaligned<Vector128<byte>>(source, 80);
+
+                        WriteUnaligned(destination, 64, lower);
+                        WriteUnaligned(destination, 80, upper);
+
+                        goto case 2;
+                    }
+
+                    case 2:
+                    {
+                        var lower = ReadUnaligned<Vector128<byte>>(source, 32);
+                        var upper = ReadUnaligned<Vector128<byte>>(source, 48);
+
+                        WriteUnaligned(destination, 32, lower);
+                        WriteUnaligned(destination, 48, upper);
+
+                        goto case 1;
+                    }
+
+                    case 1:
+                    {
+                        var lower = ReadUnaligned<Vector128<byte>>(source);
+                        var upper = ReadUnaligned<Vector128<byte>>(source, 16);
+
+                        WriteUnaligned(destination, lower);
+                        WriteUnaligned(destination, 16, upper);
+
+                        goto case 0;
+                    }
+
+                    case 0:
+                    {
+                        SmallCopy(destination, source, length);
+                        break;
+                    }
+                }
+            }
         }
 
         /// <summary>Frees an allocated chunk of unmanaged memory.</summary>

--- a/sources/Core/Utilities/MemoryUtilities.cs
+++ b/sources/Core/Utilities/MemoryUtilities.cs
@@ -1,9 +1,9 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using static TerraFX.Interop.Mimalloc;
 using static TerraFX.Runtime.Configuration;
 using static TerraFX.Utilities.AssertionUtilities;
@@ -233,35 +233,61 @@ namespace TerraFX.Utilities
 
         /// <summary>Clears a destination buffer to zero.</summary>
         /// <param name="destination">The destination buffer to clear.</param>
-        /// <param name="length">The length, in bytes, of <paramref name="destination" />.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
-        public static void Clear(void* destination, nuint length)
+        /// <param name="size">The size, in bytes, of <paramref name="destination" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="size" /> is not <c>zero</c>.</exception>
+        public static void Clear(void* destination, nuint size)
         {
-            if (length == 0)
+            if (size == 0)
             {
                 return;
             }
             ThrowIfNull(destination, nameof(destination));
 
-            ClearUnsafe(destination, length);
+            ClearUnsafe(destination, size);
         }
 
         /// <summary>Clears a destination buffer to zero.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of <paramref name="destination" />.</typeparam>
         /// <param name="destination">The destination buffer to clear.</param>
-        /// <param name="length">The length, in bytes, of <paramref name="destination" />.</param>
-        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> is not <c>null</c> if <paramref name="length" /> is not <c>zero</c>.</remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ClearUnsafe(void* destination, nuint length)
-        {
-            Assert(AssertionsEnabled && ((destination != null) || (length == 0)));
+        public static void Clear<T>(void* destination)
+            where T : unmanaged => Clear(destination, SizeOf<T>());
 
-            if (length <= 32)
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="destination" />.</typeparam>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <param name="count">The count of elements in <paramref name="destination" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="count" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ClearArray<T>(void* destination, nuint count)
+            where T : unmanaged => Clear(destination, count * SizeOf<T>());
+
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="destination" />.</typeparam>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <param name="count">The count of elements in <paramref name="destination" />.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> is not <c>null</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ClearArrayUnsafe<T>(void* destination, nuint count)
+            where T : unmanaged => ClearUnsafe(destination, count * SizeOf<T>());
+
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <param name="size">The size, in bytes, of <paramref name="destination" />.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> is not <c>null</c> if <paramref name="size" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ClearUnsafe(void* destination, nuint size)
+        {
+            Assert(AssertionsEnabled && ((destination != null) || (size == 0)));
+
+            if (size <= 32)
             {
-                SmallClear(destination, length);
+                SmallClear(destination, size);
             }
             else
             {
-                LargeClear(destination, length);
+                LargeClear(destination, size);
             }
 
             static void LargeClear(void* destination, nuint length)
@@ -427,15 +453,23 @@ namespace TerraFX.Utilities
             }
         }
 
+        /// <summary>Clears a destination buffer to zero.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="destination" />.</typeparam>
+        /// <param name="destination">The destination buffer to clear.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> is not <c>null</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ClearUnsafe<T>(void* destination)
+            where T : unmanaged => ClearUnsafe(destination, SizeOf<T>());
+
         /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
         /// <param name="destination">The destination buffer to which memory should be copied.</param>
         /// <param name="source">The source buffer from which memory is copied.</param>
-        /// <param name="length">The length, in bytes, to be copied.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
-        public static void Copy(void* destination, void* source, nuint length)
+        /// <param name="size">The size, in bytes, to be copied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="size" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="size" /> is not <c>zero</c>.</exception>
+        public static void Copy(void* destination, void* source, nuint size)
         {
-            if (length == 0)
+            if (size == 0)
             {
                 return;
             }
@@ -443,7 +477,7 @@ namespace TerraFX.Utilities
             ThrowIfNull(source, nameof(source));
             ThrowIfNull(destination, nameof(destination));
 
-            CopyUnsafe(destination, source, length);
+            CopyUnsafe(destination, source, size);
         }
 
         /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
@@ -459,6 +493,50 @@ namespace TerraFX.Utilities
             ThrowIfNotInInsertBounds(sourceLength, destinationLength, nameof(sourceLength), nameof(destinationLength));
             Copy(destination, source, sourceLength);
         }
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of <paramref name="source" />.</typeparam>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Copy<T>(void* destination, void* source)
+            where T : unmanaged => Copy(destination, source, SizeOf<T>());
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="source" />.</typeparam>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="count">The count of elements in <paramref name="source" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="count" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="count" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyArray<T>(void* destination, void* source, nuint count)
+            where T : unmanaged => Copy(destination, source, count * SizeOf<T>());
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="source" /> and <paramref name="destination" />.</typeparam>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="destinationCount">The count of elements in <paramref name="destination" />.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="sourceCount">The count of elements in <paramref name="source" />.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="sourceCount" /> is greater than <paramref name="destinationCount" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <c>null</c> and <paramref name="sourceCount" /> is not <c>zero</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="destination" /> is <c>null</c> and <paramref name="destinationCount" /> is not <c>zero</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyArray<T>(void* destination, nuint destinationCount, void* source, nuint sourceCount)
+            where T : unmanaged => Copy(destination, destinationCount * SizeOf<T>(), source, sourceCount * SizeOf<T>());
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of the elements in <paramref name="source" />.</typeparam>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <param name="count">The count of elements in <paramref name="source" />.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> and <paramref name="source" /> are not <c>null</c> if <paramref name="count" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyArrayUnsafe<T>(void* destination, void* source, nuint count)
+            where T : unmanaged => CopyUnsafe(destination, source, count * SizeOf<T>());
 
         /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
         /// <param name="destination">The destination buffer to which memory should be copied.</param>
@@ -752,6 +830,15 @@ namespace TerraFX.Utilities
                 }
             }
         }
+
+        /// <summary>Copies memory from a source buffer to a destination buffer.</summary>
+        /// <typeparam name="T">The type used to compute the size, in bytes, of <paramref name="source" />.</typeparam>
+        /// <param name="destination">The destination buffer to which memory should be copied.</param>
+        /// <param name="source">The source buffer from which memory is copied.</param>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="destination" /> and <paramref name="source" /> are not <c>null</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyUnsafe<T>(void* destination, void* source)
+            where T : unmanaged => CopyUnsafe(destination, source, SizeOf<T>());
 
         /// <summary>Frees an allocated chunk of unmanaged memory.</summary>
         /// <param name="address">The address to an allocated chunk of memory to free</param>
@@ -1098,6 +1185,59 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T* TryAllocateArray<T>(nuint count, nuint alignment, nuint offset, bool zero = false)
             where T : unmanaged => zero ? mi_calloc_aligned_at_tp<T>(count, alignment, offset) : mi_mallocn_aligned_at_tp<T>(count, alignment, offset);
+
+        /// <summary>Tries to get the index of a given item in the specified buffer.</summary>
+        /// <typeparam name="T">The type of the item to try and get the index for.</typeparam>
+        /// <param name="items">The items to search for <paramref name="item" />.</param>
+        /// <param name="length">The length, in items, of <paramref name="items" />.</param>
+        /// <param name="item">The item to try and get the index for.</param>
+        /// <param name="index">When <c>true</c> is returned, this contains the index of <paramref name="item" />.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in <paramref name="items" />; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="items" /> is <c>null</c> and <paramref name="length" /> is not <c>zero</c>.</exception>
+        public static bool TryGetIndexOf<T>(T* items, nuint length, T item, out nuint index)
+            where T : unmanaged
+        {
+            if (length == 0)
+            {
+                index = 0;
+                return false;
+            }
+            ThrowIfNull(items, nameof(items));
+
+            return TryGetIndexOfUnsafe(items, length, item, out index);
+        }
+
+        /// <summary>Tries to get the index of a given item in the specified buffer.</summary>
+        /// <typeparam name="T">The type of the item to try and get the index for.</typeparam>
+        /// <param name="items">The items to search for <paramref name="item" />.</param>
+        /// <param name="length">The length, in items, of <paramref name="items" />.</param>
+        /// <param name="item">The item to try and get the index for.</param>
+        /// <param name="index">When <c>true</c> is returned, this contains the index of <paramref name="item" />.</param>
+        /// <returns><c>true</c> if <paramref name="item" /> was found in <paramref name="items" />; otherwise, <c>false</c>.</returns>
+        /// <remarks>This method is unsafe because it does not validate <paramref name="items" /> is not <c>null</c> if <paramref name="length" /> is not <c>zero</c>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetIndexOfUnsafe<T>(T* items, nuint length, T item, out nuint index)
+            where T : unmanaged
+        {
+            return SoftwareFallback(items, length, item, out index);
+
+            static bool SoftwareFallback(T* items, nuint length, T item, out nuint index)
+            {
+                var equalityComparer = EqualityComparer<T>.Default;
+
+                for (nuint i = 0; i < length; i++)
+                {
+                    if (equalityComparer.Equals(items[i], item))
+                    {
+                        index = i;
+                        return true;
+                    }
+                }
+
+                index = 0;
+                return false;
+            }
+        }
 
         /// <summary>Tries to reallocate a chunk of unmanaged memory.</summary>
         /// <param name="address">The address of an allocated chunk of memory to reallocate</param>

--- a/sources/Core/Utilities/MemoryUtilities.cs
+++ b/sources/Core/Utilities/MemoryUtilities.cs
@@ -548,7 +548,7 @@ namespace TerraFX.Utilities
         {
             Assert(AssertionsEnabled && ((destination != null) || (length == 0)));
             Assert(AssertionsEnabled && ((source != null) || (length == 0)));
-            Assert(AssertionsEnabled && (destination != source));
+            Assert(AssertionsEnabled && ((destination != source) || (length == 0)));
             
             if (length <= 32)
             {

--- a/sources/Core/Utilities/UnsafeUtilities.cs
+++ b/sources/Core/Utilities/UnsafeUtilities.cs
@@ -129,8 +129,28 @@ namespace TerraFX.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T NullRef<T>() => ref Unsafe.NullRef<T>();
 
+        /// <inheritdoc cref="Unsafe.ReadUnaligned{T}(void*)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadUnaligned<T>(void* source)
+            where T : unmanaged => Unsafe.ReadUnaligned<T>(source);
+
+        /// <inheritdoc cref="Unsafe.ReadUnaligned{T}(void*)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadUnaligned<T>(void* source, nuint offset)
+            where T : unmanaged => Unsafe.ReadUnaligned<T>((void*)((nuint)source + offset));
+
         /// <inheritdoc cref="Unsafe.SizeOf{T}" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint SizeOf<T>() => unchecked((uint)Unsafe.SizeOf<T>());
+
+        /// <inheritdoc cref="Unsafe.WriteUnaligned{T}(void*, T)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteUnaligned<T>(void* source, T value)
+            where T : unmanaged => Unsafe.WriteUnaligned<T>(source, value);
+
+        /// <inheritdoc cref="Unsafe.WriteUnaligned{T}(void*, T)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteUnaligned<T>(void* source, nuint offset, T value)
+            where T : unmanaged => Unsafe.WriteUnaligned((void*)((nuint)source + offset), value);
     }
 }

--- a/sources/Core/ValueLazy`1.DebugView.cs
+++ b/sources/Core/ValueLazy`1.DebugView.cs
@@ -9,18 +9,18 @@ namespace TerraFX
     {
         internal sealed class DebugView
         {
-            private readonly ValueLazy<T> _value;
+            private readonly ValueLazy<T> _lazy;
 
-            public DebugView(ValueLazy<T> value)
+            public DebugView(ValueLazy<T> lazy)
             {
-                _value = value;
+                _lazy = lazy;
             }
 
-            public bool IsValueCreated => _value.IsValueCreated;
+            public bool IsValueCreated => _lazy.IsValueCreated;
 
-            public bool IsValueFaulted => _value.IsValueFaulted;
+            public bool IsValueFaulted => _lazy.IsValueFaulted;
 
-            public T? Value => _value.ValueOrDefault;
+            public T? Value => _lazy.ValueOrDefault;
         }
     }
 }

--- a/tests/Core/Collections/UnmanagedValueList`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueList`1Tests.cs
@@ -616,6 +616,55 @@ namespace TerraFX.UnitTests.Collections
             }
         }
 
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.TrimExcess" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                valueList.TrimExcess();
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+
+                valueList.Add(4);
+                valueList.Add(5);
+
+                valueList.TrimExcess();
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)5)
+                );
+
+                valueList.EnsureCapacity(15);
+                valueList.TrimExcess(0.3f);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)15)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                valueList.TrimExcess();
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
         /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.TryGetIndexOf(T, out nuint)" /> method.</summary>
         [Test]
         public static void TryGetIndexOfTest()

--- a/tests/Core/Collections/UnmanagedValueList`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueList`1Tests.cs
@@ -1,0 +1,655 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="UnmanagedValueList{T}" /> struct.</summary>
+    public static class UnmanagedValueListTests
+    {
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.UnmanagedValueList()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            using var valueList = new UnmanagedValueList<int>();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo((nuint)0)
+                   .And.Count.EqualTo((nuint)0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.UnmanagedValueList(nuint, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorNUIntNUIntTest()
+        {
+            using (var valueList = new UnmanagedValueList<int>(5))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(5, 2))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(5, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueList = new UnmanagedValueList<int>(0, 2))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(0, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.UnmanagedValueList(UnmanagedReadOnlySpan{T}, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedReadOnlySpanNUIntTest()
+        {
+            using var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array.AsSpan()))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(array.AsSpan(), 2))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(array.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueList = new UnmanagedValueList<int>(UnmanagedArray<int>.Empty.AsSpan()))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(UnmanagedArray<int>.Empty.AsSpan(), 2))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(UnmanagedArray<int>.Empty.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueList = new UnmanagedValueList<int>(new UnmanagedArray<int>().AsSpan()))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(new UnmanagedArray<int>().AsSpan(), 2))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(new UnmanagedArray<int>().AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.UnmanagedValueList(UnmanagedArray{T}, bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedArrayBooleanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: false))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(UnmanagedArray<int>.Empty, takeOwnership: false))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>(UnmanagedArray<int>.Empty, takeOwnership: true))
+            {
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueList<int>(new UnmanagedArray<int>(), takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new UnmanagedValueList<int>(new UnmanagedArray<int>(), takeOwnership: true),
+                Throws.ArgumentNullException
+                        .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}" /> indexer.</summary>
+        [Test]
+        public static void GetItemTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueList[1],
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueList[3],
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)3)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList[0],
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)0)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}" /> indexer.</summary>
+        [Test]
+        public static void SetItemTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var disposableList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                var valueList = disposableList;
+
+                Assert.That(() => valueList[1] = 4,
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueList[3] = 4,
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)3)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+
+            using (var disposableList = new UnmanagedValueList<int>())
+            {
+                var valueList = disposableList;
+
+                Assert.That(() => valueList[0] = 4,
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)0)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.Add(T)" /> method.</summary>
+        [Test]
+        public static void AddTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                valueList.Add(4);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                Assert.That(() => valueList[3],
+                    Is.EqualTo(4)
+                );
+
+                valueList.Add(5);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+
+                Assert.That(() => valueList[4],
+                    Is.EqualTo(5)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                valueList.Add(6);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)1)
+                       .And.Count.EqualTo((nuint)1)
+                );
+
+                Assert.That(() => valueList[0],
+                    Is.EqualTo(6)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                valueList.Clear();
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                valueList.Clear();
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueList.Contains(1),
+                    Is.True
+                );
+
+                Assert.That(() => valueList.Contains(4),
+                    Is.False
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList.Contains(0),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.CopyTo(UnmanagedSpan{T})" /> method.</summary>
+        [Test]
+        public static void CopyToUnmanagedSpanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                using (var destination = new UnmanagedArray<int>(3))
+                {
+                    valueList.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(3)
+                    );
+                }
+
+                using (var destination = new UnmanagedArray<int>(6))
+                {
+                    valueList.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(3)
+                    );
+
+                    Assert.That(() => destination[3],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[4],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[5],
+                        Is.EqualTo(0)
+                    );
+                }
+
+                Assert.That(() => valueList.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)3)
+                          .And.Property("ParamName").EqualTo("Count")
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.Nothing
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.EnsureCapacity(nuint)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using var valueList = new UnmanagedValueList<int>(array);
+            valueList.EnsureCapacity(0);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueList.EnsureCapacity(3);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueList.EnsureCapacity(4);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo((nuint)6)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueList.EnsureCapacity(16);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo((nuint)16)
+                   .And.Count.EqualTo((nuint)3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.Insert(nuint, T)" /> method.</summary>
+        [Test]
+        public static void InsertTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                valueList.Insert(3, 4);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                Assert.That(() => valueList[3],
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueList.Insert(5, 5),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)5)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                valueList.Insert(0, 1);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)1)
+                       .And.Count.EqualTo((nuint)1)
+                );
+
+                Assert.That(() => valueList[0],
+                    Is.EqualTo(1)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.Remove(T)" /> method.</summary>
+        [Test]
+        public static void RemoveTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+
+                Assert.That(() => valueList.Remove(1),
+                    Is.True
+                );
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)2)
+                );
+
+                Assert.That(() => valueList[0],
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueList[1],
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueList.Remove(0),
+                    Is.False
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList.Remove(0),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.RemoveAt(nuint)" /> method.</summary>
+        [Test]
+        public static void RemoveAtTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                valueList.RemoveAt(0);
+
+                Assert.That(() => valueList,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)2)
+                );
+
+                Assert.That(() => valueList[0],
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueList[1],
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueList.RemoveAt(2),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)2)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList.RemoveAt(0),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)0)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueList{T}.TryGetIndexOf(T, out nuint)" /> method.</summary>
+        [Test]
+        public static void TryGetIndexOfTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
+            {
+                var result = valueList.TryGetIndexOf(1, out var index);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => index,
+                    Is.EqualTo((nuint)0)
+                );
+
+                Assert.That(() => valueList.TryGetIndexOf(4, out _),
+                    Is.False
+                );
+            }
+
+            using (var valueList = new UnmanagedValueList<int>())
+            {
+                Assert.That(() => valueList.TryGetIndexOf(0, out _),
+                    Is.False
+                );
+            }
+        }
+    }
+}

--- a/tests/Core/Collections/UnmanagedValueList`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueList`1Tests.cs
@@ -542,7 +542,6 @@ namespace TerraFX.UnitTests.Collections
 
             using (var valueList = new UnmanagedValueList<int>(array, takeOwnership: true))
             {
-
                 Assert.That(() => valueList.Remove(1),
                     Is.True
                 );

--- a/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
@@ -1,0 +1,737 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="UnmanagedValueQueue{T}" /> struct.</summary>
+    public static class UnmanagedValueQueueTests
+    {
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.UnmanagedValueQueue()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            using var valueQueue = new UnmanagedValueQueue<int>();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo((nuint)0)
+                   .And.Count.EqualTo((nuint)0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.UnmanagedValueQueue(nuint, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorNUIntNUIntTest()
+        {
+            using (var valueQueue = new UnmanagedValueQueue<int>(5))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(5, 2))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(5, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(0, 2))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(0, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.UnmanagedValueQueue(UnmanagedReadOnlySpan{T}, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedReadOnlySpanNUIntTest()
+        {
+            using var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array.AsSpan()))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array.AsSpan(), 2))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(array.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(UnmanagedArray<int>.Empty.AsSpan()))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(UnmanagedArray<int>.Empty.AsSpan(), 2))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(UnmanagedArray<int>.Empty.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(new UnmanagedArray<int>().AsSpan()))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(new UnmanagedArray<int>().AsSpan(), 2))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(new UnmanagedArray<int>().AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.UnmanagedValueQueue(UnmanagedArray{T}, bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedArrayBooleanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(UnmanagedArray<int>.Empty, takeOwnership: false))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(UnmanagedArray<int>.Empty, takeOwnership: true))
+            {
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueQueue<int>(new UnmanagedArray<int>(), takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new UnmanagedValueQueue<int>(new UnmanagedArray<int>(), takeOwnership: true),
+                Throws.ArgumentNullException
+                        .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                valueQueue.Clear();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                _ = valueQueue.Dequeue();
+
+                valueQueue.Enqueue(4);
+                valueQueue.Clear();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                _ = valueQueue.Dequeue();
+
+                valueQueue.Enqueue(4);
+                valueQueue.Enqueue(5);
+
+                valueQueue.Clear();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                valueQueue.Clear();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueQueue.Contains(1),
+                    Is.True
+                );
+
+                Assert.That(() => valueQueue.Contains(4),
+                    Is.False
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(4);
+
+                Assert.That(() => valueQueue.Contains(1),
+                    Is.False
+                );
+
+                Assert.That(() => valueQueue.Contains(4),
+                    Is.True
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(5);
+                valueQueue.Enqueue(6);
+
+                Assert.That(() => valueQueue.Contains(2),
+                    Is.False
+                );
+
+                Assert.That(() => valueQueue.Contains(5),
+                    Is.True
+                );
+
+                Assert.That(() => valueQueue.Contains(6),
+                    Is.True
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.Contains(0),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.CopyTo(UnmanagedSpan{T})" /> method.</summary>
+        [Test]
+        public static void CopyToUnmanagedSpanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                using (var destination = new UnmanagedArray<int>(3))
+                {
+                    valueQueue.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(3)
+                    );
+
+                    _ = valueQueue.Dequeue();
+                    valueQueue.Enqueue(4);
+
+                    valueQueue.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(3)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(4)
+                    );
+                }
+
+                using (var destination = new UnmanagedArray<int>(6))
+                {
+                    valueQueue.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(3)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(4)
+                    );
+
+                    Assert.That(() => destination[3],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[4],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[5],
+                        Is.EqualTo(0)
+                    );
+
+                    _ = valueQueue.Dequeue();
+                    valueQueue.Enqueue(5);
+                    valueQueue.Enqueue(6);
+
+                    valueQueue.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(3)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(4)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(5)
+                    );
+
+                    Assert.That(() => destination[3],
+                        Is.EqualTo(6)
+                    );
+
+                    Assert.That(() => destination[4],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[5],
+                        Is.EqualTo(0)
+                    );
+                }
+
+                Assert.That(() => valueQueue.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)4)
+                          .And.Property("ParamName").EqualTo("Count")
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.Nothing
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.Dequeue()" /> method.</summary>
+        [Test]
+        public static void DequeueTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Throws.InvalidOperationException
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(4);
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(2)
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(5);
+                valueQueue.Enqueue(6);
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(5)
+                );
+
+                Assert.That(() => valueQueue.Dequeue(),
+                    Is.EqualTo(6)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.Dequeue(),
+                    Throws.InvalidOperationException
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.Enqueue(T)" /> method.</summary>
+        [Test]
+        public static void EnqueueTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                valueQueue.Enqueue(4);
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                valueQueue.Enqueue(5);
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(5);
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                valueQueue.Enqueue(6);
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)1)
+                       .And.Count.EqualTo((nuint)1)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.EnsureCapacity(nuint)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using var valueQueue = new UnmanagedValueQueue<int>(array);
+            valueQueue.EnsureCapacity(0);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueQueue.EnsureCapacity(3);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueQueue.EnsureCapacity(4);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo((nuint)6)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueQueue.EnsureCapacity(16);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo((nuint)16)
+                   .And.Count.EqualTo((nuint)3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Peek()" /> method.</summary>
+        [Test]
+        public static void PeekTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueQueue.Peek(),
+                    Is.EqualTo(1)
+                );
+
+                valueQueue.Enqueue(4);
+
+                Assert.That(() => valueQueue.Peek(),
+                    Is.EqualTo(1)
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(5);
+
+                Assert.That(() => valueQueue.Peek(),
+                    Is.EqualTo(2)
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(6);
+                valueQueue.Enqueue(7);
+
+                Assert.That(() => valueQueue.Peek(),
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.Peek(),
+                    Throws.InvalidOperationException
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
+        [Test]
+        public static void TryDequeueTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                var result = valueQueue.TryDequeue(out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                valueQueue.Enqueue(4);
+                result = valueQueue.TryDequeue(out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)2)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.TryDequeue(out _),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryPeek(out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                var result = valueQueue.TryPeek(out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                valueQueue.Enqueue(4);
+                result = valueQueue.TryPeek(out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.TryPeek(out _),
+                    Is.False
+                );
+            }
+        }
+    }
+}

--- a/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
@@ -640,6 +640,71 @@ namespace TerraFX.UnitTests.Collections
             }
         }
 
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.Peek(nuint)" /> method.</summary>
+        [Test]
+        public static void PeekNUIntTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueQueue.Peek(0),
+                    Is.EqualTo(1)
+                );
+
+                valueQueue.Enqueue(4);
+
+                Assert.That(() => valueQueue.Peek(0),
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueQueue.Peek(3),
+                    Is.EqualTo(4)
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(5);
+
+                Assert.That(() => valueQueue.Peek(0),
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueQueue.Peek(1),
+                    Is.EqualTo(3)
+                );
+
+                _ = valueQueue.Dequeue();
+                valueQueue.Enqueue(6);
+                valueQueue.Enqueue(7);
+
+                Assert.That(() => valueQueue.Peek(0),
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueQueue.Peek(2),
+                    Is.EqualTo(5)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.Peek(0),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)0)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+        }
+
         /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
         [Test]
         public static void TryDequeueTest()
@@ -729,6 +794,63 @@ namespace TerraFX.UnitTests.Collections
             using (var valueQueue = new UnmanagedValueQueue<int>())
             {
                 Assert.That(() => valueQueue.TryPeek(out _),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.TryPeek(nuint, out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekNUIntTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                var result = valueQueue.TryPeek(0, out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                valueQueue.Enqueue(4);
+                result = valueQueue.TryPeek(0, out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                result = valueQueue.TryPeek(3, out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                Assert.That(() => valueQueue.TryPeek(0, out _),
                     Is.False
                 );
             }

--- a/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueQueue`1Tests.cs
@@ -705,6 +705,71 @@ namespace TerraFX.UnitTests.Collections
             }
         }
 
+        /// <summary>Provides validation of the <see cref="UnmanagedValueQueue{T}.TrimExcess" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                valueQueue.TrimExcess();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: false))
+            {
+                _ = valueQueue.Dequeue();
+
+                valueQueue.Enqueue(4);
+                valueQueue.TrimExcess();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>(array, takeOwnership: true))
+            {
+                valueQueue.Enqueue(4);
+                valueQueue.Enqueue(5);
+
+                valueQueue.TrimExcess();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)5)
+                );
+
+                valueQueue.EnsureCapacity(15);
+                valueQueue.TrimExcess(0.3f);
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)15)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueQueue = new UnmanagedValueQueue<int>())
+            {
+                valueQueue.TrimExcess();
+
+                Assert.That(() => valueQueue,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
         /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
         [Test]
         public static void TryDequeueTest()

--- a/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
@@ -705,6 +705,71 @@ namespace TerraFX.UnitTests.Collections
             }
         }
 
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.TrimExcess" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                valueStack.TrimExcess();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                _ = valueStack.Pop();
+
+                valueStack.Push(4);
+                valueStack.TrimExcess();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                valueStack.Push(4);
+                valueStack.Push(5);
+
+                valueStack.TrimExcess();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)5)
+                );
+
+                valueStack.EnsureCapacity(15);
+                valueStack.TrimExcess(0.3f);
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)15)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                valueStack.TrimExcess();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
         /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPeek(out T)" /> method.</summary>
         [Test]
         public static void TryPeekTest()

--- a/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
@@ -1,0 +1,737 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="UnmanagedValueStack{T}" /> struct.</summary>
+    public static class UnmanagedValueStackTests
+    {
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.UnmanagedValueStack()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            using var valueStack = new UnmanagedValueStack<int>();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo((nuint)0)
+                   .And.Count.EqualTo((nuint)0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.UnmanagedValueStack(nuint, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorNUIntNUIntTest()
+        {
+            using (var valueStack = new UnmanagedValueStack<int>(5))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(5, 2))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)5)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(5, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueStack = new UnmanagedValueStack<int>(0, 2))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(0, 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.UnmanagedValueStack(UnmanagedReadOnlySpan{T}, nuint)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedReadOnlySpanNUIntTest()
+        {
+            using var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array.AsSpan()))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array.AsSpan(), 2))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(array.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueStack = new UnmanagedValueStack<int>(UnmanagedArray<int>.Empty.AsSpan()))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(UnmanagedArray<int>.Empty.AsSpan(), 2))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(UnmanagedArray<int>.Empty.AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+
+            using (var valueStack = new UnmanagedValueStack<int>(new UnmanagedArray<int>().AsSpan()))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(new UnmanagedArray<int>().AsSpan(), 2))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(new UnmanagedArray<int>().AsSpan(), 3),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                        .And.Property("ActualValue").EqualTo((nuint)3)
+                        .And.Property("ParamName").EqualTo("alignment")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.UnmanagedValueStack(UnmanagedArray{T}, bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorUnmanagedArrayBooleanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(UnmanagedArray<int>.Empty, takeOwnership: false))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(UnmanagedArray<int>.Empty, takeOwnership: true))
+            {
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            Assert.That(() => new UnmanagedValueStack<int>(new UnmanagedArray<int>(), takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new UnmanagedValueStack<int>(new UnmanagedArray<int>(), takeOwnership: true),
+                Throws.ArgumentNullException
+                        .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                valueStack.Clear();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                _ = valueStack.Pop();
+
+                valueStack.Push(4);
+                valueStack.Clear();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                _ = valueStack.Pop();
+
+                valueStack.Push(4);
+                valueStack.Push(5);
+
+                valueStack.Clear();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                valueStack.Clear();
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)0)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueStack.Contains(1),
+                    Is.True
+                );
+
+                Assert.That(() => valueStack.Contains(4),
+                    Is.False
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(4);
+
+                Assert.That(() => valueStack.Contains(3),
+                    Is.False
+                );
+
+                Assert.That(() => valueStack.Contains(4),
+                    Is.True
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(5);
+                valueStack.Push(6);
+
+                Assert.That(() => valueStack.Contains(4),
+                    Is.False
+                );
+
+                Assert.That(() => valueStack.Contains(5),
+                    Is.True
+                );
+
+                Assert.That(() => valueStack.Contains(6),
+                    Is.True
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.Contains(0),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.CopyTo(UnmanagedSpan{T})" /> method.</summary>
+        [Test]
+        public static void CopyToUnmanagedSpanTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                using (var destination = new UnmanagedArray<int>(3))
+                {
+                    valueStack.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(3)
+                    );
+
+                    _ = valueStack.Pop();
+                    valueStack.Push(4);
+
+                    valueStack.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(4)
+                    );
+                }
+
+                using (var destination = new UnmanagedArray<int>(6))
+                {
+                    valueStack.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(4)
+                    );
+
+                    Assert.That(() => destination[3],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[4],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[5],
+                        Is.EqualTo(0)
+                    );
+
+                    _ = valueStack.Pop();
+                    valueStack.Push(5);
+                    valueStack.Push(6);
+
+                    valueStack.CopyTo(destination);
+
+                    Assert.That(() => destination[0],
+                        Is.EqualTo(1)
+                    );
+
+                    Assert.That(() => destination[1],
+                        Is.EqualTo(2)
+                    );
+
+                    Assert.That(() => destination[2],
+                        Is.EqualTo(5)
+                    );
+
+                    Assert.That(() => destination[3],
+                        Is.EqualTo(6)
+                    );
+
+                    Assert.That(() => destination[4],
+                        Is.EqualTo(0)
+                    );
+
+                    Assert.That(() => destination[5],
+                        Is.EqualTo(0)
+                    );
+                }
+
+                Assert.That(() => valueStack.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)4)
+                          .And.Property("ParamName").EqualTo("Count")
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.CopyTo(UnmanagedArray<int>.Empty),
+                    Throws.Nothing
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.EnsureCapacity(nuint)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using var valueStack = new UnmanagedValueStack<int>(array);
+            valueStack.EnsureCapacity(0);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueStack.EnsureCapacity(3);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo((nuint)3)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueStack.EnsureCapacity(4);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo((nuint)6)
+                   .And.Count.EqualTo((nuint)3)
+            );
+
+            valueStack.EnsureCapacity(16);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo((nuint)16)
+                   .And.Count.EqualTo((nuint)3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Peek()" /> method.</summary>
+        [Test]
+        public static void PeekTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueStack.Peek(),
+                    Is.EqualTo(3)
+                );
+
+                valueStack.Push(4);
+
+                Assert.That(() => valueStack.Peek(),
+                    Is.EqualTo(4)
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(5);
+
+                Assert.That(() => valueStack.Peek(),
+                    Is.EqualTo(5)
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(6);
+                valueStack.Push(7);
+
+                Assert.That(() => valueStack.Peek(),
+                    Is.EqualTo(7)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.Peek(),
+                    Throws.InvalidOperationException
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Pop()" /> method.</summary>
+        [Test]
+        public static void PopTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(2)
+                );
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueStack.Pop(),
+                    Throws.InvalidOperationException
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                _ = valueStack.Pop();
+                valueStack.Push(4);
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(4)
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(5);
+                valueStack.Push(6);
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(6)
+                );
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(5)
+                );
+
+                Assert.That(() => valueStack.Pop(),
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)0)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.Pop(),
+                    Throws.InvalidOperationException
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Push(T)" /> method.</summary>
+        [Test]
+        public static void PushTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: false))
+            {
+                valueStack.Push(4);
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+
+                valueStack.Push(5);
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                _ = valueStack.Pop();
+                valueStack.Push(5);
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)3)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                valueStack.Push(6);
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)1)
+                       .And.Count.EqualTo((nuint)1)
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPeek(out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                var result = valueStack.TryPeek(out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(3)
+                );
+
+                valueStack.Push(4);
+                result = valueStack.TryPeek(out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.TryPeek(out _),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPop(out T)" /> method.</summary>
+        [Test]
+        public static void TryPopTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                var result = valueStack.TryPop(out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(3)
+                );
+
+                valueStack.Push(4);
+                result = valueStack.TryPop(out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)3)
+                       .And.Count.EqualTo((nuint)2)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.TryPop(out _),
+                    Is.False
+                );
+            }
+        }
+    }
+}

--- a/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
+++ b/tests/Core/Collections/UnmanagedValueStack`1Tests.cs
@@ -518,6 +518,71 @@ namespace TerraFX.UnitTests.Collections
             }
         }
 
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Peek(nuint)" /> method.</summary>
+        [Test]
+        public static void PeekNUIntTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                Assert.That(() => valueStack.Peek(0),
+                    Is.EqualTo(3)
+                );
+
+                valueStack.Push(4);
+
+                Assert.That(() => valueStack.Peek(0),
+                    Is.EqualTo(4)
+                );
+
+                Assert.That(() => valueStack.Peek(3),
+                    Is.EqualTo(1)
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(5);
+
+                Assert.That(() => valueStack.Peek(0),
+                    Is.EqualTo(5)
+                );
+
+                Assert.That(() => valueStack.Peek(1),
+                    Is.EqualTo(3)
+                );
+
+                _ = valueStack.Pop();
+                valueStack.Push(6);
+                valueStack.Push(7);
+
+                Assert.That(() => valueStack.Peek(0),
+                    Is.EqualTo(7)
+                );
+
+                Assert.That(() => valueStack.Peek(2),
+                    Is.EqualTo(3)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)5)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.Peek(0),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                          .And.Property("ActualValue").EqualTo((nuint)0)
+                          .And.Property("ParamName").EqualTo("index")
+                );
+            }
+        }
+
         /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.Pop()" /> method.</summary>
         [Test]
         public static void PopTest()
@@ -682,6 +747,63 @@ namespace TerraFX.UnitTests.Collections
             using (var valueStack = new UnmanagedValueStack<int>())
             {
                 Assert.That(() => valueStack.TryPeek(out _),
+                    Is.False
+                );
+            }
+        }
+
+        /// <summary>Provides validation of the <see cref="UnmanagedValueStack{T}.TryPeek(nuint, out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekNUIntTest()
+        {
+            var array = new UnmanagedArray<int>(3);
+
+            array[0] = 1;
+            array[1] = 2;
+            array[2] = 3;
+
+            using (var valueStack = new UnmanagedValueStack<int>(array, takeOwnership: true))
+            {
+                var result = valueStack.TryPeek(0, out var value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(3)
+                );
+
+                valueStack.Push(4);
+                result = valueStack.TryPeek(0, out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(4)
+                );
+
+                result = valueStack.TryPeek(3, out value);
+
+                Assert.That(() => result,
+                    Is.True
+                );
+
+                Assert.That(() => value,
+                    Is.EqualTo(1)
+                );
+
+                Assert.That(() => valueStack,
+                    Has.Property("Capacity").EqualTo((nuint)6)
+                       .And.Count.EqualTo((nuint)4)
+                );
+            }
+
+            using (var valueStack = new UnmanagedValueStack<int>())
+            {
+                Assert.That(() => valueStack.TryPeek(0, out _),
                     Is.False
                 );
             }

--- a/tests/Core/Collections/ValueList`1Tests.cs
+++ b/tests/Core/Collections/ValueList`1Tests.cs
@@ -457,5 +457,44 @@ namespace TerraFX.UnitTests.Collections
                       .And.Property("ParamName").EqualTo("index")
             );
         }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.TrimExcess(float)" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.TrimExcess();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueList.Add(4);
+            valueList.Add(5);
+
+            valueList.TrimExcess();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueList.EnsureCapacity(15);
+            valueList.TrimExcess(0.3f);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(15)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueList = new ValueList<int>();
+            valueList.TrimExcess();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
     }
 }

--- a/tests/Core/Collections/ValueList`1Tests.cs
+++ b/tests/Core/Collections/ValueList`1Tests.cs
@@ -1,0 +1,461 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="ValueList{T}" /> struct.</summary>
+    public static class ValueListTests
+    {
+        /// <summary>Provides validation of the <see cref="ValueList{T}.ValueList()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            Assert.That(() => new ValueList<int>(),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.ValueList(int)" /> constructor.</summary>
+        [Test]
+        public static void CtorInt32Test()
+        {
+            Assert.That(() => new ValueList<int>(5),
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueList<int>(-5),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-5)
+                      .And.Property("ParamName").EqualTo("capacity")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.ValueList(IEnumerable{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorIEnumerableTest()
+        {
+            Assert.That(() => new ValueList<int>(Enumerable.Range(0, 3)),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueList<int>(Enumerable.Empty<int>()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueList<int>((null as IEnumerable<int>)!),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("source")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.ValueList(ReadOnlySpan{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorReadOnlySpanTest()
+        {
+            Assert.That(() => new ValueList<int>(new int[] { 1, 2, 3 }.AsSpan()),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueList<int>(Array.Empty<int>().AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueList<int>((null as int[]).AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.ValueList(T[], bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorArrayBooleanTest()
+        {
+            Assert.That(() => new ValueList<int>(new int[] { 1, 2, 3 }, takeOwnership: false),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueList<int>(new int[] { 1, 2, 3 }, takeOwnership: true),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueList<int>(Array.Empty<int>(), takeOwnership: false),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueList<int>(Array.Empty<int>(), takeOwnership: true),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueList<int>((null as int[])!, takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new ValueList<int>((null as int[])!, takeOwnership: true),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}" /> indexer.</summary>
+        [Test]
+        public static void GetItemTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueList[1],
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueList[-1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => valueList[3],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(3)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => new ValueList<int>()[0],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}" /> indexer.</summary>
+        [Test]
+        public static void SetItemTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueList[1] = 4,
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueList[-1] = 4,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => valueList[3] = 4,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(3)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList[0] = 4,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.Add(T)" /> method.</summary>
+        [Test]
+        public static void AddTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.Add(4);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            Assert.That(() => valueList[3],
+                Is.EqualTo(4)
+            );
+
+            valueList.Add(5);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            Assert.That(() => valueList[4],
+                Is.EqualTo(5)
+            );
+
+            valueList = new ValueList<int>();
+            valueList.Add(6);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(1)
+                   .And.Count.EqualTo(1)
+            );
+
+            Assert.That(() => valueList[0],
+                Is.EqualTo(6)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.Clear();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueList = new ValueList<int>();
+            valueList.Clear();
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueList.Contains(1),
+                Is.True
+            );
+
+            Assert.That(() => valueList.Contains(4),
+                Is.False
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList.Contains(0),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.CopyTo(Span{T})" /> method.</summary>
+        [Test]
+        public static void CopyToTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            var destination = new int[3];
+            valueList.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 3 })
+            );
+
+            destination = new int[6];
+            valueList.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 3, 0, 0, 0 })
+            );
+
+            Assert.That(() => valueList.CopyTo(Array.Empty<int>()),
+                Throws.ArgumentException
+                      .And.Property("ParamName").EqualTo("destination")
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList.CopyTo(Array.Empty<int>()),
+                Throws.Nothing
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.EnsureCapacity(int)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.EnsureCapacity(-1);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueList.EnsureCapacity(0);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueList.EnsureCapacity(3);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueList.EnsureCapacity(4);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueList.EnsureCapacity(16);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(16)
+                   .And.Count.EqualTo(3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.IndexOf(T)" /> method.</summary>
+        [Test]
+        public static void IndexOfTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueList.IndexOf(1),
+                Is.EqualTo(0)
+            );
+
+            Assert.That(() => valueList.IndexOf(4),
+                Is.EqualTo(-1)
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList.IndexOf(0),
+                Is.EqualTo(-1)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.Insert(int, T)" /> method.</summary>
+        [Test]
+        public static void InsertTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.Insert(3, 4);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            Assert.That(() => valueList[3],
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueList.Insert(5, 5),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(5)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            valueList = new ValueList<int>();
+            valueList.Insert(0, 1);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(1)
+                   .And.Count.EqualTo(1)
+            );
+
+            Assert.That(() => valueList[0],
+                Is.EqualTo(1)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.Remove(T)" /> method.</summary>
+        [Test]
+        public static void RemoveTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueList.Remove(1),
+                Is.True
+            );
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(2)
+            );
+
+            Assert.That(() => valueList[0],
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueList[1],
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueList.Remove(0),
+                Is.False
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList.Remove(0),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueList{T}.RemoveAt(int)" /> method.</summary>
+        [Test]
+        public static void RemoveAtTest()
+        {
+            var valueList = new ValueList<int>(new int[] { 1, 2, 3 });
+            valueList.RemoveAt(0);
+
+            Assert.That(() => valueList,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(2)
+            );
+
+            Assert.That(() => valueList[0],
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueList[1],
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueList.RemoveAt(-1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => valueList.RemoveAt(2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            valueList = new ValueList<int>();
+
+            Assert.That(() => valueList.RemoveAt(0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+    }
+}

--- a/tests/Core/Collections/ValueQueue`1Tests.cs
+++ b/tests/Core/Collections/ValueQueue`1Tests.cs
@@ -439,6 +439,63 @@ namespace TerraFX.UnitTests.Collections
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Peek(int)" /> method.</summary>
+        [Test]
+        public static void PeekInt32Test()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueQueue.Peek(0),
+                Is.EqualTo(1)
+            );
+
+            valueQueue.Enqueue(4);
+
+            Assert.That(() => valueQueue.Peek(0),
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueQueue.Peek(3),
+                Is.EqualTo(4)
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+
+            Assert.That(() => valueQueue.Peek(0),
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueQueue.Peek(1),
+                Is.EqualTo(3)
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(6);
+            valueQueue.Enqueue(7);
+
+            Assert.That(() => valueQueue.Peek(0),
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueQueue.Peek(2),
+                Is.EqualTo(5)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.Peek(0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
         [Test]
         public static void TryDequeueTest()
@@ -511,6 +568,54 @@ namespace TerraFX.UnitTests.Collections
             valueQueue = new ValueQueue<int>();
 
             Assert.That(() => valueQueue.TryPeek(out _),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryPeek(int, out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekInt32Test()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            var result = valueQueue.TryPeek(0, out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            valueQueue.Enqueue(4);
+            result = valueQueue.TryPeek(0, out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            result = valueQueue.TryPeek(3, out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.TryPeek(0, out _),
                 Is.False
             );
         }

--- a/tests/Core/Collections/ValueQueue`1Tests.cs
+++ b/tests/Core/Collections/ValueQueue`1Tests.cs
@@ -496,6 +496,59 @@ namespace TerraFX.UnitTests.Collections
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TrimExcess(float)" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            valueQueue.TrimExcess();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            _ = valueQueue.Dequeue();
+
+            valueQueue.Enqueue(4);
+            valueQueue.TrimExcess();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            valueQueue.Enqueue(4);
+            valueQueue.Enqueue(5);
+
+            valueQueue.TrimExcess();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueQueue.EnsureCapacity(15);
+            valueQueue.TrimExcess(0.3f);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(15)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueQueue = new ValueQueue<int>();
+            valueQueue.TrimExcess();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
         [Test]
         public static void TryDequeueTest()

--- a/tests/Core/Collections/ValueQueue`1Tests.cs
+++ b/tests/Core/Collections/ValueQueue`1Tests.cs
@@ -1,0 +1,518 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="ValueQueue{T}" /> struct.</summary>
+    public static class ValueQueueTests
+    {
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.ValueQueue()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            Assert.That(() => new ValueQueue<int>(),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.ValueQueue(int)" /> constructor.</summary>
+        [Test]
+        public static void CtorInt32Test()
+        {
+            Assert.That(() => new ValueQueue<int>(5),
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueQueue<int>(-5),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-5)
+                      .And.Property("ParamName").EqualTo("capacity")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.ValueQueue(IEnumerable{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorIEnumerableTest()
+        {
+            Assert.That(() => new ValueQueue<int>(Enumerable.Range(0, 3)),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueQueue<int>(Enumerable.Empty<int>()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueQueue<int>((null as IEnumerable<int>)!),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("source")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.ValueQueue(ReadOnlySpan{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorReadOnlySpanTest()
+        {
+            Assert.That(() => new ValueQueue<int>(new int[] { 1, 2, 3 }.AsSpan()),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueQueue<int>(Array.Empty<int>().AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueQueue<int>((null as int[]).AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.ValueQueue(T[], bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorArrayBooleanTest()
+        {
+            Assert.That(() => new ValueQueue<int>(new int[] { 1, 2, 3 }, takeOwnership: false),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueQueue<int>(new int[] { 1, 2, 3 }, takeOwnership: true),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueQueue<int>(Array.Empty<int>(), takeOwnership: false),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueQueue<int>(Array.Empty<int>(), takeOwnership: true),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueQueue<int>((null as int[])!, takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new ValueQueue<int>((null as int[])!, takeOwnership: true),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            valueQueue.Clear();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            _ = valueQueue.Dequeue();
+
+            valueQueue.Enqueue(4);
+            valueQueue.Clear();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            _ = valueQueue.Dequeue();
+
+            valueQueue.Enqueue(4);
+            valueQueue.Enqueue(5);
+
+            valueQueue.Clear();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueQueue = new ValueQueue<int>();
+            valueQueue.Clear();
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueQueue.Contains(1),
+                Is.True
+            );
+
+            Assert.That(() => valueQueue.Contains(4),
+                Is.False
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(4);
+
+            Assert.That(() => valueQueue.Contains(1),
+                Is.False
+            );
+
+            Assert.That(() => valueQueue.Contains(4),
+                Is.True
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+            valueQueue.Enqueue(6);
+
+            Assert.That(() => valueQueue.Contains(2),
+                Is.False
+            );
+
+            Assert.That(() => valueQueue.Contains(5),
+                Is.True
+            );
+
+            Assert.That(() => valueQueue.Contains(6),
+                Is.True
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.Contains(0),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.CopyTo(Span{T})" /> method.</summary>
+        [Test]
+        public static void CopyToTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            var destination = new int[3];
+            valueQueue.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 3 })
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(4);
+
+            valueQueue.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 2, 3, 4 })
+            );
+
+            destination = new int[6];
+            valueQueue.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 2, 3, 4, 0, 0, 0 })
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+            valueQueue.Enqueue(6);
+
+            valueQueue.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 3, 4, 5, 6, 0, 0 })
+            );
+
+            Assert.That(() => valueQueue.CopyTo(Array.Empty<int>()),
+                Throws.ArgumentException
+                      .And.Property("ParamName").EqualTo("destination")
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.CopyTo(Array.Empty<int>()),
+                Throws.Nothing
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Dequeue()" /> method.</summary>
+        [Test]
+        public static void DequeueTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Throws.InvalidOperationException
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(4);
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(2)
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+            valueQueue.Enqueue(6);
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(5)
+            );
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Is.EqualTo(6)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.Dequeue(),
+                Throws.InvalidOperationException
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Enqueue(T)" /> method.</summary>
+        [Test]
+        public static void EnqueueTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            valueQueue.Enqueue(4);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueQueue.Enqueue(5);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue = new ValueQueue<int>();
+            valueQueue.Enqueue(6);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(1)
+                   .And.Count.EqualTo(1)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.EnsureCapacity(int)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            valueQueue.EnsureCapacity(-1);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue.EnsureCapacity(0);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue.EnsureCapacity(3);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue.EnsureCapacity(4);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueQueue.EnsureCapacity(16);
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(16)
+                   .And.Count.EqualTo(3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.Peek()" /> method.</summary>
+        [Test]
+        public static void PeekTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueQueue.Peek(),
+                Is.EqualTo(1)
+            );
+
+            valueQueue.Enqueue(4);
+
+            Assert.That(() => valueQueue.Peek(),
+                Is.EqualTo(1)
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(5);
+
+            Assert.That(() => valueQueue.Peek(),
+                Is.EqualTo(2)
+            );
+
+            _ = valueQueue.Dequeue();
+            valueQueue.Enqueue(6);
+            valueQueue.Enqueue(7);
+
+            Assert.That(() => valueQueue.Peek(),
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.Peek(),
+                Throws.InvalidOperationException
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryDequeue(out T)" /> method.</summary>
+        [Test]
+        public static void TryDequeueTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            var result = valueQueue.TryDequeue(out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            valueQueue.Enqueue(4);
+            result = valueQueue.TryDequeue(out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(2)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.TryDequeue(out _),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueQueue{T}.TryPeek(out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekTest()
+        {
+            var valueQueue = new ValueQueue<int>(new int[] { 1, 2, 3 });
+            var result = valueQueue.TryPeek(out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            valueQueue.Enqueue(4);
+            result = valueQueue.TryPeek(out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueQueue,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueQueue = new ValueQueue<int>();
+
+            Assert.That(() => valueQueue.TryPeek(out _),
+                Is.False
+            );
+        }
+    }
+}

--- a/tests/Core/Collections/ValueStack`1Tests.cs
+++ b/tests/Core/Collections/ValueStack`1Tests.cs
@@ -1,0 +1,518 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using TerraFX.Collections;
+
+namespace TerraFX.UnitTests.Collections
+{
+    /// <summary>Provides a set of tests covering the <see cref="ValueStack{T}" /> struct.</summary>
+    public static class ValueStackTests
+    {
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.ValueStack()" /> constructor.</summary>
+        [Test]
+        public static void CtorTest()
+        {
+            Assert.That(() => new ValueStack<int>(),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.ValueStack(int)" /> constructor.</summary>
+        [Test]
+        public static void CtorInt32Test()
+        {
+            Assert.That(() => new ValueStack<int>(5),
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueStack<int>(-5),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-5)
+                      .And.Property("ParamName").EqualTo("capacity")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.ValueStack(IEnumerable{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorIEnumerableTest()
+        {
+            Assert.That(() => new ValueStack<int>(Enumerable.Range(0, 3)),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueStack<int>(Enumerable.Empty<int>()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueStack<int>((null as IEnumerable<int>)!),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("source")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.ValueStack(ReadOnlySpan{T})" /> constructor.</summary>
+        [Test]
+        public static void CtorReadOnlySpanTest()
+        {
+            Assert.That(() => new ValueStack<int>(new int[] { 1, 2, 3 }.AsSpan()),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueStack<int>(Array.Empty<int>().AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueStack<int>((null as int[]).AsSpan()),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.ValueStack(T[], bool)" /> constructor.</summary>
+        [Test]
+        public static void CtorArrayBooleanTest()
+        {
+            Assert.That(() => new ValueStack<int>(new int[] { 1, 2, 3 }, takeOwnership: false),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueStack<int>(new int[] { 1, 2, 3 }, takeOwnership: true),
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            Assert.That(() => new ValueStack<int>(Array.Empty<int>(), takeOwnership: false),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueStack<int>(Array.Empty<int>(), takeOwnership: true),
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+
+            Assert.That(() => new ValueStack<int>((null as int[])!, takeOwnership: false),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+
+            Assert.That(() => new ValueStack<int>((null as int[])!, takeOwnership: true),
+                Throws.ArgumentNullException
+                      .And.Property("ParamName").EqualTo("array")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Clear" /> method.</summary>
+        [Test]
+        public static void ClearTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            valueStack.Clear();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            _ = valueStack.Pop();
+
+            valueStack.Push(4);
+            valueStack.Clear();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            _ = valueStack.Pop();
+
+            valueStack.Push(4);
+            valueStack.Push(5);
+
+            valueStack.Clear();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueStack = new ValueStack<int>();
+            valueStack.Clear();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Contains(T)" /> method.</summary>
+        [Test]
+        public static void ContainsTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueStack.Contains(1),
+                Is.True
+            );
+
+            Assert.That(() => valueStack.Contains(4),
+                Is.False
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(4);
+
+            Assert.That(() => valueStack.Contains(3),
+                Is.False
+            );
+
+            Assert.That(() => valueStack.Contains(4),
+                Is.True
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+            valueStack.Push(6);
+
+            Assert.That(() => valueStack.Contains(4),
+                Is.False
+            );
+
+            Assert.That(() => valueStack.Contains(5),
+                Is.True
+            );
+
+            Assert.That(() => valueStack.Contains(6),
+                Is.True
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.Contains(0),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.CopyTo(Span{T})" /> method.</summary>
+        [Test]
+        public static void CopyToTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            var destination = new int[3];
+            valueStack.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 3 })
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(4);
+
+            valueStack.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 4 })
+            );
+
+            destination = new int[6];
+            valueStack.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 4, 0, 0, 0 })
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+            valueStack.Push(6);
+
+            valueStack.CopyTo(destination);
+
+            Assert.That(() => destination,
+                Is.EquivalentTo(new int[] { 1, 2, 5, 6, 0, 0 })
+            );
+
+            Assert.That(() => valueStack.CopyTo(Array.Empty<int>()),
+                Throws.ArgumentException
+                      .And.Property("ParamName").EqualTo("destination")
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.CopyTo(Array.Empty<int>()),
+                Throws.Nothing
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.EnsureCapacity(int)" /> method.</summary>
+        [Test]
+        public static void EnsureCapacityTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            valueStack.EnsureCapacity(-1);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack.EnsureCapacity(0);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack.EnsureCapacity(3);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack.EnsureCapacity(4);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack.EnsureCapacity(16);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(16)
+                   .And.Count.EqualTo(3)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Peek()" /> method.</summary>
+        [Test]
+        public static void PeekTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueStack.Peek(),
+                Is.EqualTo(3)
+            );
+
+            valueStack.Push(4);
+
+            Assert.That(() => valueStack.Peek(),
+                Is.EqualTo(4)
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+
+            Assert.That(() => valueStack.Peek(),
+                Is.EqualTo(5)
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(6);
+            valueStack.Push(7);
+
+            Assert.That(() => valueStack.Peek(),
+                Is.EqualTo(7)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.Peek(),
+                Throws.InvalidOperationException
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Pop()" /> method.</summary>
+        [Test]
+        public static void PopTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(2)
+            );
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueStack.Pop(),
+                Throws.InvalidOperationException
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            _ = valueStack.Pop();
+            valueStack.Push(4);
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(4)
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+            valueStack.Push(6);
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(6)
+            );
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(5)
+            );
+
+            Assert.That(() => valueStack.Pop(),
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(0)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.Pop(),
+                Throws.InvalidOperationException
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Push(T)" /> method.</summary>
+        [Test]
+        public static void PushTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            valueStack.Push(4);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueStack.Push(5);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack = new ValueStack<int>();
+            valueStack.Push(6);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(1)
+                   .And.Count.EqualTo(1)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPeek(out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            var result = valueStack.TryPeek(out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(3)
+            );
+
+            valueStack.Push(4);
+            result = valueStack.TryPeek(out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.TryPeek(out _),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPop(out T)" /> method.</summary>
+        [Test]
+        public static void TryPopTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            var result = valueStack.TryPop(out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(3)
+            );
+
+            valueStack.Push(4);
+            result = valueStack.TryPop(out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(2)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.TryPop(out _),
+                Is.False
+            );
+        }
+    }
+}

--- a/tests/Core/Collections/ValueStack`1Tests.cs
+++ b/tests/Core/Collections/ValueStack`1Tests.cs
@@ -342,6 +342,63 @@ namespace TerraFX.UnitTests.Collections
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.Peek(int)" /> method.</summary>
+        [Test]
+        public static void PeekInt32Test()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            Assert.That(() => valueStack.Peek(0),
+                Is.EqualTo(3)
+            );
+
+            valueStack.Push(4);
+
+            Assert.That(() => valueStack.Peek(0),
+                Is.EqualTo(4)
+            );
+
+            Assert.That(() => valueStack.Peek(3),
+                Is.EqualTo(1)
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(5);
+
+            Assert.That(() => valueStack.Peek(0),
+                Is.EqualTo(5)
+            );
+
+            Assert.That(() => valueStack.Peek(1),
+                Is.EqualTo(3)
+            );
+
+            _ = valueStack.Pop();
+            valueStack.Push(6);
+            valueStack.Push(7);
+
+            Assert.That(() => valueStack.Peek(0),
+                Is.EqualTo(7)
+            );
+
+            Assert.That(() => valueStack.Peek(2),
+                Is.EqualTo(3)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.Peek(0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ValueStack{T}.Pop()" /> method.</summary>
         [Test]
         public static void PopTest()
@@ -473,6 +530,54 @@ namespace TerraFX.UnitTests.Collections
             valueStack = new ValueStack<int>();
 
             Assert.That(() => valueStack.TryPeek(out _),
+                Is.False
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPeek(int, out T)" /> method.</summary>
+        [Test]
+        public static void TryPeekInt32Test()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            var result = valueStack.TryPeek(0, out var value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(3)
+            );
+
+            valueStack.Push(4);
+            result = valueStack.TryPeek(0, out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(4)
+            );
+
+            result = valueStack.TryPeek(3, out value);
+
+            Assert.That(() => result,
+                Is.True
+            );
+
+            Assert.That(() => value,
+                Is.EqualTo(1)
+            );
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(6)
+                   .And.Count.EqualTo(4)
+            );
+
+            valueStack = new ValueStack<int>();
+
+            Assert.That(() => valueStack.TryPeek(0, out _),
                 Is.False
             );
         }

--- a/tests/Core/Collections/ValueStack`1Tests.cs
+++ b/tests/Core/Collections/ValueStack`1Tests.cs
@@ -496,6 +496,61 @@ namespace TerraFX.UnitTests.Collections
             );
         }
 
+
+
+        /// <summary>Provides validation of the <see cref="ValueStack{T}.TrimExcess(float)" /> method.</summary>
+        [Test]
+        public static void TrimExcessTest()
+        {
+            var valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+            valueStack.TrimExcess();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            _ = valueStack.Pop();
+
+            valueStack.Push(4);
+            valueStack.TrimExcess();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(3)
+                   .And.Count.EqualTo(3)
+            );
+
+            valueStack = new ValueStack<int>(new int[] { 1, 2, 3 });
+
+            valueStack.Push(4);
+            valueStack.Push(5);
+
+            valueStack.TrimExcess();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(5)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueStack.EnsureCapacity(15);
+            valueStack.TrimExcess(0.3f);
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(15)
+                   .And.Count.EqualTo(5)
+            );
+
+            valueStack = new ValueStack<int>();
+            valueStack.TrimExcess();
+
+            Assert.That(() => valueStack,
+                Has.Property("Capacity").EqualTo(0)
+                   .And.Count.EqualTo(0)
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ValueStack{T}.TryPeek(out T)" /> method.</summary>
         [Test]
         public static void TryPeekTest()

--- a/tests/Core/Runtime/ResourcesTests.cs
+++ b/tests/Core/Runtime/ResourcesTests.cs
@@ -1,6 +1,5 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
 using System.Globalization;
 using NUnit.Framework;
 using TerraFX.Runtime;
@@ -227,6 +226,17 @@ namespace TerraFX.UnitTests.Runtime
             Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
 
             Assert.That(Resources.ValueIsNegativeMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="Resources.ValueIsNotInSignedBoundsMessage" /> property.</summary>
+        [TestCase("en", "'{0}' is negative or greater than or equal to '{1}'")]
+        public static void ValueIsNotInBoundsSignedMessageTest(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.ValueIsNotInSignedBoundsMessage,
                 Is.EqualTo(expectedMessage)
             );
         }

--- a/tests/Core/Runtime/ResourcesTests.cs
+++ b/tests/Core/Runtime/ResourcesTests.cs
@@ -232,11 +232,44 @@ namespace TerraFX.UnitTests.Runtime
 
         /// <summary>Provides validation of the <see cref="Resources.ValueIsNotInSignedBoundsMessage" /> property.</summary>
         [TestCase("en", "'{0}' is negative or greater than or equal to '{1}'")]
-        public static void ValueIsNotInBoundsSignedMessageTest(string cultureName, string expectedMessage)
+        public static void ValueIsNotInSignedBoundsMessageTest(string cultureName, string expectedMessage)
         {
             Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
 
             Assert.That(Resources.ValueIsNotInSignedBoundsMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="Resources.ValueIsNotInSignedBoundsMessage" /> property.</summary>
+        [TestCase("en", "'{0}' is negative or greater than '{1}'")]
+        public static void ValueIsNotInSignedInsertBoundsMessage(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.ValueIsNotInSignedInsertBoundsMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="Resources.ValueIsNotInUnsignedBoundsMessage" /> property.</summary>
+        [TestCase("en", "'{0}' is greater than or equal to '{1}'")]
+        public static void ValueIsNotInUnsignedBoundsMessageTest(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.ValueIsNotInUnsignedBoundsMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="Resources.ValueIsNotInUnsignedBoundsMessage" /> property.</summary>
+        [TestCase("en", "'{0}' is greater than '{1}'")]
+        public static void ValueIsNotInUnsignedInsertBoundsMessage(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.ValueIsNotInUnsignedInsertBoundsMessage,
                 Is.EqualTo(expectedMessage)
             );
         }

--- a/tests/Core/Runtime/ResourcesTests.cs
+++ b/tests/Core/Runtime/ResourcesTests.cs
@@ -285,6 +285,17 @@ namespace TerraFX.UnitTests.Runtime
             );
         }
 
+        /// <summary>Provides validation of the <see cref="Resources.ValueIsNotZeroMessage" /> property.</summary>
+        [TestCase("en", "'{0}' is not zero")]
+        public static void ValueIsNotZeroMessageTest(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.ValueIsNotZeroMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="Resources.ValueIsNullMessage" /> property.</summary>
         [TestCase("en", "'{0}' is null")]
         public static void ValueIsNullMessageTest(string cultureName, string expectedMessage)

--- a/tests/Core/Runtime/ResourcesTests.cs
+++ b/tests/Core/Runtime/ResourcesTests.cs
@@ -32,6 +32,28 @@ namespace TerraFX.UnitTests.Runtime
             );
         }
 
+        /// <summary>Provides validation of the <see cref="Resources.EmptyQueueMessage" /> property.</summary>
+        [TestCase("en", "The queue is empty")]
+        public static void EmptyQueueMessageTest(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.EmptyQueueMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="Resources.EmptyStackMessage" /> property.</summary>
+        [TestCase("en", "The stack is empty")]
+        public static void EmptyStackMessageTest(string cultureName, string expectedMessage)
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo(cultureName);
+
+            Assert.That(Resources.EmptyStackMessage,
+                Is.EqualTo(expectedMessage)
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="Resources.InvalidFlagCombinationMessage" /> property.</summary>
         [TestCase("en", "'{0}' has an invalid flag combination")]
         public static void InvalidFlagCombinationMessageTest(string cultureName, string expectedMessage)

--- a/tests/Core/Utilities/AppContextUtilitiesTests.cs
+++ b/tests/Core/Utilities/AppContextUtilitiesTests.cs
@@ -16,7 +16,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, false),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, false),
@@ -54,7 +54,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (byte)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (byte)0),
@@ -92,7 +92,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0.0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0.0),
@@ -130,7 +130,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (short)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (short)0),
@@ -168,7 +168,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0),
@@ -206,7 +206,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0L),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0L),
@@ -244,7 +244,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (nint)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (nint)0),
@@ -282,7 +282,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (sbyte)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (sbyte)0),
@@ -320,7 +320,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0.0f),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0.0f),
@@ -358,7 +358,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, ""),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             AppContextUtilities.SetAppContextData(string.Empty, "a");
@@ -386,7 +386,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (ushort)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (ushort)0),
@@ -424,7 +424,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0U),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0U),
@@ -462,7 +462,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, 0UL),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, 0UL),
@@ -500,7 +500,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.GetAppContextData(null!, (nuint)0),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
 
             Assert.That(() => AppContextUtilities.GetAppContextData(string.Empty, (nuint)0),
@@ -538,7 +538,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => AppContextUtilities.SetAppContextData(null!, string.Empty),
                 Throws.ArgumentNullException
-                      .With.Property("ParamName").EqualTo("name")
+                      .And.Property("ParamName").EqualTo("name")
             );
         }
     }

--- a/tests/Core/Utilities/AssertionUtilitiesTests.cs
+++ b/tests/Core/Utilities/AssertionUtilitiesTests.cs
@@ -97,6 +97,19 @@ namespace TerraFX.UnitTests.Utilities
             );
         }
 
+        /// <summary>Provides validation of the <see cref="AssertionUtilities.AssertNotNull{T}(UnmanagedArray{T})" /> method.</summary>
+        [Test]
+        public static unsafe void AssertNotNullUnmanagedArrayTest()
+        {
+            Assert.That(() => AssertionUtilities.AssertNotNull(UnmanagedArray<int>.Empty),
+                Throws.Nothing
+            );
+
+            Assert.That(() => AssertionUtilities.AssertNotNull(new UnmanagedArray<int>()),
+                Configuration.AssertionsEnabled ? Throws.Exception : Throws.Nothing
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="AssertionUtilities.AssertThread(Thread)" /> method.</summary>
         [Test]
         public static unsafe void AssertThreadTest()

--- a/tests/Core/Utilities/ExceptionUtilitiesTests.cs
+++ b/tests/Core/Utilities/ExceptionUtilitiesTests.cs
@@ -63,6 +63,24 @@ namespace TerraFX.UnitTests.Utilities
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowForEmptyQueue" /> method.</summary>
+        [Test]
+        public static void ThrowForEmptyQueueTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowForEmptyQueue(),
+                Throws.InstanceOf<InvalidOperationException>()
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowForEmptyStack" /> method.</summary>
+        [Test]
+        public static void ThrowForEmptyStackTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowForEmptyStack(),
+                Throws.InstanceOf<InvalidOperationException>()
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowForInvalidFlagsCombination{TEnum}(TEnum, string)" /> method.</summary>
         [Test]
         public static void ThrowForInvalidFlagsCombinationTest()

--- a/tests/Core/Utilities/ExceptionUtilitiesTests.cs
+++ b/tests/Core/Utilities/ExceptionUtilitiesTests.cs
@@ -796,6 +796,102 @@ namespace TerraFX.UnitTests.Utilities
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(int, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(0, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(1, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(long, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(0L, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(1L, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1L)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(nint, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroNIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero((nint)0, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero((nint)1, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)1)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(uint, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroUInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(0U, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(1U, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1U)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(ulong, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroUInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(0UL, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero(1UL, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1UL)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotZero(nuint, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNotZeroNUIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero((nuint)0, "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotZero((nuint)1, "value"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nuint)1)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNull{T}(T, string)" /> method.</summary>
         [Test]
         public static void ThrowIfNullObjectTest()
@@ -821,6 +917,22 @@ namespace TerraFX.UnitTests.Utilities
             );
 
             Assert.That(() => ExceptionUtilities.ThrowIfNull(null, "value"),
+                Throws.ArgumentNullException
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains("null")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNull{T}(UnmanagedArray{T}, string)" /> method.</summary>
+        [Test]
+        public static unsafe void ThrowIfNullUnmanagedArrayTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNull(new UnmanagedArray<int>(), "value"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNull(UnmanagedArray<int>.Empty, "value"),
                 Throws.ArgumentNullException
                       .And.Message.Contains("'value'")
                       .And.Message.Contains("null")

--- a/tests/Core/Utilities/ExceptionUtilitiesTests.cs
+++ b/tests/Core/Utilities/ExceptionUtilitiesTests.cs
@@ -928,11 +928,11 @@ namespace TerraFX.UnitTests.Utilities
         [Test]
         public static unsafe void ThrowIfNullUnmanagedArrayTest()
         {
-            Assert.That(() => ExceptionUtilities.ThrowIfNull(new UnmanagedArray<int>(), "value"),
+            Assert.That(() => ExceptionUtilities.ThrowIfNull(UnmanagedArray<int>.Empty, "value"),
                 Throws.Nothing
             );
 
-            Assert.That(() => ExceptionUtilities.ThrowIfNull(UnmanagedArray<int>.Empty, "value"),
+            Assert.That(() => ExceptionUtilities.ThrowIfNull(new UnmanagedArray<int>(), "value"),
                 Throws.ArgumentNullException
                       .And.Message.Contains("'value'")
                       .And.Message.Contains("null")

--- a/tests/Core/Utilities/ExceptionUtilitiesTests.cs
+++ b/tests/Core/Utilities/ExceptionUtilitiesTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
-using TerraFX.Runtime;
 using TerraFX.Threading;
 using TerraFX.Utilities;
 
@@ -21,9 +20,9 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowArgumentException("message", "value"),
                 Throws.ArgumentException
-                      .With.Message.Contains("message")
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Message.Contains("message")
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -33,9 +32,9 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowArgumentNullException("value"),
                 Throws.ArgumentNullException
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains("null")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains("null")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -45,10 +44,10 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowArgumentOutOfRangeException("message", Guid.Empty, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(Guid.Empty)
-                      .And.With.Message.Contains("message")
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(Guid.Empty)
+                      .And.Message.Contains("message")
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -58,9 +57,9 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowExternalException("method", -1),
                 Throws.InstanceOf<ExternalException>()
-                      .With.Property("ErrorCode").EqualTo(-1)
-                      .And.With.Message.Contains("'method'")
-                      .And.With.Message.Contains($"'{-1}'")
+                      .And.Property("ErrorCode").EqualTo(-1)
+                      .And.Message.Contains("'method'")
+                      .And.Message.Contains($"'{-1}'")
             );
         }
 
@@ -70,10 +69,10 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForInvalidFlagsCombination(AttributeTargets.Assembly, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(AttributeTargets.Assembly)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains(AttributeTargets.Assembly.ToString())
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(AttributeTargets.Assembly)
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains(AttributeTargets.Assembly.ToString())
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -83,9 +82,9 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForInvalidKind(AttributeTargets.Class, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(AttributeTargets.Class)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(AttributeTargets.Class)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -95,10 +94,10 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForInvalidKind(AttributeTargets.Class, "value", AttributeTargets.Struct),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(AttributeTargets.Class)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains($"'{AttributeTargets.Struct}'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(AttributeTargets.Class)
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains($"'{AttributeTargets.Struct}'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -110,9 +109,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForInvalidParent(value, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").SameAs(value)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").SameAs(value)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -124,7 +123,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForInvalidState("state"),
                 Throws.InvalidOperationException
-                      .And.With.Message.Contains("'state'")
+                      .And.Message.Contains("'state'")
             );
         }
 
@@ -134,10 +133,10 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForInvalidType(typeof(object), "value", typeof(string)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").SameAs(typeof(object))
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains($"'{typeof(string)}'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").SameAs(typeof(object))
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains($"'{typeof(string)}'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -147,7 +146,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForLastError("method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -161,7 +160,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero(1, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -175,7 +174,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero(1L, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -189,7 +188,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero((nint)1, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -203,7 +202,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero(1U, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -217,7 +216,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero(1UL, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -231,7 +230,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfNotZero((nuint)1, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -245,7 +244,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero(0, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -259,7 +258,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero(0L, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -273,7 +272,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero((nint)0, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -287,7 +286,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero(0U, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -301,7 +300,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero(0UL, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -315,7 +314,7 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowForLastErrorIfZero((nuint)0, "method"),
                 Throws.InstanceOf<ExternalException>()
-                      .And.With.Message.Contains("'method'")
+                      .And.Message.Contains("'method'")
             );
         }
 
@@ -334,8 +333,8 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowForUnsupportedSurfaceKind("surface"),
                 Throws.InstanceOf<NotSupportedException>()
-                      .With.Message.Contains("'surface'")
-                      .And.With.Message.Contains("GraphicsSurfaceKind")
+                      .And.Message.Contains("'surface'")
+                      .And.Message.Contains("GraphicsSurfaceKind")
             );
         }
 
@@ -353,14 +352,14 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfDisposedOrDisposing(state, "type"),
                 Throws.InstanceOf<ObjectDisposedException>()
-                      .With.Message.Contains("'type'")
+                      .And.Message.Contains("'type'")
             );
 
             state.EndDispose();
 
             Assert.That(() => ExceptionUtilities.ThrowIfDisposedOrDisposing(state, "type"),
                 Throws.InstanceOf<ObjectDisposedException>()
-                      .With.Message.Contains("'type'")
+                      .And.Message.Contains("'type'")
             );
         }
 
@@ -374,9 +373,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNegative(-1, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(-1)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -390,9 +389,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNegative(-1L, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(-1L)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(-1L)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -406,9 +405,195 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNegative((nint)(-1), "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo((nint)(-1))
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo((nint)(-1))
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(int, int, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(0, 1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(-1, 1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(1, 1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(2, 1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(long, long, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(0L, 1L, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(-1L, 1L, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1L)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(1L, 1L, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1L)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(2L, 1L, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2L)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(nint, nint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsNIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nint)0, (nint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nint)(-1), (nint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)(-1))
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nint)1, (nint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)1)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nint)2, (nint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(int, int, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(0, 1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(1, 1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(-1, 1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(2, 1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(long, long, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(0L, 1L, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(1L, 1L, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(-1L, 1L, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(-1L)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(2L, 1L, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2L)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(nint, nint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsNIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nint)0, (nint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nint)1, (nint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nint)(-1), (nint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)(-1))
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nint)2, (nint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nint)2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
             );
         }
 
@@ -422,9 +607,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNotPow2(0U, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0U)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0U)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -438,9 +623,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNotPow2(0UL, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0UL)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0UL)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -454,9 +639,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNotPow2((nuint)0, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo((nuint)0)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo((nuint)0)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -483,9 +668,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNull<object>(null, "value"),
                 Throws.ArgumentNullException
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains("null")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains("null")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -499,9 +684,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfNull(null, "value"),
                 Throws.ArgumentNullException
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Message.Contains("null")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Message.Contains("'value'")
+                      .And.Message.Contains("null")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -515,9 +700,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero(0, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -531,9 +716,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero(0L, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0L)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0L)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -547,9 +732,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero((nint)0, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo((nint)0)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo((nint)0)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -563,9 +748,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero(0U, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0U)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0U)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -579,9 +764,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero(0UL, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo(0UL)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo(0UL)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -595,9 +780,9 @@ namespace TerraFX.UnitTests.Utilities
 
             Assert.That(() => ExceptionUtilities.ThrowIfZero((nuint)0, "value"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
-                      .With.Property("ActualValue").EqualTo((nuint)0)
-                      .And.With.Message.Contains("'value'")
-                      .And.With.Property("ParamName").EqualTo("value")
+                      .And.Property("ActualValue").EqualTo((nuint)0)
+                      .And.Message.Contains("'value'")
+                      .And.Property("ParamName").EqualTo("value")
             );
         }
 
@@ -607,7 +792,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowInvalidOperationException("message"),
                 Throws.InvalidOperationException
-                      .And.With.Message.Contains("message")
+                      .And.Message.Contains("message")
             );
         }
 
@@ -617,7 +802,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowKeyNotFoundException("key", "collection"),
                 Throws.InstanceOf<KeyNotFoundException>()
-                      .And.With.Message.Contains("'collection'")
+                      .And.Message.Contains("'collection'")
             );
         }
 
@@ -636,7 +821,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowObjectDisposedException("value"),
                 Throws.InstanceOf<ObjectDisposedException>()
-                      .With.Message.Contains("'value'")
+                      .And.Message.Contains("'value'")
             );
         }
 
@@ -646,7 +831,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowOutOfMemoryException(42UL),
                 Throws.InstanceOf<OutOfMemoryException>()
-                      .With.Message.Contains($"'{42UL}'")
+                      .And.Message.Contains($"'{42UL}'")
             );
         }
 
@@ -656,7 +841,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowOutOfMemoryException((nuint)42),
                 Throws.InstanceOf<OutOfMemoryException>()
-                      .With.Message.Contains($"'{(nuint)42}'")
+                      .And.Message.Contains($"'{(nuint)42}'")
             );
         }
 
@@ -666,7 +851,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowOutOfMemoryException(42UL, 24UL),
                 Throws.InstanceOf<OutOfMemoryException>()
-                      .With.Message.Contains($"'{42UL}x{24UL}'")
+                      .And.Message.Contains($"'{42UL}x{24UL}'")
             );
         }
 
@@ -676,7 +861,7 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowOutOfMemoryException((nuint)42, (nuint)24),
                 Throws.InstanceOf<OutOfMemoryException>()
-                      .With.Message.Contains($"'{(nuint)42}x{(nuint)24}'")
+                      .And.Message.Contains($"'{(nuint)42}x{(nuint)24}'")
             );
         }
 
@@ -686,8 +871,8 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowTimeoutException("method", 42),
                 Throws.InstanceOf<TimeoutException>()
-                      .With.Message.Contains("'method'")
-                      .And.With.Message.Contains($"'{42}'")
+                      .And.Message.Contains("'method'")
+                      .And.Message.Contains($"'{42}'")
             );
         }
 
@@ -697,8 +882,8 @@ namespace TerraFX.UnitTests.Utilities
         {
             Assert.That(() => ExceptionUtilities.ThrowTimeoutException("method", TimeSpan.FromMilliseconds(42)),
                 Throws.InstanceOf<TimeoutException>()
-                      .With.Message.Contains("'method'")
-                      .And.With.Message.Contains($"'{TimeSpan.FromMilliseconds(42).TotalMilliseconds}'")
+                      .And.Message.Contains("'method'")
+                      .And.Message.Contains($"'{TimeSpan.FromMilliseconds(42).TotalMilliseconds}'")
             );
         }
     }

--- a/tests/Core/Utilities/ExceptionUtilitiesTests.cs
+++ b/tests/Core/Utilities/ExceptionUtilitiesTests.cs
@@ -510,6 +510,81 @@ namespace TerraFX.UnitTests.Utilities
             );
         }
 
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(uint, uint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsUInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(0U, 1U, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(1U, 1U, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1U)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(2U, 1U, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2U)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(ulong, ulong, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsUInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(0UL, 1UL, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(1UL, 1UL, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(1UL)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds(2UL, 1UL, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2UL)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInBounds(nuint, nuint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInBoundsNUIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nuint)0, (nuint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nuint)1, (nuint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nuint)1)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInBounds((nuint)2, (nuint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nuint)2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
         /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(int, int, string, string)" /> method.</summary>
         [Test]
         public static void ThrowIfNotInInsertBoundsInt32Test()
@@ -591,6 +666,69 @@ namespace TerraFX.UnitTests.Utilities
             Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nint)2, (nint)1, "index", "length"),
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
                       .And.Property("ActualValue").EqualTo((nint)2)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(uint, uint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsUInt32Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(0U, 1U, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(1U, 1U, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(2U, 1U, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2U)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(ulong, ulong, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsUInt64Test()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(0UL, 1UL, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(1UL, 1UL, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds(2UL, 1UL, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo(2UL)
+                      .And.Message.Contains("'index'")
+                      .And.Message.Contains("'length'")
+                      .And.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        /// <summary>Provides validation of the <see cref="ExceptionUtilities.ThrowIfNotInInsertBounds(nuint, nuint, string, string)" /> method.</summary>
+        [Test]
+        public static void ThrowIfNotInInsertBoundsNUIntTest()
+        {
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nuint)0, (nuint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nuint)1, (nuint)1, "index", "length"),
+                Throws.Nothing
+            );
+
+            Assert.That(() => ExceptionUtilities.ThrowIfNotInInsertBounds((nuint)2, (nuint)1, "index", "length"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .And.Property("ActualValue").EqualTo((nuint)2)
                       .And.Message.Contains("'index'")
                       .And.Message.Contains("'length'")
                       .And.Property("ParamName").EqualTo("index")

--- a/tests/Core/Utilities/MarshalUtilitiesTests.cs
+++ b/tests/Core/Utilities/MarshalUtilitiesTests.cs
@@ -1,12 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Threading;
 using NUnit.Framework;
-using TerraFX.Runtime;
-using TerraFX.Threading;
 using TerraFX.Utilities;
 
 namespace TerraFX.UnitTests.Utilities


### PR DESCRIPTION
This adds a number of basic "value" collection types. These types namely exist for use as an internal implementation detail of other types to avoid additional allocations and indirections.
There also exists "unmanaged value" collection types that server a similar purpose but which are backed by native memory and only accept `where T : unmanaged` types.

This starts out with support for the following collection types:
* `List`
* `Queue`
* `Stack`

and also provides the following unmanaged helper types:
* `UnmanagedArray`
* `UnmanagedReadOnlySpan`
* `UnmanagedSpan`