### PR TITLE
Remove net5.0 support and move forward to a net6.0 build without the breaking change

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,6 +68,7 @@
     <RepositoryType>git</RepositoryType>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json;
       https://pkgs.terrafx.dev/index.json;
     </RestoreSources>
     <UseSharedCompilation>true</UseSharedCompilation>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,8 +28,8 @@
 
   <!-- Settings that are only set for libraries -->
   <PropertyGroup Condition="'$(OutputType)' == 'Library'">
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <!-- Package versions for package references across all projects -->

--- a/samples/TerraFX/TerraFX.Samples.csproj
+++ b/samples/TerraFX/TerraFX.Samples.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <PublishTrimmed>false</PublishTrimmed>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,8 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel 5.0 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
-    & $DotNetInstallScript -Channel 6.0 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel main -Version 6.0.100-rtm.21480.21 -InstallDir $DotNetInstallDirectory -Architecture $architecture
 
     $env:PATH="$DotNetInstallDirectory;$env:PATH"
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,8 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel 5.0 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
-  . "$DotNetInstallScript" --channel 6.0 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel main --version 6.0.100-rtm.21480.21 --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
 
   PATH="$DotNetInstallDirectory:$PATH:"
 fi

--- a/sources/ApplicationModel/TerraFX.ApplicationModel.csproj
+++ b/sources/ApplicationModel/TerraFX.ApplicationModel.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Audio/Core/TerraFX.Audio.csproj
+++ b/sources/Audio/Core/TerraFX.Audio.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Audio/PulseAudio/TerraFX.Audio.PulseAudio.csproj
+++ b/sources/Audio/PulseAudio/TerraFX.Audio.PulseAudio.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Core/TerraFX.csproj
+++ b/sources/Core/TerraFX.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Graphics/Core/TerraFX.Graphics.csproj
+++ b/sources/Graphics/Core/TerraFX.Graphics.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Graphics/D3D12/TerraFX.Graphics.D3D12.csproj
+++ b/sources/Graphics/D3D12/TerraFX.Graphics.D3D12.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Graphics/Vulkan/TerraFX.Graphics.Vulkan.csproj
+++ b/sources/Graphics/Vulkan/TerraFX.Graphics.Vulkan.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/UI/Core/TerraFX.UI.csproj
+++ b/sources/UI/Core/TerraFX.UI.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/UI/Win32/TerraFX.UI.Win32.csproj
+++ b/sources/UI/Win32/TerraFX.UI.Win32.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/UI/WinForms/TerraFX.UI.WinForms.csproj
+++ b/sources/UI/WinForms/TerraFX.UI.WinForms.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/sources/UI/Xlib/TerraFX.UI.Xlib.csproj
+++ b/sources/UI/Xlib/TerraFX.UI.Xlib.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ApplicationModel/TerraFX.ApplicationModel.UnitTests.csproj
+++ b/tests/ApplicationModel/TerraFX.ApplicationModel.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Audio/Core/TerraFX.Audio.UnitTests.csproj
+++ b/tests/Audio/Core/TerraFX.Audio.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Audio/PulseAudio/TerraFX.Audio.PulseAudio.UnitTests.csproj
+++ b/tests/Audio/PulseAudio/TerraFX.Audio.PulseAudio.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core/TerraFX.UnitTests.csproj
+++ b/tests/Core/TerraFX.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Graphics/Core/TerraFX.Graphics.UnitTests.csproj
+++ b/tests/Graphics/Core/TerraFX.Graphics.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Graphics/D3D12/TerraFX.Graphics.D3D12.UnitTests.csproj
+++ b/tests/Graphics/D3D12/TerraFX.Graphics.D3D12.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Graphics/Vulkan/TerraFX.Graphics.Vulkan.UnitTests.csproj
+++ b/tests/Graphics/Vulkan/TerraFX.Graphics.Vulkan.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UI/Core/TerraFX.UI.UnitTests.csproj
+++ b/tests/UI/Core/TerraFX.UI.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UI/Win32/TerraFX.UI.Win32.UnitTests.csproj
+++ b/tests/UI/Win32/TerraFX.UI.Win32.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UI/WinForms/TerraFX.UI.WinForms.UnitTests.csproj
+++ b/tests/UI/WinForms/TerraFX.UI.WinForms.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UI/Xlib/TerraFX.UI.Xlib.UnitTests.csproj
+++ b/tests/UI/Xlib/TerraFX.UI.Xlib.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This involves disabling trimming until the rewrite can occur