### PR TITLE
Work around NU1507 and the `langversion=latest` when targeting .NET 6 with a .NET 7 SDK issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,7 @@
     <Features>strict</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <HighEntropyVA>true</HighEntropyVA>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <MinClientVersion>4.3</MinClientVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <!-- Settings that append the existing setting value -->
   <PropertyGroup>
-    <NoWarn>$(NoWarn);AD0001;NU5105</NoWarn>
+    <NoWarn>$(NoWarn);AD0001;NU1507;NU5105</NoWarn>
   </PropertyGroup>
 
   <!-- Settings that are only set for CI builds -->


### PR DESCRIPTION
This works around two minor issues when working with the latest .NET 7 SDK.

The former should be properly fixed via a `nuget.config` file and the latter will be fixed with .NET 7 RC1 when the `UnscopedRef` attribute support is available.